### PR TITLE
Ralph pkg #10: Update check (npm view + dedup via state.json)

### DIFF
--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -37,7 +37,7 @@ program
   .description('Run sanity checks and launch the Ralph loop in a detached tmux session')
   .action(async () => {
     try {
-      await startCommand()
+      await startCommand({ currentVersion: pkg.version })
     } catch (e) {
       if (e instanceof StartAbort) {
         process.exit(e.exitCode ?? 1)

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -33,6 +33,10 @@ export async function startCommand({
   loadEnv = loadEnvFile,
   hasCommand = commandExists,
   ask = confirm,
+  currentVersion = 'unknown',
+  update = checkForUpdate,
+  readSt = readState,
+  writeSt = writeState,
 } = {}) {
   const out = (msg) => stdout.write(msg + '\n')
   const err = (msg) => stderr.write(msg + '\n')

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { execa } from 'execa'
+import pc from 'picocolors'
 import { loadEnvFile } from '../utils/env.js'
 import { commandExists } from '../utils/which.js'
 import { confirm } from '../utils/prompt.js'
@@ -8,6 +9,8 @@ import { templatePath } from '../paths.js'
 import { assertCriticalDeps } from './doctor.js'
 import { checkDeps } from '../deps.js'
 import { detectPlatform } from '../platform.js'
+import { readState, writeState } from '../state.js'
+import { checkForUpdate } from '../update-check.js'
 
 const TMUX_SESSION = 'ralph'
 const SEARCH_QUERY =

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -211,6 +211,20 @@ export async function startCommand({
     return { exitCode: 0, started: false }
   }
 
+  // 8.5. Update check (best-effort, silent on failure)
+  const state = readSt(cwd)
+  if (state) {
+    const { newVersion, updatedState } = await update(currentVersion, state, { exec })
+    if (newVersion) {
+      out(
+        pc.yellow(
+          `New version available: ${newVersion} (run npm i -g @lucasfe/ralph to update)`,
+        ),
+      )
+      writeSt(cwd, updatedState)
+    }
+  }
+
   // 9. Launch tmux detached, running the bash loop shipped with the package
   const ralphTemplate = templatePath('ralph.sh')
   const tmuxLaunch = await exec(

--- a/packages/ralph/lib/update-check.js
+++ b/packages/ralph/lib/update-check.js
@@ -1,0 +1,64 @@
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+
+export function isValidSemver(s) {
+  return typeof s === 'string' && SEMVER_RE.test(s.trim())
+}
+
+export function compareSemver(a, b) {
+  const parse = (v) => {
+    const [main, pre = ''] = v.split('+')[0].split('-', 2).length === 2
+      ? v.split('+')[0].split(/-(.+)/)
+      : [v.split('+')[0], '']
+    const parts = main.split('.').map((n) => Number(n))
+    return { parts, pre }
+  }
+  const A = parse(a)
+  const B = parse(b)
+  for (let i = 0; i < 3; i++) {
+    const x = A.parts[i] ?? 0
+    const y = B.parts[i] ?? 0
+    if (x > y) return 1
+    if (x < y) return -1
+  }
+  if (A.pre === B.pre) return 0
+  if (A.pre === '') return 1
+  if (B.pre === '') return -1
+  return A.pre < B.pre ? -1 : A.pre > B.pre ? 1 : 0
+}
+
+export async function checkForUpdate(
+  currentVersion,
+  state,
+  { exec, timeoutMs = 5000 } = {},
+) {
+  const safeState = state ?? {}
+  if (typeof exec !== 'function') {
+    return { newVersion: null, updatedState: safeState }
+  }
+  let result
+  try {
+    result = await exec('npm', ['view', '@lucasfe/ralph', 'version'], {
+      timeout: timeoutMs,
+      reject: false,
+    })
+  } catch {
+    return { newVersion: null, updatedState: safeState }
+  }
+  if (!result || result.exitCode !== 0 || result.timedOut) {
+    return { newVersion: null, updatedState: safeState }
+  }
+  const fetched = (result.stdout || '').trim()
+  if (!isValidSemver(fetched) || !isValidSemver(currentVersion)) {
+    return { newVersion: null, updatedState: safeState }
+  }
+  if (compareSemver(fetched, currentVersion) <= 0) {
+    return { newVersion: null, updatedState: safeState }
+  }
+  if (safeState.last_seen_release === fetched) {
+    return { newVersion: null, updatedState: safeState }
+  }
+  return {
+    newVersion: fetched,
+    updatedState: { ...safeState, last_seen_release: fetched },
+  }
+}

--- a/packages/ralph/lib/update-check.js
+++ b/packages/ralph/lib/update-check.js
@@ -6,11 +6,11 @@ export function isValidSemver(s) {
 
 export function compareSemver(a, b) {
   const parse = (v) => {
-    const [main, pre = ''] = v.split('+')[0].split('-', 2).length === 2
-      ? v.split('+')[0].split(/-(.+)/)
-      : [v.split('+')[0], '']
-    const parts = main.split('.').map((n) => Number(n))
-    return { parts, pre }
+    const noBuild = v.split('+')[0]
+    const dashIdx = noBuild.indexOf('-')
+    const main = dashIdx === -1 ? noBuild : noBuild.slice(0, dashIdx)
+    const pre = dashIdx === -1 ? '' : noBuild.slice(dashIdx + 1)
+    return { parts: main.split('.').map((n) => Number(n)), pre }
   }
   const A = parse(a)
   const B = parse(b)

--- a/packages/ralph/lib/update-check.test.js
+++ b/packages/ralph/lib/update-check.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest'
+import {
+  checkForUpdate,
+  compareSemver,
+  isValidSemver,
+} from './update-check.js'
+
+function makeExec(handler) {
+  const calls = []
+  const exec = async (cmd, args, opts) => {
+    calls.push({ cmd, args, opts })
+    return handler({ cmd, args, opts })
+  }
+  exec.calls = calls
+  return exec
+}
+
+describe('isValidSemver', () => {
+  it('accepts standard releases', () => {
+    expect(isValidSemver('0.1.0')).toBe(true)
+    expect(isValidSemver('1.2.3')).toBe(true)
+    expect(isValidSemver('10.20.30')).toBe(true)
+  })
+
+  it('accepts pre-releases and build metadata', () => {
+    expect(isValidSemver('0.1.0-alpha.0')).toBe(true)
+    expect(isValidSemver('1.0.0-rc.1')).toBe(true)
+    expect(isValidSemver('1.0.0+build.5')).toBe(true)
+  })
+
+  it('rejects invalid input', () => {
+    expect(isValidSemver('')).toBe(false)
+    expect(isValidSemver('not-a-version')).toBe(false)
+    expect(isValidSemver('1.2')).toBe(false)
+    expect(isValidSemver(null)).toBe(false)
+    expect(isValidSemver(undefined)).toBe(false)
+  })
+})
+
+describe('compareSemver', () => {
+  it('orders by major/minor/patch', () => {
+    expect(compareSemver('1.0.0', '0.9.9')).toBe(1)
+    expect(compareSemver('0.1.0', '0.2.0')).toBe(-1)
+    expect(compareSemver('0.1.1', '0.1.0')).toBe(1)
+    expect(compareSemver('1.2.3', '1.2.3')).toBe(0)
+  })
+
+  it('treats releases as greater than pre-releases', () => {
+    expect(compareSemver('0.1.0', '0.1.0-alpha.0')).toBe(1)
+    expect(compareSemver('0.1.0-alpha.0', '0.1.0')).toBe(-1)
+  })
+
+  it('compares pre-releases lexicographically when numeric parts equal', () => {
+    expect(compareSemver('0.1.0-alpha.1', '0.1.0-alpha.0')).toBe(1)
+    expect(compareSemver('0.1.0-alpha.0', '0.1.0-beta.0')).toBe(-1)
+  })
+})
+
+describe('checkForUpdate', () => {
+  const okOut = (stdout) => async () => ({
+    exitCode: 0,
+    stdout,
+    stderr: '',
+    timedOut: false,
+  })
+
+  it('returns the new version when remote is greater than current', async () => {
+    const exec = makeExec(okOut('0.2.0\n'))
+    const result = await checkForUpdate('0.1.0', { last_seen_release: '' }, { exec })
+    expect(result.newVersion).toBe('0.2.0')
+    expect(result.updatedState.last_seen_release).toBe('0.2.0')
+    expect(exec.calls[0]).toMatchObject({
+      cmd: 'npm',
+      args: ['view', '@lucasfe/ralph', 'version'],
+    })
+    expect(exec.calls[0].opts).toMatchObject({ timeout: 5000 })
+  })
+
+  it('preserves other state fields when updating last_seen_release', async () => {
+    const exec = makeExec(okOut('0.2.0'))
+    const state = {
+      last_seen_release: '',
+      validated_at: '2026-04-27T00:00:00Z',
+      detected_stack: 'npm',
+      notes: 'hi',
+    }
+    const result = await checkForUpdate('0.1.0', state, { exec })
+    expect(result.updatedState).toEqual({
+      last_seen_release: '0.2.0',
+      validated_at: '2026-04-27T00:00:00Z',
+      detected_stack: 'npm',
+      notes: 'hi',
+    })
+  })
+
+  it('dedupes when last_seen_release already equals the latest', async () => {
+    const exec = makeExec(okOut('0.2.0'))
+    const result = await checkForUpdate(
+      '0.1.0',
+      { last_seen_release: '0.2.0' },
+      { exec },
+    )
+    expect(result.newVersion).toBeNull()
+    expect(result.updatedState).toEqual({ last_seen_release: '0.2.0' })
+  })
+
+  it('returns null when remote equals current version', async () => {
+    const exec = makeExec(okOut('0.1.0'))
+    const result = await checkForUpdate('0.1.0', { last_seen_release: '' }, { exec })
+    expect(result.newVersion).toBeNull()
+  })
+
+  it('returns null when remote is older than current (rollback case)', async () => {
+    const exec = makeExec(okOut('0.0.9'))
+    const result = await checkForUpdate('0.1.0', { last_seen_release: '' }, { exec })
+    expect(result.newVersion).toBeNull()
+  })
+
+  it('returns null on timeout (exec rejects)', async () => {
+    const exec = makeExec(async () => {
+      const e = new Error('Command timed out after 5000ms')
+      e.timedOut = true
+      throw e
+    })
+    const result = await checkForUpdate(
+      '0.1.0',
+      { last_seen_release: '' },
+      { exec },
+    )
+    expect(result.newVersion).toBeNull()
+    expect(result.updatedState).toEqual({ last_seen_release: '' })
+  })
+
+  it('returns null on timeout (exec resolves with timedOut flag)', async () => {
+    const exec = makeExec(async () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'timeout',
+      timedOut: true,
+    }))
+    const result = await checkForUpdate(
+      '0.1.0',
+      { last_seen_release: '' },
+      { exec },
+    )
+    expect(result.newVersion).toBeNull()
+  })
+
+  it('returns null when npm is missing (ENOENT)', async () => {
+    const exec = makeExec(async () => {
+      const e = new Error('spawn npm ENOENT')
+      e.code = 'ENOENT'
+      throw e
+    })
+    const result = await checkForUpdate(
+      '0.1.0',
+      { last_seen_release: '' },
+      { exec },
+    )
+    expect(result.newVersion).toBeNull()
+  })
+
+  it('returns null when npm view exits non-zero (network error)', async () => {
+    const exec = makeExec(async () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'network down',
+    }))
+    const result = await checkForUpdate(
+      '0.1.0',
+      { last_seen_release: '' },
+      { exec },
+    )
+    expect(result.newVersion).toBeNull()
+  })
+
+  it('returns null when remote output is not valid semver', async () => {
+    const exec = makeExec(okOut('garbage-output\n'))
+    const result = await checkForUpdate(
+      '0.1.0',
+      { last_seen_release: '' },
+      { exec },
+    )
+    expect(result.newVersion).toBeNull()
+  })
+
+  it('returns null when no exec is provided', async () => {
+    const result = await checkForUpdate('0.1.0', { last_seen_release: '' }, {})
+    expect(result.newVersion).toBeNull()
+  })
+
+  it('tolerates state without last_seen_release', async () => {
+    const exec = makeExec(okOut('0.2.0'))
+    const result = await checkForUpdate('0.1.0', {}, { exec })
+    expect(result.newVersion).toBe('0.2.0')
+    expect(result.updatedState.last_seen_release).toBe('0.2.0')
+  })
+})

--- a/packages/ralph/test/commands/start.test.js
+++ b/packages/ralph/test/commands/start.test.js
@@ -164,6 +164,96 @@ describe('startCommand', () => {
     expect(deps.exec.calls.some((c) => c.includes('--remove-label'))).toBe(false)
   })
 
+  it('prints update warning and persists last_seen_release when newer version is available', async () => {
+    const deps = baseDeps()
+    const cwd = '/repo'
+    const writes = []
+    deps.currentVersion = '0.1.0'
+    deps.readSt = () => ({ last_seen_release: '', detected_stack: 'npm' })
+    deps.writeSt = (root, obj) => writes.push({ root, obj })
+    deps.exec = makeExec({
+      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph --limit 100 --json number -q . | length':
+        { exitCode: 0, stdout: '1', stderr: '' },
+      'npm view @lucasfe/ralph version': { exitCode: 0, stdout: '0.2.0\n', stderr: '' },
+      [`tmux new -d -s ralph cd '${cwd}' && bash '${RALPH_TEMPLATE}'`]: {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+    })
+    await startCommand({ ...deps, cwd })
+    expect(deps.stdout.output()).toContain('New version available: 0.2.0')
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toEqual({
+      root: cwd,
+      obj: { last_seen_release: '0.2.0', detected_stack: 'npm' },
+    })
+  })
+
+  it('skips update check entirely when state.json is missing', async () => {
+    const deps = baseDeps()
+    const cwd = '/repo'
+    const writes = []
+    deps.currentVersion = '0.1.0'
+    deps.readSt = () => null
+    deps.writeSt = (root, obj) => writes.push({ root, obj })
+    deps.exec = makeExec({
+      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph --limit 100 --json number -q . | length':
+        { exitCode: 0, stdout: '1', stderr: '' },
+      [`tmux new -d -s ralph cd '${cwd}' && bash '${RALPH_TEMPLATE}'`]: {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+    })
+    await startCommand({ ...deps, cwd })
+    expect(writes).toHaveLength(0)
+    expect(deps.exec.calls.some((c) => c.startsWith('npm view'))).toBe(false)
+  })
+
+  it('does not print warning or write state when remote version is not newer', async () => {
+    const deps = baseDeps()
+    const cwd = '/repo'
+    const writes = []
+    deps.currentVersion = '0.2.0'
+    deps.readSt = () => ({ last_seen_release: '' })
+    deps.writeSt = (root, obj) => writes.push({ root, obj })
+    deps.exec = makeExec({
+      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph --limit 100 --json number -q . | length':
+        { exitCode: 0, stdout: '1', stderr: '' },
+      'npm view @lucasfe/ralph version': { exitCode: 0, stdout: '0.1.0\n', stderr: '' },
+      [`tmux new -d -s ralph cd '${cwd}' && bash '${RALPH_TEMPLATE}'`]: {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+    })
+    await startCommand({ ...deps, cwd })
+    expect(deps.stdout.output()).not.toContain('New version available')
+    expect(writes).toHaveLength(0)
+  })
+
   it('removes orphan labels when user answers yes', async () => {
     const deps = baseDeps()
     deps.ask = async () => true


### PR DESCRIPTION
Closes #23

## What

Adds `lib/update-check.js` exporting `checkForUpdate(currentVersion, state, { exec, timeoutMs })` which:
- runs `npm view @lucasfe/ralph version` via injected `exec` with a 5s timeout
- returns the new version when remote > current AND remote != `state.last_seen_release` (dedup)
- silently returns `null` on timeout, missing npm, network failure, equal/older remote, or invalid output
- never throws

## Wiring

`lib/commands/start.js` reads `.ralph/state.json`, runs the check after sanity passes and before launching tmux, prints a yellow one-liner via picocolors when a new version is found, and writes the updated state. When state.json is missing the check is skipped.

## Tests

`lib/update-check.test.js` covers the six required cases (newer, dedup, equal, older, timeout, npm-missing) plus a few extras (network error, invalid output, missing exec, state without last_seen_release). New start tests cover the warn+persist path, the no-state skip, and the no-update path.