### PR TITLE
Ralph pkg #4: detect-stack module + fixture tests

### DIFF
--- a/packages/ralph/lib/detect-stack.js
+++ b/packages/ralph/lib/detect-stack.js
@@ -1,0 +1,91 @@
+import { existsSync as realExistsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const STACKS = {
+  pnpm: {
+    install: 'pnpm install --frozen-lockfile',
+    test: 'pnpm test',
+    lint: 'pnpm lint',
+    stack: 'pnpm',
+  },
+  yarn: {
+    install: 'yarn install --frozen-lockfile',
+    test: 'yarn test',
+    lint: 'yarn lint',
+    stack: 'yarn',
+  },
+  npm: {
+    install: 'npm ci',
+    test: 'npm test',
+    lint: 'npm run lint',
+    stack: 'npm',
+  },
+  python: {
+    install: 'pip install -e .',
+    test: 'pytest',
+    lint: 'ruff check .',
+    stack: 'python',
+  },
+  pip: {
+    install: 'pip install -r requirements.txt',
+    test: 'pytest',
+    lint: '',
+    stack: 'pip',
+  },
+  go: {
+    install: 'go mod download',
+    test: 'go test ./...',
+    lint: 'go vet ./...',
+    stack: 'go',
+  },
+  rust: {
+    install: 'cargo fetch',
+    test: 'cargo test',
+    lint: 'cargo clippy',
+    stack: 'rust',
+  },
+  ruby: {
+    install: 'bundle install',
+    test: 'bundle exec rake test',
+    lint: '',
+    stack: 'ruby',
+  },
+  php: {
+    install: 'composer install',
+    test: 'composer test',
+    lint: '',
+    stack: 'php',
+  },
+  unknown: {
+    install: '',
+    test: '',
+    lint: '',
+    stack: 'unknown',
+  },
+}
+
+const DETECTION_ORDER = [
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['yarn.lock', 'yarn'],
+  ['package.json', 'npm'],
+  ['pyproject.toml', 'python'],
+  ['requirements.txt', 'pip'],
+  ['go.mod', 'go'],
+  ['Cargo.toml', 'rust'],
+  ['Gemfile', 'ruby'],
+  ['composer.json', 'php'],
+]
+
+export function detectStack(projectDir, fsImpl) {
+  const existsSync =
+    fsImpl && typeof fsImpl.existsSync === 'function' ? fsImpl.existsSync.bind(fsImpl) : realExistsSync
+
+  for (const [manifest, key] of DETECTION_ORDER) {
+    if (existsSync(join(projectDir, manifest))) {
+      return { ...STACKS[key] }
+    }
+  }
+  return { ...STACKS.unknown }
+}
+
+export const STACK_TABLE = STACKS

--- a/packages/ralph/lib/detect-stack.test.js
+++ b/packages/ralph/lib/detect-stack.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { detectStack } from './detect-stack.js'
+
+function makeFs(files) {
+  return Volume.fromJSON(files, '/project')
+}
+
+describe('detectStack', () => {
+  it('detects pnpm from pnpm-lock.yaml', () => {
+    const fs = makeFs({ '/project/pnpm-lock.yaml': '', '/project/package.json': '{}' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'pnpm install --frozen-lockfile',
+      test: 'pnpm test',
+      lint: 'pnpm lint',
+      stack: 'pnpm',
+    })
+  })
+
+  it('detects yarn from yarn.lock', () => {
+    const fs = makeFs({ '/project/yarn.lock': '', '/project/package.json': '{}' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'yarn install --frozen-lockfile',
+      test: 'yarn test',
+      lint: 'yarn lint',
+      stack: 'yarn',
+    })
+  })
+
+  it('detects npm from a lone package.json', () => {
+    const fs = makeFs({ '/project/package.json': '{}' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'npm ci',
+      test: 'npm test',
+      lint: 'npm run lint',
+      stack: 'npm',
+    })
+  })
+
+  it('detects python from pyproject.toml', () => {
+    const fs = makeFs({ '/project/pyproject.toml': '[project]\nname = "demo"\n' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'pip install -e .',
+      test: 'pytest',
+      lint: 'ruff check .',
+      stack: 'python',
+    })
+  })
+
+  it('detects pip from requirements.txt without pyproject.toml', () => {
+    const fs = makeFs({ '/project/requirements.txt': 'requests==2.31.0\n' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'pip install -r requirements.txt',
+      test: 'pytest',
+      lint: '',
+      stack: 'pip',
+    })
+  })
+
+  it('detects go from go.mod', () => {
+    const fs = makeFs({ '/project/go.mod': 'module example.com/demo\n' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'go mod download',
+      test: 'go test ./...',
+      lint: 'go vet ./...',
+      stack: 'go',
+    })
+  })
+
+  it('detects rust from Cargo.toml', () => {
+    const fs = makeFs({ '/project/Cargo.toml': '[package]\nname = "demo"\n' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'cargo fetch',
+      test: 'cargo test',
+      lint: 'cargo clippy',
+      stack: 'rust',
+    })
+  })
+
+  it('detects ruby from Gemfile', () => {
+    const fs = makeFs({ '/project/Gemfile': "source 'https://rubygems.org'\n" })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'bundle install',
+      test: 'bundle exec rake test',
+      lint: '',
+      stack: 'ruby',
+    })
+  })
+
+  it('detects php from composer.json', () => {
+    const fs = makeFs({ '/project/composer.json': '{}' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: 'composer install',
+      test: 'composer test',
+      lint: '',
+      stack: 'php',
+    })
+  })
+
+  it('falls back to unknown when no manifest is present', () => {
+    const fs = makeFs({ '/project/README.md': '# demo' })
+    expect(detectStack('/project', fs)).toEqual({
+      install: '',
+      test: '',
+      lint: '',
+      stack: 'unknown',
+    })
+  })
+
+  it('falls back to unknown for an empty project directory', () => {
+    const fs = makeFs({ '/project/.gitkeep': '' })
+    expect(detectStack('/project', fs).stack).toBe('unknown')
+  })
+
+  it('prefers pnpm over yarn when both lockfiles coexist', () => {
+    const fs = makeFs({
+      '/project/pnpm-lock.yaml': '',
+      '/project/yarn.lock': '',
+      '/project/package.json': '{}',
+    })
+    expect(detectStack('/project', fs).stack).toBe('pnpm')
+  })
+
+  it('prefers yarn over npm when yarn.lock and package.json coexist', () => {
+    const fs = makeFs({
+      '/project/yarn.lock': '',
+      '/project/package.json': '{}',
+    })
+    expect(detectStack('/project', fs).stack).toBe('yarn')
+  })
+
+  it('prefers pyproject.toml over requirements.txt', () => {
+    const fs = makeFs({
+      '/project/pyproject.toml': '[project]\nname = "demo"\n',
+      '/project/requirements.txt': 'requests==2.31.0\n',
+    })
+    expect(detectStack('/project', fs).stack).toBe('python')
+  })
+
+  it('prefers Node manifests over Python ones when both exist', () => {
+    const fs = makeFs({
+      '/project/package.json': '{}',
+      '/project/pyproject.toml': '[project]\nname = "demo"\n',
+    })
+    expect(detectStack('/project', fs).stack).toBe('npm')
+  })
+
+  it('returns a fresh object on each call (no shared mutation)', () => {
+    const fs = makeFs({ '/project/go.mod': 'module x\n' })
+    const a = detectStack('/project', fs)
+    a.install = 'mutated'
+    const b = detectStack('/project', fs)
+    expect(b.install).toBe('go mod download')
+  })
+})

--- a/packages/ralph/vitest.config.js
+++ b/packages/ralph/vitest.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['test/**/*.test.js', 'src/**/*.test.js'],
+    include: ['test/**/*.test.js', 'src/**/*.test.js', 'lib/**/*.test.js'],
     passWithNoTests: true,
   },
 })


### PR DESCRIPTION
Closes #17

## Summary

- Adds `packages/ralph/lib/detect-stack.js` exporting `detectStack(projectDir, fs?)` that returns `{ install, test, lint, stack }` based on manifest files in the project directory
- Covers all 9 manifest cases from the autodetect table in `RALPH_PACKAGE_PLAN.md` (D5) plus an `unknown` fallback
- Lockfile precedence: `pnpm-lock.yaml` > `yarn.lock` > `package.json`; `pyproject.toml` > `requirements.txt`
- Optional `fs` parameter allows injecting `memfs` for hermetic tests; defaults to `node:fs.existsSync`
- Adds `packages/ralph/lib/detect-stack.test.js` with 16 tests using `memfs` fixtures (one per stack row + 5 precedence/fallback tests + a no-shared-mutation test)
- Extends `packages/ralph/vitest.config.js` `include` to cover co-located `lib/**/*.test.js` per the PRD's stated convention

## Test plan

- [x] `cd packages/ralph && npm test` — 35 tests pass (16 new in detect-stack.test.js)
- [x] Root `npm test` — 108 tests pass
- [x] Root `npm run lint` — 0 errors