### PR TITLE
Ralph pkg #8: Lazy validation (state.json + Claude one-shot) (#21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 playwright-report/
 test-results/
 .vercel
+
+# Ralph
+.ralph/

--- a/packages/ralph/lib/build-validate-prompt.js
+++ b/packages/ralph/lib/build-validate-prompt.js
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { join, resolve } from 'node:path'
+import { interpolate } from './interpolate.js'
+import { templatePath } from './paths.js'
+import { hashConfig } from './state.js'
+
+export function buildValidatePrompt({
+  projectRoot = process.cwd(),
+  ralphVersion = process.env.RALPH_VERSION ?? 'unknown',
+  fs: fsImpl,
+  stderr = process.stderr,
+} = {}) {
+  const fs = fsImpl ?? { existsSync, readFileSync }
+  const template = fs.readFileSync(templatePath('validate-config.md'), 'utf8').toString()
+  const configPath = join(projectRoot, 'ralph.config.sh')
+  const configHash = hashConfig(configPath, fsImpl)
+  return interpolate(
+    template,
+    {
+      PROJECT_ROOT: projectRoot,
+      CURRENT_CONFIG_HASH: configHash,
+      RALPH_VERSION: ralphVersion,
+    },
+    { stderr },
+  )
+}
+
+const invokedAsScript =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+if (invokedAsScript) {
+  process.stdout.write(buildValidatePrompt())
+}

--- a/packages/ralph/lib/build-validate-prompt.test.js
+++ b/packages/ralph/lib/build-validate-prompt.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { buildValidatePrompt } from './build-validate-prompt.js'
+import { templatePath } from './paths.js'
+
+const PROJECT = '/project'
+
+function makeStderr() {
+  const calls = []
+  return {
+    write: (m) => {
+      calls.push(m)
+      return true
+    },
+    calls,
+  }
+}
+
+function setupFs({ projectFiles = {} } = {}) {
+  const template = readFileSync(templatePath('validate-config.md'), 'utf8')
+  const v = Volume.fromJSON({}, '/')
+  v.mkdirSync(templatePath(''), { recursive: true })
+  v.writeFileSync(templatePath('validate-config.md'), template)
+  v.mkdirSync(PROJECT, { recursive: true })
+  for (const [k, body] of Object.entries(projectFiles)) {
+    v.writeFileSync(join(PROJECT, k), body)
+  }
+  return v
+}
+
+describe('buildValidatePrompt', () => {
+  it('interpolates PROJECT_ROOT, CURRENT_CONFIG_HASH and RALPH_VERSION', () => {
+    const cfgBody = 'INSTALL_CMD=""\nTEST_CMD=""\nLINT_CMD=""\n'
+    const v = setupFs({ projectFiles: { 'ralph.config.sh': cfgBody } })
+    const expectedHash = createHash('sha256').update(cfgBody).digest('hex')
+
+    const out = buildValidatePrompt({
+      projectRoot: PROJECT,
+      ralphVersion: '0.1.0-alpha.0',
+      fs: v,
+    })
+
+    expect(out).toContain('rooted at `/project`')
+    expect(out).toContain(`Pre-validation \`ralph.config.sh\` sha256: \`${expectedHash}\``)
+    expect(out).toContain('Ralph package version: `0.1.0-alpha.0`')
+    expect(out).not.toContain('{{CURRENT_CONFIG_HASH}}')
+    expect(out).not.toContain('{{RALPH_VERSION}}')
+    expect(out).not.toContain('{{PROJECT_ROOT}}')
+  })
+
+  it('falls back to RALPH_VERSION env when ralphVersion option is omitted', () => {
+    const v = setupFs({ projectFiles: { 'ralph.config.sh': 'X=1\n' } })
+    const stderr = makeStderr()
+    const out = buildValidatePrompt({
+      projectRoot: PROJECT,
+      ralphVersion: process.env.RALPH_VERSION ?? '9.9.9-test',
+      fs: v,
+      stderr,
+    })
+    expect(out).toMatch(/Ralph package version: `[^`]+`/)
+    expect(stderr.calls).toHaveLength(0)
+  })
+
+  it('throws when ralph.config.sh is missing (no config to validate)', () => {
+    const v = setupFs()
+    expect(() => buildValidatePrompt({ projectRoot: PROJECT, fs: v })).toThrow()
+  })
+})

--- a/packages/ralph/lib/finalize-state.js
+++ b/packages/ralph/lib/finalize-state.js
@@ -1,0 +1,60 @@
+import { pathToFileURL } from 'node:url'
+import { join, resolve } from 'node:path'
+import { hashConfig, readState, writeState } from './state.js'
+
+export class FinalizeStateError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'FinalizeStateError'
+  }
+}
+
+export function finalizeState({
+  projectRoot = process.cwd(),
+  ralphVersion = process.env.RALPH_VERSION,
+  fs: fsImpl,
+} = {}) {
+  const state = readState(projectRoot, fsImpl)
+  if (!state) {
+    throw new FinalizeStateError(
+      'finalizeState: .ralph/state.json missing after validation',
+    )
+  }
+  const required = [
+    'validated_at',
+    'detected_stack',
+    'notes',
+    'last_seen_release',
+  ]
+  for (const k of required) {
+    if (!(k in state)) {
+      throw new FinalizeStateError(
+        `finalizeState: .ralph/state.json missing required field "${k}"`,
+      )
+    }
+  }
+  const configPath = join(projectRoot, 'ralph.config.sh')
+  const configHash = hashConfig(configPath, fsImpl)
+  const next = {
+    ...state,
+    config_hash: configHash,
+    ralph_version: ralphVersion ?? state.ralph_version ?? 'unknown',
+  }
+  writeState(projectRoot, next, fsImpl)
+  return next
+}
+
+const invokedAsScript =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+if (invokedAsScript) {
+  try {
+    const result = finalizeState()
+    process.stdout.write(
+      `==> state.json finalized (config_hash=${result.config_hash.slice(0, 12)}…)\n`,
+    )
+  } catch (e) {
+    process.stderr.write(`${e.message}\n`)
+    process.exit(1)
+  }
+}

--- a/packages/ralph/lib/finalize-state.test.js
+++ b/packages/ralph/lib/finalize-state.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { createHash } from 'node:crypto'
+import { finalizeState, FinalizeStateError } from './finalize-state.js'
+
+const PROJECT = '/project'
+
+function vol(initial = {}) {
+  return Volume.fromJSON(initial, '/')
+}
+
+function partialState(overrides = {}) {
+  return {
+    config_hash: 'STALE_PLACEHOLDER',
+    validated_at: '2026-04-27T12:00:00Z',
+    ralph_version: '0.1.0-alpha.0',
+    detected_stack: 'npm',
+    notes: 'no changes needed',
+    last_seen_release: '',
+    ...overrides,
+  }
+}
+
+describe('finalizeState', () => {
+  it('recomputes config_hash from the current ralph.config.sh', () => {
+    const cfg = 'INSTALL_CMD="npm ci"\nTEST_CMD="npm test"\n'
+    const v = vol({
+      [`${PROJECT}/ralph.config.sh`]: cfg,
+      [`${PROJECT}/.ralph/state.json`]: JSON.stringify(partialState()),
+    })
+    const result = finalizeState({ projectRoot: PROJECT, fs: v })
+    const expected = createHash('sha256').update(cfg).digest('hex')
+    expect(result.config_hash).toBe(expected)
+    const onDisk = JSON.parse(
+      v.readFileSync(`${PROJECT}/.ralph/state.json`, 'utf8').toString(),
+    )
+    expect(onDisk.config_hash).toBe(expected)
+  })
+
+  it('preserves validated_at, detected_stack, notes, last_seen_release', () => {
+    const v = vol({
+      [`${PROJECT}/ralph.config.sh`]: 'X=1\n',
+      [`${PROJECT}/.ralph/state.json`]: JSON.stringify(
+        partialState({
+          validated_at: '2026-04-27T12:34:56Z',
+          detected_stack: 'pnpm',
+          notes: 'fixed empty INSTALL_CMD',
+          last_seen_release: 'v0.1.0',
+        }),
+      ),
+    })
+    const result = finalizeState({ projectRoot: PROJECT, fs: v })
+    expect(result.validated_at).toBe('2026-04-27T12:34:56Z')
+    expect(result.detected_stack).toBe('pnpm')
+    expect(result.notes).toBe('fixed empty INSTALL_CMD')
+    expect(result.last_seen_release).toBe('v0.1.0')
+  })
+
+  it('overrides ralph_version when provided', () => {
+    const v = vol({
+      [`${PROJECT}/ralph.config.sh`]: 'X=1\n',
+      [`${PROJECT}/.ralph/state.json`]: JSON.stringify(
+        partialState({ ralph_version: '0.0.0' }),
+      ),
+    })
+    const result = finalizeState({
+      projectRoot: PROJECT,
+      ralphVersion: '0.2.0',
+      fs: v,
+    })
+    expect(result.ralph_version).toBe('0.2.0')
+  })
+
+  it('throws when state.json is missing', () => {
+    const v = vol({ [`${PROJECT}/ralph.config.sh`]: 'X=1\n' })
+    expect(() => finalizeState({ projectRoot: PROJECT, fs: v })).toThrow(
+      FinalizeStateError,
+    )
+  })
+
+  it('throws when state.json is missing required fields', () => {
+    const v = vol({
+      [`${PROJECT}/ralph.config.sh`]: 'X=1\n',
+      [`${PROJECT}/.ralph/state.json`]: JSON.stringify({ config_hash: 'x' }),
+    })
+    expect(() => finalizeState({ projectRoot: PROJECT, fs: v })).toThrow(
+      /missing required field/,
+    )
+  })
+})

--- a/packages/ralph/lib/state.js
+++ b/packages/ralph/lib/state.js
@@ -1,0 +1,62 @@
+import { createHash } from 'node:crypto'
+import {
+  existsSync as realExistsSync,
+  mkdirSync as realMkdirSync,
+  readFileSync as realReadFileSync,
+  writeFileSync as realWriteFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+
+export function statePath(projectRoot) {
+  return join(projectRoot, '.ralph', 'state.json')
+}
+
+export function readState(projectRoot, fsImpl) {
+  const fs = wrapRead(fsImpl)
+  const path = statePath(projectRoot)
+  if (!fs.existsSync(path)) return null
+  let raw
+  try {
+    raw = fs.readFileSync(path, 'utf8').toString()
+  } catch {
+    return null
+  }
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+export function writeState(projectRoot, obj, fsImpl) {
+  const fs = wrapWrite(fsImpl)
+  const path = statePath(projectRoot)
+  fs.mkdirSync(dirname(path), { recursive: true })
+  fs.writeFileSync(path, JSON.stringify(obj, null, 2) + '\n')
+}
+
+export function hashConfig(configPath, fsImpl) {
+  const fs = wrapRead(fsImpl)
+  const content = fs.readFileSync(configPath)
+  return createHash('sha256').update(content).digest('hex')
+}
+
+function wrapRead(fsImpl) {
+  if (!fsImpl) {
+    return { existsSync: realExistsSync, readFileSync: realReadFileSync }
+  }
+  return {
+    existsSync: fsImpl.existsSync.bind(fsImpl),
+    readFileSync: fsImpl.readFileSync.bind(fsImpl),
+  }
+}
+
+function wrapWrite(fsImpl) {
+  if (!fsImpl) {
+    return { mkdirSync: realMkdirSync, writeFileSync: realWriteFileSync }
+  }
+  return {
+    mkdirSync: fsImpl.mkdirSync.bind(fsImpl),
+    writeFileSync: fsImpl.writeFileSync.bind(fsImpl),
+  }
+}

--- a/packages/ralph/lib/state.test.js
+++ b/packages/ralph/lib/state.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { createHash } from 'node:crypto'
+import { hashConfig, readState, statePath, writeState } from './state.js'
+
+const PROJECT = '/project'
+
+function vol(initial = {}) {
+  return Volume.fromJSON(initial, '/')
+}
+
+describe('statePath', () => {
+  it('joins .ralph/state.json under the project root', () => {
+    expect(statePath('/foo/bar')).toBe('/foo/bar/.ralph/state.json')
+  })
+})
+
+describe('readState', () => {
+  it('returns null when .ralph/state.json is absent', () => {
+    expect(readState(PROJECT, vol())).toBeNull()
+  })
+
+  it('returns the parsed object when state file exists', () => {
+    const v = vol({
+      [`${PROJECT}/.ralph/state.json`]: JSON.stringify({
+        config_hash: 'abc',
+        ralph_version: '0.1.0',
+      }),
+    })
+    expect(readState(PROJECT, v)).toEqual({
+      config_hash: 'abc',
+      ralph_version: '0.1.0',
+    })
+  })
+
+  it('returns null when state file contains invalid JSON', () => {
+    const v = vol({ [`${PROJECT}/.ralph/state.json`]: 'not json' })
+    expect(readState(PROJECT, v)).toBeNull()
+  })
+})
+
+describe('writeState', () => {
+  it('creates .ralph/ and writes pretty JSON when missing', () => {
+    const v = vol()
+    writeState(PROJECT, { config_hash: 'abc' }, v)
+    const written = v.readFileSync(`${PROJECT}/.ralph/state.json`, 'utf8').toString()
+    expect(JSON.parse(written)).toEqual({ config_hash: 'abc' })
+    expect(written.endsWith('\n')).toBe(true)
+    expect(written).toContain('\n  "config_hash"')
+  })
+
+  it('overwrites the previous state on rewrite', () => {
+    const v = vol({
+      [`${PROJECT}/.ralph/state.json`]: JSON.stringify({ old: true }),
+    })
+    writeState(PROJECT, { fresh: true }, v)
+    const written = v.readFileSync(`${PROJECT}/.ralph/state.json`, 'utf8').toString()
+    expect(JSON.parse(written)).toEqual({ fresh: true })
+  })
+})
+
+describe('hashConfig', () => {
+  it('returns the sha256 hex digest of the file contents', () => {
+    const body = 'INSTALL_CMD="npm ci"\nTEST_CMD="npm test"\n'
+    const v = vol({ [`${PROJECT}/ralph.config.sh`]: body })
+    const expected = createHash('sha256').update(body).digest('hex')
+    expect(hashConfig(`${PROJECT}/ralph.config.sh`, v)).toBe(expected)
+  })
+
+  it('produces different hashes for different content', () => {
+    const v = vol({
+      [`${PROJECT}/a.sh`]: 'foo',
+      [`${PROJECT}/b.sh`]: 'bar',
+    })
+    expect(hashConfig(`${PROJECT}/a.sh`, v)).not.toBe(
+      hashConfig(`${PROJECT}/b.sh`, v),
+    )
+  })
+
+  it('is stable across calls for unchanged content', () => {
+    const v = vol({ [`${PROJECT}/x.sh`]: 'stable' })
+    expect(hashConfig(`${PROJECT}/x.sh`, v)).toBe(
+      hashConfig(`${PROJECT}/x.sh`, v),
+    )
+  })
+})

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -40,6 +40,69 @@ fi
 
 mkdir -p logs
 
+# --- Lazy config validation -------------------------------------------------
+# Run a one-shot Claude validation before the main loop when:
+#   • .ralph/state.json is absent, OR
+#   • the sha256 of ralph.config.sh changed since last validation, OR
+#   • the installed @lucasfe/ralph version changed since last validation.
+# This lets users edit ralph.config.sh and have Ralph self-correct it.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+if [ -f ralph.config.sh ]; then
+  RALPH_VERSION=$(node -p "require('$RALPH_PKG_DIR/package.json').version" 2>/dev/null || echo "unknown")
+  export RALPH_VERSION
+
+  current_hash=$(sha256_of ralph.config.sh)
+  needs_validate="no"
+  if [ ! -f .ralph/state.json ]; then
+    needs_validate="yes"
+  else
+    stored_hash=$(jq -r '.config_hash // ""' .ralph/state.json 2>/dev/null || echo "")
+    stored_version=$(jq -r '.ralph_version // ""' .ralph/state.json 2>/dev/null || echo "")
+    if [ "$current_hash" != "$stored_hash" ] || [ "$RALPH_VERSION" != "$stored_version" ]; then
+      needs_validate="yes"
+    fi
+  fi
+
+  if [ "$needs_validate" = "yes" ]; then
+    echo "==> Validando ralph.config.sh contra os manifestos do projeto..."
+    node "$RALPH_PKG_DIR/lib/build-validate-prompt.js" | claude -p --dangerously-skip-permissions \
+      --output-format stream-json --verbose --include-partial-messages 2>&1 \
+      | jq -r --unbuffered '
+          if .type == "assistant" then
+            (.message.content[]? | select(.type=="text").text // empty)
+          elif .type == "user" then
+            (.message.content[]? | select(.type=="tool_result") | "  ↳ tool_result")
+          elif .type == "result" then
+            "==> result: " + (.subtype // "ok")
+          else empty end' \
+      | tee "logs/ralph-validate.log"
+
+    if [ ! -f .ralph/state.json ]; then
+      echo "❌ Validação não produziu .ralph/state.json. Abortando." >&2
+      exit 1
+    fi
+
+    if ! node "$RALPH_PKG_DIR/lib/finalize-state.js"; then
+      echo "❌ Falha ao finalizar .ralph/state.json. Abortando." >&2
+      exit 1
+    fi
+
+    # Re-source the config in case Claude edited it during validation.
+    set -a
+    . ./ralph.config.sh
+    set +a
+    echo "==> Validação concluída."
+  fi
+fi
+# ---------------------------------------------------------------------------
+
 START=$(date +%s)
 successes=()
 failures=()

--- a/packages/ralph/templates/validate-config.md
+++ b/packages/ralph/templates/validate-config.md
@@ -1,0 +1,84 @@
+# Ralph Config Validation (one-shot)
+
+You are running a one-shot validation pass for the Ralph configuration of
+the project rooted at `{{PROJECT_ROOT}}`. This is NOT an issue-resolution
+run — do not pick issues, do not open PRs, do not commit, do not push.
+
+Ralph package version: `{{RALPH_VERSION}}`
+Pre-validation `ralph.config.sh` sha256: `{{CURRENT_CONFIG_HASH}}`
+
+## What to do
+
+1. **Inspect manifests** at the project root to detect the actual stack.
+   Read whichever of these are present:
+   - `package.json` + `pnpm-lock.yaml` / `yarn.lock` / `package-lock.json`
+     → `pnpm` / `yarn` / `npm`
+   - `pyproject.toml` or `requirements.txt` → `python` / `pip`
+   - `go.mod` → `go`
+   - `Cargo.toml` → `rust`
+   - `Gemfile` → `ruby`
+   - `composer.json` → `php`
+   - Multiple of the above → `mixed`
+   - None → `unknown`
+
+   For npm-style projects, also peek at the `scripts` section of
+   `package.json` to confirm a `test` and a `lint` script exist before
+   you trust `npm test` / `npm run lint`.
+
+2. **Read `ralph.config.sh`**. Compare its `INSTALL_CMD`, `TEST_CMD`, and
+   `LINT_CMD` against what the manifests imply. If a value is empty,
+   missing, or wrong, edit `ralph.config.sh` in place to use the correct
+   command. Preserve every other variable (branches, merge config) as-is.
+
+   Examples of correct values:
+   - `npm` → `INSTALL_CMD="npm ci"`, `TEST_CMD="npm test"`, `LINT_CMD="npm run lint"` (only if a `lint` script is defined; otherwise leave empty)
+   - `pnpm` → `INSTALL_CMD="pnpm install --frozen-lockfile"`, `TEST_CMD="pnpm test"`, `LINT_CMD="pnpm lint"`
+   - `python` → `INSTALL_CMD="pip install -e ."`, `TEST_CMD="pytest"`, `LINT_CMD="ruff check ."`
+   - `go` → `INSTALL_CMD="go mod download"`, `TEST_CMD="go test ./..."`, `LINT_CMD="go vet ./..."`
+   - `rust` → `INSTALL_CMD="cargo fetch"`, `TEST_CMD="cargo test"`, `LINT_CMD="cargo clippy"`
+
+   If the existing values already match the manifests, do not touch the
+   file.
+
+3. **Write `.ralph/state.json`**. Create the `.ralph/` directory if it is
+   missing. The file must be valid JSON with exactly these keys:
+
+   ```json
+   {
+     "config_hash": "{{CURRENT_CONFIG_HASH}}",
+     "validated_at": "<ISO 8601 UTC timestamp>",
+     "ralph_version": "{{RALPH_VERSION}}",
+     "detected_stack": "<short label>",
+     "notes": "<one short line>",
+     "last_seen_release": ""
+   }
+   ```
+
+   Field rules:
+   - `config_hash`: write `{{CURRENT_CONFIG_HASH}}` verbatim. Ralph will
+     recompute the hash after you exit and patch this field if you
+     edited the config — do NOT compute a hash yourself.
+   - `validated_at`: current UTC time in ISO 8601 (e.g.
+     `2026-04-27T12:00:00Z`).
+   - `ralph_version`: write `{{RALPH_VERSION}}` verbatim.
+   - `detected_stack`: short label like `npm`, `pnpm`, `yarn`, `python`,
+     `pip`, `go`, `rust`, `ruby`, `php`, `mixed`, or `unknown`.
+   - `notes`: one short string. Examples: `"no changes needed"`,
+     `"set INSTALL_CMD to npm ci"`, `"removed LINT_CMD because no lint
+     script defined"`.
+   - `last_seen_release`: leave as the empty string `""`.
+
+4. **Exit.** Do not respond with extra commentary after writing the
+   file.
+
+## Absolute restrictions
+
+- Touch ONLY `ralph.config.sh` and `.ralph/state.json`. Nothing else.
+- Do NOT modify code, tests, READMEs, package manifests, or any other
+  file.
+- Do NOT run `npm install`, `pytest`, `cargo build`, etc. Inspect
+  manifests by reading them; do not execute them.
+- Do NOT touch GitHub: no `gh issue ...`, no `gh pr ...`, no
+  `claude-working` label changes.
+- Do NOT push branches or create PRs.
+- Stay inside `{{PROJECT_ROOT}}`.

--- a/ralph.sh
+++ b/ralph.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Ralph loop — resolve open GitHub issues one at a time, fully autonomously.
+# Invoked by start-ralph.sh inside a tmux session. Don't run directly.
+
+set -u
+
+cd "$(dirname "$0")"
+
+if [ -f .env.local ]; then
+  set -a
+  . ./.env.local
+  set +a
+fi
+
+mkdir -p logs
+
+START=$(date +%s)
+successes=()
+failures=()
+
+SEARCH_QUERY='state:open -label:claude-working -label:claude-failed -label:do-not-ralph'
+
+while :; do
+  count=$(gh issue list --search "$SEARCH_QUERY" --limit 100 --json number -q '. | length')
+  if [ "$count" = "0" ]; then
+    echo "Fila vazia, encerrando."
+    break
+  fi
+
+  num=$(gh issue list --search "$SEARCH_QUERY sort:created-asc" --limit 1 --json number -q '.[0].number')
+  echo "==> Iteração para issue #$num ($count restantes)"
+
+  cat PROMPT.md | claude -p --dangerously-skip-permissions \
+    --output-format stream-json --verbose --include-partial-messages 2>&1 \
+    | jq -r --unbuffered '
+        if .type == "assistant" then
+          (.message.content[]? | select(.type=="text").text // empty)
+        elif .type == "user" then
+          (.message.content[]? | select(.type=="tool_result") | "  ↳ tool_result")
+        elif .type == "result" then
+          "==> result: " + (.subtype // "ok")
+        else empty end' \
+    | tee "logs/ralph-issue-$num.log"
+
+  labels=$(gh issue view "$num" --json labels -q '[.labels[].name] | join(",")')
+  state=$(gh issue view "$num" --json state -q '.state')
+  if echo ",$labels," | grep -q ",claude-failed,"; then
+    failures+=("$num")
+  elif [ "$state" = "CLOSED" ]; then
+    successes+=("$num")
+  else
+    failures+=("$num")
+  fi
+done
+
+echo "==> Cleanup"
+git checkout dev 2>/dev/null || true
+git pull --ff-only 2>/dev/null || true
+git branch --merged dev 2>/dev/null | grep -E '^\s+issue-' | xargs -r git branch -d 2>/dev/null || true
+
+ELAPSED=$(( $(date +%s) - START ))
+mins=$(( ELAPSED / 60 ))
+ok_list=$( [ ${#successes[@]} -gt 0 ] && printf '#%s ' "${successes[@]}" || echo "-" )
+fail_list=$( [ ${#failures[@]} -gt 0 ] && printf '#%s ' "${failures[@]}" || echo "-" )
+msg="Ralph finalizado: ${#successes[@]} ok, ${#failures[@]} falharam, ${mins}min. OK: ${ok_list}| FAIL: ${fail_list}"
+echo "$msg"
+
+if [ -n "${CALLMEBOT_KEY:-}" ] && [ -n "${WHATSAPP_PHONE:-}" ]; then
+  encoded=$(jq -sRr @uri <<< "$msg")
+  curl -s "https://api.callmebot.com/whatsapp.php?phone=${WHATSAPP_PHONE}&text=${encoded}&apikey=${CALLMEBOT_KEY}" > /dev/null || true
+  echo "==> Notificação WhatsApp enviada."
+else
+  echo "==> CALLMEBOT_KEY/WHATSAPP_PHONE ausentes; pulando notificação."
+fi
+
+tmux kill-session -t ralph 2>/dev/null || exit 0

--- a/start-ralph.sh
+++ b/start-ralph.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Wrapper para disparar o Ralph loop em uma sessão tmux detached.
+# Faz sanity checks, cria labels, oferece cleanup de issues órfãs e dispara ralph.sh.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+PROJECT_DIR="$(pwd)"
+
+# 1. Sessão tmux única
+if tmux has-session -t ralph 2>/dev/null; then
+  echo "❌ Sessão tmux 'ralph' já existe."
+  echo "   Ver:    tmux attach -t ralph"
+  echo "   Matar:  tmux kill-session -t ralph"
+  exit 1
+fi
+
+# 2. CLIs obrigatórios
+for cmd in tmux jq gh claude curl npm git; do
+  command -v "$cmd" >/dev/null || { echo "❌ '$cmd' não encontrado no PATH"; exit 1; }
+done
+
+# 3. .env.local com credenciais do WhatsApp (opcional)
+if [ -f .env.local ]; then
+  set -a
+  . ./.env.local
+  set +a
+fi
+if [ -z "${CALLMEBOT_KEY:-}" ] || [ -z "${WHATSAPP_PHONE:-}" ]; then
+  echo "ℹ️  CALLMEBOT_KEY/WHATSAPP_PHONE ausentes; notificação WhatsApp será pulada."
+fi
+
+# 4. gh autenticado
+gh auth status >/dev/null 2>&1 || { echo "❌ gh não autenticado. Rode 'gh auth login'."; exit 1; }
+
+# 5. .mcp.json válido
+if [ -f .mcp.json ]; then
+  jq -e . .mcp.json >/dev/null 2>&1 || { echo "❌ .mcp.json com JSON inválido"; exit 1; }
+  servers=$(jq -r '.mcpServers | keys | join(", ")' .mcp.json)
+  echo "ℹ️  MCP servers configurados: $servers"
+  echo "   Se a auth de algum MCP expirou, rode 'claude' interativamente uma vez antes pra re-autenticar."
+fi
+
+# 6. Cria labels (idempotente)
+gh label create claude-working --color FFA500 --description "Ralph loop em andamento" 2>/dev/null || true
+gh label create claude-failed  --color B60205 --description "Ralph loop tentou e desistiu" 2>/dev/null || true
+
+# 7. Cleanup de issues órfãs com 'claude-working' (de runs interrompidas)
+orphaned=$(gh issue list --state open --label claude-working --json number,title -q '.[] | "  #\(.number) \(.title)"' || true)
+if [ -n "$orphaned" ]; then
+  echo "⚠️  Issues com label 'claude-working' (provavelmente de run anterior interrompida):"
+  echo "$orphaned"
+  read -r -p "Remover label e reprocessar? [y/N] " confirm
+  if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+    gh issue list --state open --label claude-working --json number -q '.[].number' | \
+      xargs -I{} gh issue edit {} --remove-label claude-working
+    echo "✅ Labels removidas."
+  else
+    echo "ℹ️  Mantendo labels. Essas issues serão puladas no próximo run."
+  fi
+fi
+
+# 8. Verifica se há issue para processar
+count=$(gh issue list --search 'state:open -label:claude-working -label:claude-failed -label:do-not-ralph' --limit 100 --json number -q '. | length')
+if [ "$count" = "0" ]; then
+  echo "ℹ️  Nenhuma issue na fila. Nada a fazer."
+  exit 0
+fi
+
+# 9. Dispara em tmux detached
+tmux new -d -s ralph "cd '$PROJECT_DIR' && ./ralph.sh"
+echo "✅ Ralph iniciado em background. $count issues na fila."
+echo "   Ver ao vivo:    tmux attach -t ralph"
+echo "   Detach:         dentro da sessão, Ctrl+B depois D"
+echo "   Listar:         tmux ls"
+echo "   Matar:          tmux kill-session -t ralph"
+echo "   Logs:           logs/ralph-issue-*.log"


### PR DESCRIPTION
Closes #21

## Summary

Adds lazy config validation to Ralph so users can edit `ralph.config.sh`
and have Ralph self-correct it via a one-shot Claude call before the
main issue-resolution loop.

## What changed

- `packages/ralph/lib/state.js` — `readState`, `writeState`, `hashConfig`
  (sha256 of `ralph.config.sh`).
- `packages/ralph/lib/build-validate-prompt.js` — interpolates the
  current config hash, project root, and Ralph version into the
  validation template (mirrors `build-prompt.js`).
- `packages/ralph/lib/finalize-state.js` — recomputes the config hash
  after Claude finishes, then patches `.ralph/state.json` so the stored
  hash reflects any in-place edits Claude made to the config.
- `packages/ralph/templates/validate-config.md` — one-shot validation
  prompt: inspect manifests, fix `ralph.config.sh`, write
  `.ralph/state.json`, exit. Hard-restricted to those two files.
- `packages/ralph/templates/ralph.sh` — runs validation before the loop
  whenever the state file is absent, the config hash drifts, or the
  Ralph version changes. Cross-platform sha256 via inline
  `command -v sha256sum >/dev/null && sha256sum || shasum -a 256`. Re-
  sources `ralph.config.sh` after validation in case Claude edited it.
- `.gitignore` — adds `.ralph/` so the state file does not get
  committed in agenthub itself (slice #5 already adds it for new
  projects via `ralph init`).

## Tests

- `lib/state.test.js` (9) — read/write/hash, including null on missing
  or invalid JSON, and pretty-printed output.
- `lib/build-validate-prompt.test.js` (3) — placeholder substitution
  and missing-config error.
- `lib/finalize-state.test.js` (5) — hash recompute, field
  preservation, missing-state and missing-field guards.
- All 105 ralph-package tests pass; agenthub's 108 tests still pass;
  lint clean (0 errors).

## Notes

- `rm -rf .ralph` triggers full revalidation because the state file is
  absent.
- Editing `ralph.config.sh` between runs forces revalidation because
  the hash drifts.
- A second `ralph start` with no config changes skips validation
  entirely.