### PR TITLE
Ralph pkg #9: Notifications (WhatsApp built-in + ralph-notify.sh hook)

### DIFF
--- a/packages/ralph/templates/ralph-notify.sh.example
+++ b/packages/ralph/templates/ralph-notify.sh.example
@@ -4,7 +4,7 @@
 #
 # Args:
 #   $1 — message string (already includes ok/fail summary)
-#   $2 — status ("ok" or "fail")
+#   $2 — status ("success" | "partial" | "failed")
 #   $3 — successes count
 #   $4 — failures count
 #   $5 — duration in minutes
@@ -17,15 +17,23 @@ mins="$5"
 
 # Slack example:
 # curl -s -X POST -H 'Content-type: application/json' \
-#   --data "{\"text\":\"$msg\"}" \
+#   --data "{\"text\":\"[$status] $msg\"}" \
 #   "$SLACK_WEBHOOK_URL"
-
-# macOS native notification:
-# osascript -e "display notification \"$msg\" with title \"Ralph\""
 
 # Discord example:
 # curl -s -H 'Content-Type: application/json' \
-#   -d "{\"content\":\"$msg\"}" \
+#   -d "{\"content\":\"[$status] $msg\"}" \
 #   "$DISCORD_WEBHOOK_URL"
 
-echo "ralph-notify: $msg"
+# macOS native notification:
+# osascript -e "display notification \"$msg\" with title \"Ralph [$status]\""
+
+# sendmail example:
+# {
+#   echo "Subject: Ralph run [$status] — $ok ok / $fail fail / ${mins}min"
+#   echo "To: you@example.com"
+#   echo
+#   echo "$msg"
+# } | sendmail -t
+
+echo "ralph-notify: [$status] $msg"

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -147,19 +147,48 @@ git checkout dev 2>/dev/null || true
 git pull --ff-only 2>/dev/null || true
 git branch --merged dev 2>/dev/null | grep -E '^\s+issue-' | xargs -r git branch -d 2>/dev/null || true
 
+# --- End-of-run notifications ---------------------------------------------
 ELAPSED=$(( $(date +%s) - START ))
-mins=$(( ELAPSED / 60 ))
-ok_list=$( [ ${#successes[@]} -gt 0 ] && printf '#%s ' "${successes[@]}" || echo "-" )
-fail_list=$( [ ${#failures[@]} -gt 0 ] && printf '#%s ' "${failures[@]}" || echo "-" )
-msg="Ralph finalizado: ${#successes[@]} ok, ${#failures[@]} falharam, ${mins}min. OK: ${ok_list}| FAIL: ${fail_list}"
+duration_min=$(( ELAPSED / 60 ))
+ok_count=${#successes[@]}
+fail_count=${#failures[@]}
+ok_list=$( [ "$ok_count" -gt 0 ] && printf '#%s ' "${successes[@]}" || echo "-" )
+fail_list=$( [ "$fail_count" -gt 0 ] && printf '#%s ' "${failures[@]}" || echo "-" )
+msg="Ralph finalizado: ${ok_count} ok, ${fail_count} falharam, ${duration_min}min. OK: ${ok_list}| FAIL: ${fail_list}"
+
+if [ "$fail_count" -eq 0 ]; then
+  status="success"
+elif [ "$ok_count" -gt 0 ]; then
+  status="partial"
+else
+  status="failed"
+fi
+
+# Stdout always — visible to anyone running `tmux attach`.
 echo "$msg"
 
-if [ -n "${CALLMEBOT_KEY:-}" ] && [ -n "${WHATSAPP_PHONE:-}" ]; then
-  encoded=$(jq -sRr @uri <<< "$msg")
-  curl -s "https://api.callmebot.com/whatsapp.php?phone=${WHATSAPP_PHONE}&text=${encoded}&apikey=${CALLMEBOT_KEY}" > /dev/null || true
-  echo "==> Notificação WhatsApp enviada."
-else
-  echo "==> CALLMEBOT_KEY/WHATSAPP_PHONE ausentes; pulando notificação."
+# Re-source .env.local so credentials added mid-run are picked up.
+if [ -f ./.env.local ]; then
+  set -a
+  . ./.env.local
+  set +a
 fi
+
+# Built-in WhatsApp via CallMeBot. Failures must not crash the loop.
+if [ -n "${CALLMEBOT_KEY:-}" ] && [ -n "${WHATSAPP_PHONE:-}" ]; then
+  encoded=$(jq -sRr @uri <<< "$msg") || encoded=""
+  if [ -n "$encoded" ]; then
+    curl -s --connect-timeout 5 \
+      "https://api.callmebot.com/whatsapp.php?phone=${WHATSAPP_PHONE}&text=${encoded}&apikey=${CALLMEBOT_KEY}" \
+      > /dev/null || true
+    echo "==> Notificação WhatsApp enviada."
+  fi
+fi
+
+# Custom hook. Project-supplied script with full freedom over channels.
+if [ -x ./ralph-notify.sh ]; then
+  ./ralph-notify.sh "$msg" "$status" "$ok_count" "$fail_count" "$duration_min" || true
+fi
+# ---------------------------------------------------------------------------
 
 tmux kill-session -t ralph 2>/dev/null || exit 0


### PR DESCRIPTION
Closes #22

## Summary

End-of-run notification block in `templates/ralph.sh`:

- **Stdout always**: prints the run summary, visible via `tmux attach`.
- **Built-in WhatsApp** via CallMeBot when `CALLMEBOT_KEY` and `WHATSAPP_PHONE` are both set in `.env.local`. Uses `curl --connect-timeout 5` and `|| true` so a network blip can't crash the loop.
- **Custom hook**: invokes `./ralph-notify.sh` if executable, with positional args `(msg, status, ok_count, fail_count, duration_min)`. Errors ignored.
- **Status enum**: `success` (no failures) | `partial` (some succeeded, some failed) | `failed` (zero successes with failures present).

`templates/ralph-notify.sh.example` now ships Slack, Discord, macOS, and sendmail templates and reflects the new status enum.

## Test plan

- [x] `npm test` — 108/108 pass
- [x] `npm run lint` — no errors
- [x] `bash -n` syntax-check on both scripts
- [x] Simulated status logic for all four cases (ok-only, mixed, fail-only, empty queue)
- [x] Verified hook receives all 5 positional args correctly