### PR TITLE
Ralph pkg #7: Split prompt-base + interpolation

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,61 +1,31 @@
-# Ralph Loop — Resolver próxima issue do GitHub
+# Project context for Ralph
 
-Você é um agente autônomo num loop de resolução de issues. Cada execução sua processa UMA issue do começo ao fim. Quando terminar, saia. O bash externo invoca você de novo pra próxima issue.
+## Stack
 
-## Sequência obrigatória
+React 19 + Vite + Tailwind CSS 4. Plain JavaScript (no TypeScript).
+Components in `src/components/`, static data in `src/data/`. Tests via
+Vitest. The Ralph package itself lives in `packages/ralph/` and has its
+own test suite (`cd packages/ralph && npm test`).
 
-0. **Garantir deps**: `npm ci` (sempre, no início).
+## MCPs
 
-1. **Selecionar issue**: rode
-   ```
-   gh issue list --state open --label '-claude-working' --label '-claude-failed' --sort created --order asc --limit 1 --json number,title,body
-   ```
-   Pegue a primeira. Se a lista estiver vazia, escreva "RALPH_DONE" e termine. (Nota: o bash já checa isso antes de te invocar, então normalmente terá issue.)
+- `mcp__supabase__*` — Supabase project access. Use when an issue
+  involves database, schema, queries, or edge functions in `supabase/`.
+- If an MCP call returns an auth error, do NOT try to re-authenticate
+  (it requires human interaction). Use `gh`, local code, and Read/Edit
+  tools instead.
 
-2. **Marcar como em andamento**: `gh issue edit N --add-label claude-working`
+## Sub-agents / slash commands
 
-3. **Preparar branch**: `git checkout dev && git pull && git checkout -b issue-N`
+- `/project:manager` — orchestrate, plan, delegate
+- `/project:frontend` — React components, Tailwind, routing
+- `/project:backend` — APIs, database, auth
+- `/project:qa` — review, tests, accessibility
+- `/project:docs` — CLAUDE.md, README, JSDoc
+- `/project:gitops` — branches, commits, PRs, CI/CD
 
-4. **Resolver**: leia o título e o body da issue, implemente a solução. Use Read/Edit/Write conforme necessário. Siga as convenções do CLAUDE.md.
+## Extra restrictions
 
-5. **Validar localmente**: rode `npm test` e `npm run lint`. Se falhar, corrija e rode de novo. Repita até passarem (máx 3 tentativas; se ainda falhar, vá para "Falhou").
-
-6. **Commit + push**: `git add <arquivos específicos> && git commit -m "fix: <descrição> (#N)" && git push -u origin issue-N`
-
-7. **Abrir PR**: `gh pr create --base dev --head issue-N --title "<título>" --body "Closes #N"`
-
-8. **Auto-merge + esperar**:
-   - `gh pr merge <pr> --auto --squash --delete-branch`
-   - Pollar `gh pr view <pr> --json state -q .state` a cada 30s. Critérios:
-     - `MERGED` → sucesso, termine.
-     - `CLOSED` (sem merge) → falha.
-     - 40 polls (20min) sem MERGED → falha.
-     - CI red detectado (`gh pr checks <pr>` retorna fail) → tente corrigir o problema; se falhar 2 vezes consecutivas → falha.
-
-## Falhou (em qualquer ponto)
-
-- `gh issue edit N --remove-label claude-working --add-label claude-failed`
-- `gh issue comment N --body "Claude tentou resolver mas falhou: <motivo curto>. Veja log em logs/ralph-issue-N.log e PR (se aberto)."`
-- Se PR foi aberto: `gh pr close <pr>`
-- Termine.
-
-## Restrições absolutas
-
-- NUNCA `git push --force` ou `git push -f`.
-- NUNCA push direto pra `main` ou `dev`. Sempre via PR.
-- NUNCA tocar em: `.env*`, `.git/`, `node_modules/`, `dist/`, `logs/`, `ralph.sh`, `start-ralph.sh`, `PROMPT.md`, `.claude/`.
-- NUNCA `rm -rf` em path absoluto. Use `rm` em arquivo específico.
-- NUNCA mergear PRs (`gh pr merge` sem `--auto`). O `--auto` cuida.
-- NUNCA fechar issues manualmente (`gh issue close`). O `Closes #N` cuida.
-- NUNCA editar, criar ou deletar arquivos fora de `/Users/lucasfe/repos/agenthub`.
-- NUNCA rodar comandos Bash que toquem arquivos fora de `/Users/lucasfe/repos/agenthub` (ex: `rm`, `mv`, `curl > path`).
-- Se `npm test` ou `npm run lint` quebrar 3 vezes seguidas, declare CLAUDE_GIVE_UP e vá para "Falhou".
-
-## MCP disponível
-
-- `mcp__supabase__*` — acesso ao Supabase do projeto. Use quando a issue envolver banco, schema, queries, ou edge functions em `supabase/`.
-- Se uma chamada MCP retornar erro de auth, NÃO tente re-autenticar (requer interação humana). Use `gh`, código local, e ferramentas Read/Edit em vez disso.
-
-## Contexto do projeto
-
-Veja `CLAUDE.md` na raiz. Resumo: React 19 + Vite + Tailwind, JS puro (não TS), componentes em `src/components/`, dados estáticos em `src/data/`, time de sub-agentes via `/project:*` slash commands.
+- Do not modify files under `packages/ralph/` unless the issue is
+  explicitly about the Ralph package — they are part of a separately
+  versioned npm package.

--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { join, resolve } from 'node:path'
+import { interpolate } from './interpolate.js'
+import { templatePath } from './paths.js'
+
+export function buildPrompt({
+  projectRoot = process.cwd(),
+  env = process.env,
+  fs: fsImpl,
+  stderr = process.stderr,
+} = {}) {
+  const fs = fsImpl ?? { existsSync, readFileSync }
+  const baseTemplate = fs.readFileSync(templatePath('prompt-base.md'), 'utf8')
+  const projectPromptPath = join(projectRoot, 'PROMPT.md')
+  const projectPrompt = fs.existsSync(projectPromptPath)
+    ? fs.readFileSync(projectPromptPath, 'utf8').toString()
+    : ''
+  const vars = {
+    INSTALL_CMD: env.INSTALL_CMD ?? '',
+    TEST_CMD: env.TEST_CMD ?? '',
+    LINT_CMD: env.LINT_CMD ?? '',
+    MAIN_BRANCH: env.MAIN_BRANCH ?? 'main',
+    DEV_BRANCH: env.DEV_BRANCH ?? 'main',
+    PR_TARGET: env.PR_TARGET ?? 'main',
+    MERGE_STRATEGY: env.MERGE_STRATEGY ?? 'squash',
+    MERGE_POLL_INTERVAL: env.MERGE_POLL_INTERVAL ?? '30',
+    MERGE_POLL_MAX: env.MERGE_POLL_MAX ?? '40',
+    PROJECT_ROOT: projectRoot,
+    PROJECT_PROMPT: projectPrompt,
+  }
+  return interpolate(baseTemplate, vars, { stderr })
+}
+
+const invokedAsScript =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+if (invokedAsScript) {
+  process.stdout.write(buildPrompt())
+}

--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { pathToFileURL } from 'node:url'
 import { join, resolve } from 'node:path'
 import { interpolate } from './interpolate.js'
 import { templatePath } from './paths.js'

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { buildPrompt } from './build-prompt.js'
+import { templatePath } from './paths.js'
+
+const PROJECT = '/project'
+
+function makeStderr() {
+  const calls = []
+  return {
+    write: (m) => {
+      calls.push(m)
+      return true
+    },
+    calls,
+  }
+}
+
+function setupFs({ projectFiles = {} } = {}) {
+  const baseTemplate = readFileSync(templatePath('prompt-base.md'), 'utf8')
+  const vol = Volume.fromJSON({}, '/')
+  vol.mkdirSync(templatePath(''), { recursive: true })
+  vol.writeFileSync(templatePath('prompt-base.md'), baseTemplate)
+  vol.mkdirSync(PROJECT, { recursive: true })
+  for (const [k, v] of Object.entries(projectFiles)) {
+    vol.writeFileSync(join(PROJECT, k), v)
+  }
+  return vol
+}
+
+describe('buildPrompt', () => {
+  it('substitutes the runtime placeholders from env into prompt-base', () => {
+    const vol = setupFs({ projectFiles: { 'PROMPT.md': '## Stack\nFoo' } })
+    const out = buildPrompt({
+      projectRoot: PROJECT,
+      env: {
+        INSTALL_CMD: 'npm ci',
+        TEST_CMD: 'npm test',
+        LINT_CMD: 'npm run lint',
+        MAIN_BRANCH: 'main',
+        DEV_BRANCH: 'dev',
+        PR_TARGET: 'dev',
+        MERGE_STRATEGY: 'rebase',
+        MERGE_POLL_INTERVAL: '15',
+        MERGE_POLL_MAX: '60',
+      },
+      fs: vol,
+    })
+    expect(out).toContain('run `npm ci`')
+    expect(out).toContain('npm test')
+    expect(out).toContain('npm run lint')
+    expect(out).toContain('git checkout dev')
+    expect(out).toContain('--base dev')
+    expect(out).toContain('--auto --rebase')
+    expect(out).toContain('every\n     15s')
+    expect(out).toContain('60 polls')
+    expect(out).toContain('Your project root is `/project`')
+  })
+
+  it("appends the project's PROMPT.md as {{PROJECT_PROMPT}}", () => {
+    const vol = setupFs({
+      projectFiles: { 'PROMPT.md': '## Stack\nReact + Vite' },
+    })
+    const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+    expect(out).toContain('## Stack\nReact + Vite')
+    expect(out.indexOf('## Stack\nReact + Vite')).toBeGreaterThan(
+      out.indexOf('## Absolute restrictions'),
+    )
+    expect(out).not.toContain('{{PROJECT_PROMPT}}')
+  })
+
+  it('renders an empty PROJECT_PROMPT when no project PROMPT.md exists', () => {
+    const vol = setupFs()
+    const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+    expect(out).not.toContain('{{PROJECT_PROMPT}}')
+  })
+
+  it('falls back to safe defaults when env vars are missing', () => {
+    const vol = setupFs()
+    const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+    expect(out).toContain('--auto --squash')
+    expect(out).toContain('every\n     30s')
+    expect(out).toContain('40 polls')
+    expect(out).toContain('git checkout main')
+  })
+
+  it('does not warn when every placeholder is satisfied', () => {
+    const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+    const stderr = makeStderr()
+    buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+    expect(stderr.calls).toHaveLength(0)
+  })
+})

--- a/packages/ralph/lib/interpolate.js
+++ b/packages/ralph/lib/interpolate.js
@@ -1,0 +1,21 @@
+const PLACEHOLDER = /\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}/g
+
+export function interpolate(template, vars = {}, { stderr = process.stderr } = {}) {
+  if (typeof template !== 'string') {
+    throw new TypeError(
+      `interpolate: template must be a string (got ${template === null ? 'null' : typeof template})`,
+    )
+  }
+  const warned = new Set()
+  return template.replace(PLACEHOLDER, (match, key) => {
+    if (Object.prototype.hasOwnProperty.call(vars, key)) {
+      const value = vars[key]
+      return value == null ? '' : String(value)
+    }
+    if (!warned.has(key)) {
+      warned.add(key)
+      stderr.write(`⚠️  interpolate: unknown placeholder {{${key}}} — left intact\n`)
+    }
+    return match
+  })
+}

--- a/packages/ralph/lib/interpolate.test.js
+++ b/packages/ralph/lib/interpolate.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest'
+import { interpolate } from './interpolate.js'
+
+function fakeStderr() {
+  const calls = []
+  return {
+    write: (msg) => {
+      calls.push(msg)
+      return true
+    },
+    calls,
+  }
+}
+
+describe('interpolate', () => {
+  it('replaces a single {{KEY}} with vars[KEY]', () => {
+    expect(interpolate('hello {{NAME}}', { NAME: 'world' })).toBe('hello world')
+  })
+
+  it('replaces multiple distinct placeholders', () => {
+    const result = interpolate('{{A}}+{{B}}={{C}}', { A: '1', B: '2', C: '3' })
+    expect(result).toBe('1+2=3')
+  })
+
+  it('replaces every occurrence of a repeated placeholder', () => {
+    expect(interpolate('{{X}} {{X}} {{X}}', { X: 'go' })).toBe('go go go')
+  })
+
+  it('inserts values verbatim when they contain regex-significant characters', () => {
+    const vars = {
+      DOLLAR: '$1',
+      DOLLAR_AMP: '$&',
+      BACK: '\\back',
+      AMP: 'a&b',
+      NESTED: '{{INNER}}',
+    }
+    expect(
+      interpolate(
+        '{{DOLLAR}}|{{DOLLAR_AMP}}|{{BACK}}|{{AMP}}|{{NESTED}}',
+        vars,
+      ),
+    ).toBe('$1|$&|\\back|a&b|{{INNER}}')
+  })
+
+  it('does not re-interpolate values that themselves contain placeholders', () => {
+    const result = interpolate('{{A}}', { A: '{{A}}', B: 'should-not-appear' })
+    expect(result).toBe('{{A}}')
+  })
+
+  it('leaves unknown placeholders intact and warns to stderr', () => {
+    const stderr = fakeStderr()
+    const result = interpolate(
+      'known={{KNOWN}} unknown={{MISSING}}',
+      { KNOWN: 'ok' },
+      { stderr },
+    )
+    expect(result).toBe('known=ok unknown={{MISSING}}')
+    expect(stderr.calls).toHaveLength(1)
+    expect(stderr.calls[0]).toContain('MISSING')
+  })
+
+  it('warns at most once per unknown placeholder, even if it repeats', () => {
+    const stderr = fakeStderr()
+    interpolate('{{A}} {{A}} {{B}} {{A}}', {}, { stderr })
+    expect(stderr.calls).toHaveLength(2)
+    expect(stderr.calls.some((m) => m.includes('A'))).toBe(true)
+    expect(stderr.calls.some((m) => m.includes('B'))).toBe(true)
+  })
+
+  it('does not write to stderr when every placeholder is known', () => {
+    const stderr = fakeStderr()
+    interpolate('{{X}}', { X: 'y' }, { stderr })
+    expect(stderr.calls).toHaveLength(0)
+  })
+
+  it('treats null/undefined vars as empty string', () => {
+    expect(interpolate('a={{A}};b={{B}}', { A: null, B: undefined })).toBe('a=;b=')
+  })
+
+  it('coerces non-string values to strings', () => {
+    expect(interpolate('n={{N}};b={{B}}', { N: 42, B: true })).toBe('n=42;b=true')
+  })
+
+  it('returns the empty template unchanged', () => {
+    expect(interpolate('', { X: 'y' })).toBe('')
+  })
+
+  it('throws TypeError when template is not a string', () => {
+    expect(() => interpolate(undefined, {})).toThrow(TypeError)
+    expect(() => interpolate(null, {})).toThrow(TypeError)
+    expect(() => interpolate(42, {})).toThrow(TypeError)
+    expect(() => interpolate({}, {})).toThrow(TypeError)
+  })
+
+  it('ignores malformed placeholders that do not match {{IDENT}}', () => {
+    const stderr = fakeStderr()
+    const template = '{{ X }} {X} {{X plain {{1BAD}}'
+    expect(interpolate(template, { X: 'y' }, { stderr })).toBe(template)
+    expect(stderr.calls).toHaveLength(0)
+  })
+
+  it('uses the default stderr when no options are provided', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      interpolate('{{UNKNOWN_DEFAULT_STDERR}}', {})
+      expect(spy).toHaveBeenCalled()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})

--- a/packages/ralph/templates/prompt-base.md
+++ b/packages/ralph/templates/prompt-base.md
@@ -1,0 +1,74 @@
+# Ralph Loop — Resolve next GitHub issue
+
+You are an autonomous agent in an issue-resolution loop. Each invocation
+processes ONE issue end-to-end. When done, exit. The outer bash will
+invoke you again for the next issue.
+
+Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
+operations.
+
+## Required sequence
+
+0. **Ensure dependencies**: run `{{INSTALL_CMD}}` (skip if empty).
+
+1. **Select issue**: run
+   ```
+   gh issue list --state open --search '-label:claude-working -label:claude-failed sort:created-asc' --limit 1 --json number,title,body
+   ```
+   Take the first. If the list is empty, write "RALPH_DONE" and exit.
+   (The bash already checks this before invoking you, so normally there
+   will be one.)
+
+2. **Mark in progress**: `gh issue edit N --add-label claude-working`
+
+3. **Prepare branch**: `git checkout {{DEV_BRANCH}} && git pull && git checkout -b issue-N`
+
+4. **Resolve**: read the issue title and body, implement the solution.
+   Use Read/Edit/Write as needed. Follow the conventions in
+   `CLAUDE.md`.
+
+5. **Validate locally**: run `{{TEST_CMD}}` and `{{LINT_CMD}}` (skip
+   the empty ones). If they fail, fix and re-run. Repeat up to 3 times;
+   if they still fail, go to "Failed".
+
+6. **Commit + push**: `git add <specific files> && git commit -m "fix: <description> (#N)" && git push -u origin issue-N`
+
+7. **Open PR**: `gh pr create --base {{PR_TARGET}} --head issue-N --title "<title>" --body "Closes #N"`
+
+8. **Auto-merge + wait**:
+   - `gh pr merge <pr> --auto --{{MERGE_STRATEGY}} --delete-branch`
+   - Poll `gh pr view <pr> --json state -q .state` every
+     {{MERGE_POLL_INTERVAL}}s. Criteria:
+     - `MERGED` → success, exit.
+     - `CLOSED` (without merge) → failure.
+     - {{MERGE_POLL_MAX}} polls without `MERGED` → failure.
+     - CI red detected (`gh pr checks <pr>` returns fail) → try to fix
+       the problem; if it fails 2 consecutive times → failure.
+
+## Failed (at any point)
+
+- `gh issue edit N --remove-label claude-working --add-label claude-failed`
+- `gh issue comment N --body "Claude tried but failed: <short reason>. See log in logs/ralph-issue-N.log and PR (if opened)."`
+- If a PR was opened: `gh pr close <pr>`
+- Exit.
+
+## Absolute restrictions
+
+- NEVER `git push --force` or `git push -f`.
+- NEVER push directly to `{{MAIN_BRANCH}}` or `{{DEV_BRANCH}}`. Always
+  via PR.
+- NEVER touch: `.env*`, `.git/`, `node_modules/`, `dist/`, `logs/`,
+  `ralph.sh`, `start-ralph.sh`, `PROMPT.md`, `ralph.config.sh`,
+  `.claude/`.
+- NEVER `rm -rf` on an absolute path. Use `rm` on a specific file.
+- NEVER merge PRs directly (`gh pr merge` without `--auto`). The
+  `--auto` handles it.
+- NEVER close issues manually (`gh issue close`). The `Closes #N` in
+  the PR body handles it.
+- NEVER edit, create, or delete files outside `{{PROJECT_ROOT}}`.
+- NEVER run Bash commands that touch files outside `{{PROJECT_ROOT}}`
+  (e.g. `rm`, `mv`, `curl > path`).
+- If `{{TEST_CMD}}` or `{{LINT_CMD}}` breaks 3 times in a row, declare
+  CLAUDE_GIVE_UP and go to "Failed".
+
+{{PROJECT_PROMPT}}

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -56,7 +56,7 @@ while :; do
   num=$(gh issue list --search "$SEARCH_QUERY sort:created-asc" --limit 1 --json number -q '.[0].number')
   echo "==> Iteração para issue #$num ($count restantes)"
 
-  cat PROMPT.md | claude -p --dangerously-skip-permissions \
+  node "$RALPH_PKG_DIR/lib/build-prompt.js" | claude -p --dangerously-skip-permissions \
     --output-format stream-json --verbose --include-partial-messages 2>&1 \
     | jq -r --unbuffered '
         if .type == "assistant" then

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -20,6 +20,18 @@ fi
 cd "$PROJECT_ROOT"
 export PROJECT_ROOT
 
+# Locate the package directory (one level up from this template).
+RALPH_PKG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export RALPH_PKG_DIR
+
+# Source ralph.config.sh first so commands/branches/merge config become env
+# vars visible to the prompt builder. Then source .env.local for credentials.
+if [ -f ralph.config.sh ]; then
+  set -a
+  . ./ralph.config.sh
+  set +a
+fi
+
 if [ -f .env.local ]; then
   set -a
   . ./.env.local


### PR DESCRIPTION
Closes #20

## Summary

- Add `lib/interpolate.js` with regex-safe `{{KEY}}` substitution and warn-on-unknown semantics.
- Add `templates/prompt-base.md` owning the obligatory 8-step sequence and absolute restrictions, with runtime placeholders + a final `{{PROJECT_PROMPT}}` slot.
- Add `lib/build-prompt.js` (importable + executable) that reads `prompt-base.md`, pulls runtime config from env, slots in the project's `PROMPT.md`, and prints the interpolated result.
- Wire `templates/ralph.sh` to source `ralph.config.sh` and pipe the interpolated prompt into Claude on every iteration.
- Reduce the agenthub repo's `PROMPT.md` to the addendum-only form (stack, MCPs, sub-agents, extra restrictions).

## Test plan

- [x] `cd packages/ralph && npm test` — 88 tests pass (14 for interpolate, 5 for build-prompt, plus prior suites).
- [x] `npm test` at repo root — 108 tests pass (project tests are unaffected; `vitest.config.js` excludes `packages/**`).
- [x] `npm run lint` — 0 errors.
- [x] `node packages/ralph/lib/build-prompt.js` from agenthub root produces a fully interpolated prompt that ends with the project's PROMPT.md addendum.