### PR TITLE
Ralph pkg #6: ralph doctor command (deps + OS install commands)

### DIFF
--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -60,4 +60,19 @@ program
     }
   })
 
+program
+  .command('doctor')
+  .description('Check required system deps and print install commands for missing ones')
+  .action(async () => {
+    try {
+      const result = await doctorCommand()
+      process.exit(result.exitCode)
+    } catch (e) {
+      if (e instanceof DoctorAbort) {
+        process.exit(e.exitCode ?? 1)
+      }
+      throw e
+    }
+  })
+
 program.parse(process.argv)

--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -6,6 +6,7 @@ import { Command } from 'commander'
 import { startCommand, StartAbort } from '../lib/commands/start.js'
 import { stopCommand, StopAbort } from '../lib/commands/stop.js'
 import { initCommand, InitAbort } from '../lib/commands/init.js'
+import { doctorCommand, DoctorAbort } from '../lib/commands/doctor.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'))

--- a/packages/ralph/lib/commands/doctor.js
+++ b/packages/ralph/lib/commands/doctor.js
@@ -1,0 +1,81 @@
+import pc from 'picocolors'
+import { checkDeps, commandExists } from '../deps.js'
+import { detectPlatform } from '../platform.js'
+
+class DoctorAbort extends Error {
+  constructor(message, exitCode = 1) {
+    super(message)
+    this.exitCode = exitCode
+  }
+}
+
+export async function doctorCommand({
+  stdout = process.stdout,
+  stderr = process.stderr,
+  hasCommand = commandExists,
+  platform = detectPlatform(),
+} = {}) {
+  const out = (m) => stdout.write(m + '\n')
+  const err = (m) => stderr.write(m + '\n')
+
+  const results = checkDeps({ hasCommand })
+  const missingCritical = results.filter((r) => !r.present && r.critical)
+  const missingNonCritical = results.filter((r) => !r.present && !r.critical)
+
+  out(`Ralph doctor — platform: ${platform}`)
+  out('')
+
+  for (const r of results) {
+    if (r.present) {
+      out(`  ${pc.green('✓')} ${r.name}`)
+    } else if (r.critical) {
+      out(`  ${pc.red('✗')} ${r.name} (required)`)
+      out(`      install: ${installFor(r, platform)}`)
+    } else {
+      out(`  ${pc.yellow('!')} ${r.name} (optional)`)
+      out(`      install: ${installFor(r, platform)}`)
+    }
+  }
+
+  out('')
+  if (missingCritical.length > 0) {
+    err(
+      pc.red(
+        `Missing ${missingCritical.length} required dep(s): ${missingCritical
+          .map((r) => r.name)
+          .join(', ')}`,
+      ),
+    )
+    return { exitCode: 1, missingCritical, missingNonCritical, platform }
+  }
+
+  if (missingNonCritical.length > 0) {
+    out(
+      pc.yellow(
+        `Optional deps missing: ${missingNonCritical.map((r) => r.name).join(', ')}`,
+      ),
+    )
+  } else {
+    out(pc.green('All deps present.'))
+  }
+  return { exitCode: 0, missingCritical, missingNonCritical, platform }
+}
+
+export function assertCriticalDeps({
+  hasCommand = commandExists,
+  platform = detectPlatform(),
+} = {}) {
+  const results = checkDeps({ hasCommand })
+  const missingCritical = results.filter((r) => !r.present && r.critical)
+  if (missingCritical.length === 0) return { ok: true, missingCritical: [] }
+  const formatted = missingCritical
+    .map((r) => `❌ '${r.name}' não encontrado no PATH (instalar: ${installFor(r, platform)})`)
+    .join('\n')
+  return { ok: false, missingCritical, message: formatted }
+}
+
+function installFor(dep, platform) {
+  return dep.install[platform] || dep.install.linux
+}
+
+export { DoctorAbort }

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -5,8 +5,10 @@ import { loadEnvFile } from '../utils/env.js'
 import { commandExists } from '../utils/which.js'
 import { confirm } from '../utils/prompt.js'
 import { templatePath } from '../paths.js'
+import { assertCriticalDeps } from './doctor.js'
+import { checkDeps } from '../deps.js'
+import { detectPlatform } from '../platform.js'
 
-const REQUIRED_COMMANDS = ['tmux', 'jq', 'gh', 'claude', 'curl', 'npm', 'git']
 const TMUX_SESSION = 'ralph'
 const SEARCH_QUERY =
   'state:open -label:claude-working -label:claude-failed -label:do-not-ralph'

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -46,12 +46,21 @@ export async function startCommand({
     }
   }
 
-  // 2. Required commands
-  for (const cmd of REQUIRED_COMMANDS) {
-    if (!hasCommand(cmd)) {
-      err(`❌ '${cmd}' não encontrado no PATH`)
-      throw new StartAbort(`missing command: ${cmd}`, 1)
-    }
+  // 2. Required commands (shared dep check)
+  const platform = detectPlatform()
+  const depCheck = assertCriticalDeps({ hasCommand, platform })
+  if (!depCheck.ok) {
+    err(depCheck.message)
+    throw new StartAbort(
+      `missing command: ${depCheck.missingCritical.map((d) => d.name).join(', ')}`,
+      1,
+    )
+  }
+  const missingNonCritical = checkDeps({ hasCommand }).filter(
+    (r) => !r.present && !r.critical,
+  )
+  for (const r of missingNonCritical) {
+    out(`⚠️  '${r.name}' não encontrado (opcional). Algumas funções podem falhar.`)
   }
 
   // 3. .env.local — informational only

--- a/packages/ralph/lib/deps.js
+++ b/packages/ralph/lib/deps.js
@@ -1,0 +1,81 @@
+export { commandExists } from './utils/which.js'
+
+export const REQUIRED_DEPS = {
+  git: {
+    critical: true,
+    install: {
+      mac: 'brew install git',
+      linux: 'apt install git',
+      wsl: 'apt install git',
+    },
+  },
+  gh: {
+    critical: true,
+    install: {
+      mac: 'brew install gh',
+      linux: 'apt install gh',
+      wsl: 'apt install gh',
+    },
+  },
+  tmux: {
+    critical: true,
+    install: {
+      mac: 'brew install tmux',
+      linux: 'apt install tmux',
+      wsl: 'apt install tmux',
+    },
+  },
+  claude: {
+    critical: true,
+    install: {
+      mac: 'npm install -g @anthropic-ai/claude-code',
+      linux: 'npm install -g @anthropic-ai/claude-code',
+      wsl: 'npm install -g @anthropic-ai/claude-code',
+    },
+  },
+  node: {
+    critical: true,
+    install: {
+      mac: 'brew install node',
+      linux: 'apt install nodejs',
+      wsl: 'apt install nodejs',
+    },
+  },
+  npm: {
+    critical: true,
+    install: {
+      mac: 'brew install node',
+      linux: 'apt install npm',
+      wsl: 'apt install npm',
+    },
+  },
+  jq: {
+    critical: false,
+    install: {
+      mac: 'brew install jq',
+      linux: 'apt install jq',
+      wsl: 'apt install jq',
+    },
+  },
+  curl: {
+    critical: false,
+    install: {
+      mac: 'brew install curl',
+      linux: 'apt install curl',
+      wsl: 'apt install curl',
+    },
+  },
+}
+
+export function checkDeps({ hasCommand, deps = REQUIRED_DEPS } = {}) {
+  const results = []
+  for (const [name, info] of Object.entries(deps)) {
+    results.push({
+      name,
+      present: hasCommand(name),
+      critical: info.critical,
+      install: info.install,
+    })
+  }
+  return results
+}

--- a/packages/ralph/lib/doctor.test.js
+++ b/packages/ralph/lib/doctor.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest'
+import { doctorCommand, assertCriticalDeps } from './commands/doctor.js'
+import { REQUIRED_DEPS } from './deps.js'
+import { detectPlatform } from './platform.js'
+
+function makeStream() {
+  const chunks = []
+  return {
+    write: (s) => {
+      chunks.push(s)
+      return true
+    },
+    output: () => chunks.join(''),
+  }
+}
+
+const allPresent = () => true
+const noneInstalled = () => false
+
+describe('doctorCommand', () => {
+  it('exits 0 when all deps are present', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const result = await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: allPresent,
+      platform: 'mac',
+    })
+    expect(result.exitCode).toBe(0)
+    expect(result.missingCritical).toEqual([])
+    expect(stdout.output()).toContain('All deps present')
+  })
+
+  it('exits 1 when a critical dep is missing', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const result = await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: (cmd) => cmd !== 'git',
+      platform: 'mac',
+    })
+    expect(result.exitCode).toBe(1)
+    expect(result.missingCritical.map((r) => r.name)).toEqual(['git'])
+    expect(stderr.output()).toContain('Missing 1 required dep')
+  })
+
+  it('exits 0 with warning when only a non-critical dep is missing', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const result = await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: (cmd) => cmd !== 'jq',
+      platform: 'mac',
+    })
+    expect(result.exitCode).toBe(0)
+    expect(result.missingCritical).toEqual([])
+    expect(result.missingNonCritical.map((r) => r.name)).toEqual(['jq'])
+    expect(stdout.output()).toContain('Optional deps missing: jq')
+  })
+
+  it('prints the macOS install command when platform is mac', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: (cmd) => cmd !== 'jq',
+      platform: 'mac',
+    })
+    expect(stdout.output()).toContain('brew install jq')
+  })
+
+  it('prints the linux install command when platform is linux', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: (cmd) => cmd !== 'jq',
+      platform: 'linux',
+    })
+    expect(stdout.output()).toContain('apt install jq')
+  })
+
+  it('prints the wsl install command when platform is wsl', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: (cmd) => cmd !== 'jq',
+      platform: 'wsl',
+    })
+    expect(stdout.output()).toContain('apt install jq')
+  })
+
+  it('lists every required dep in the output', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: allPresent,
+      platform: 'mac',
+    })
+    for (const name of Object.keys(REQUIRED_DEPS)) {
+      expect(stdout.output()).toContain(name)
+    }
+  })
+
+  it('exits 1 when both critical and non-critical are missing', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const result = await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: noneInstalled,
+      platform: 'mac',
+    })
+    expect(result.exitCode).toBe(1)
+    expect(result.missingCritical.length).toBeGreaterThan(0)
+    expect(result.missingNonCritical.length).toBeGreaterThan(0)
+  })
+})
+
+describe('assertCriticalDeps', () => {
+  it('returns ok when all critical deps present', () => {
+    const result = assertCriticalDeps({ hasCommand: allPresent, platform: 'mac' })
+    expect(result.ok).toBe(true)
+    expect(result.missingCritical).toEqual([])
+  })
+
+  it('returns not ok with formatted message when critical dep missing', () => {
+    const result = assertCriticalDeps({
+      hasCommand: (cmd) => cmd !== 'tmux',
+      platform: 'mac',
+    })
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain("❌ 'tmux' não encontrado no PATH")
+    expect(result.message).toContain('brew install tmux')
+  })
+
+  it('does not flag non-critical deps as failures', () => {
+    const result = assertCriticalDeps({
+      hasCommand: (cmd) => cmd !== 'jq',
+      platform: 'mac',
+    })
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('detectPlatform', () => {
+  it('returns mac for darwin', () => {
+    expect(detectPlatform({ platform: 'darwin' })).toBe('mac')
+  })
+
+  it('returns linux when /proc/version has no microsoft tag', () => {
+    expect(
+      detectPlatform({ platform: 'linux', readProcVersion: () => 'Linux version 5.x ...' }),
+    ).toBe('linux')
+  })
+
+  it('returns wsl when /proc/version mentions Microsoft', () => {
+    expect(
+      detectPlatform({
+        platform: 'linux',
+        readProcVersion: () => 'Linux version 5.x Microsoft WSL2',
+      }),
+    ).toBe('wsl')
+  })
+
+  it('returns wsl when /proc/version mentions microsoft (lowercase)', () => {
+    expect(
+      detectPlatform({
+        platform: 'linux',
+        readProcVersion: () => 'linux 5.x microsoft-standard',
+      }),
+    ).toBe('wsl')
+  })
+
+  it('returns linux when /proc/version is unreadable', () => {
+    expect(detectPlatform({ platform: 'linux', readProcVersion: () => '' })).toBe('linux')
+  })
+})

--- a/packages/ralph/lib/platform.js
+++ b/packages/ralph/lib/platform.js
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+
+export function detectPlatform({
+  platform = process.platform,
+  readProcVersion = defaultReadProcVersion,
+} = {}) {
+  if (platform === 'darwin') return 'mac'
+  if (platform === 'linux') {
+    const version = readProcVersion()
+    if (version && /microsoft/i.test(version)) return 'wsl'
+    return 'linux'
+  }
+  return 'linux'
+}
+
+function defaultReadProcVersion() {
+  try {
+    return readFileSync('/proc/version', 'utf8')
+  } catch {
+    return ''
+  }
+}

--- a/packages/ralph/test/commands/start.test.js
+++ b/packages/ralph/test/commands/start.test.js
@@ -50,14 +50,33 @@ describe('startCommand', () => {
     expect(deps.stderr.output()).toContain("Sessão tmux 'ralph' já existe.")
   })
 
-  it('aborts when a required command is missing', async () => {
+  it('aborts when a critical command is missing', async () => {
     const deps = baseDeps()
-    deps.hasCommand = (cmd) => cmd !== 'jq'
+    deps.hasCommand = (cmd) => cmd !== 'git'
     deps.exec = makeExec({
       'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
     })
     await expect(startCommand(deps)).rejects.toBeInstanceOf(StartAbort)
-    expect(deps.stderr.output()).toContain("❌ 'jq' não encontrado no PATH")
+    expect(deps.stderr.output()).toContain("❌ 'git' não encontrado no PATH")
+  })
+
+  it('warns but does not abort when a non-critical command is missing', async () => {
+    const deps = baseDeps()
+    deps.hasCommand = (cmd) => cmd !== 'jq'
+    deps.exec = makeExec({
+      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph --limit 100 --json number -q . | length':
+        { exitCode: 0, stdout: '0', stderr: '' },
+    })
+    const result = await startCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(deps.stdout.output()).toContain("⚠️  'jq' não encontrado (opcional)")
   })
 
   it('aborts when gh auth status fails', async () => {


### PR DESCRIPTION
## Summary

Adds `ralph doctor` subcommand and a shared dependency check used by both `doctor` and `start`.

- `lib/platform.js` — `detectPlatform()` returns `'mac' | 'linux' | 'wsl'` (uses `process.platform` + `/proc/version`)
- `lib/deps.js` — `commandExists(name)` re-export + `REQUIRED_DEPS` map keyed by dep with `{ critical, install: { mac, linux, wsl } }`
- `lib/commands/doctor.js` — prints colored status (green/red/yellow via picocolors), exits 1 only when a critical dep (`git`, `gh`, `tmux`, `claude`, `node`, `npm`) is missing; prints OS-specific install commands for misses
- `lib/commands/start.js` — refactored to call the shared `assertCriticalDeps` helper before launching tmux; non-critical deps (`jq`, `curl`) now warn instead of aborting
- `bin/ralph.js` — wires the new `doctor` subcommand
- `lib/doctor.test.js` — covers all-present / missing-critical / missing-non-critical + per-OS install command + platform detection branches

Closes #19

## Test plan

- [x] `cd packages/ralph && npm test` passes (69 tests)
- [x] Root `npm test` passes (108 tests)
- [x] `npm run lint` clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)