### PR TITLE
GitHub Issue Creator: HTTP client, repo filter, Deno test infra

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,18 +279,18 @@ npm run dev          # Start dev server (localhost:5173)
 npm run build        # Production build
 npm run preview      # Preview production build
 npm run lint         # ESLint check
-npm test             # Run all tests (vitest)
-npm run test:watch   # Run tests in watch mode
-npm run test:coverage # Run tests with coverage report
+npm test             # Run frontend tests (vitest)
+npm run test:watch   # Run frontend tests in watch mode
+npm run test:coverage # Run frontend tests with coverage report
+npm run test:functions # Run Edge Function tests (deno)
 ```
 
 ## Testing
 
-- **Framework**: Vitest 2 + @testing-library/react
-- **Config**: `vitest.config.js` (jsdom environment, automatic JSX)
-- **Setup**: `src/test/setup.js` (jest-dom matchers, matchMedia mock)
-- **Utils**: `src/test/test-utils.jsx` — `renderWithProviders()` wraps components with BrowserRouter + ThemeProvider + StackProvider
-- **Convention**: Test files live next to their source: `Component.test.jsx`
+The repo has two distinct test suites:
+
+- **Frontend (`npm test`)** — Vitest 2 + @testing-library/react against React components, contexts, and pure JS modules under `src/`. Config: `vitest.config.js` (jsdom environment, automatic JSX). Setup: `src/test/setup.js` (jest-dom matchers, matchMedia mock). Utils: `src/test/test-utils.jsx` — `renderWithProviders()` wraps components with BrowserRouter + ThemeProvider + StackProvider. Convention: test files live next to their source as `Component.test.jsx`.
+- **Edge Functions (`npm run test:functions`)** — Deno's built-in test runner against TypeScript modules under `supabase/functions/`. Edge Functions run in Deno at the Supabase edge, so they need a Deno-native suite (vitest cannot import `Deno.*` APIs or `jsr:` modules). Convention: test files live next to their source as `module.test.ts`. Requires Deno installed locally (`brew install deno`). Vitest's `exclude` skips `supabase/functions/**` so the two suites do not collide.
 
 ## Branching & CI/CD
 

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,47 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.13"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    }
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@eslint/js@^9.39.4",
+        "npm:@playwright/test@^1.58.2",
+        "npm:@supabase/supabase-js@^2.100.1",
+        "npm:@tailwindcss/vite@^4.2.2",
+        "npm:@testing-library/jest-dom@^6.9.1",
+        "npm:@testing-library/react@^16.3.2",
+        "npm:@testing-library/user-event@^14.6.1",
+        "npm:@types/react-dom@^19.2.3",
+        "npm:@types/react@^19.2.14",
+        "npm:@vitejs/plugin-react@^6.0.1",
+        "npm:eslint-plugin-react-hooks@^7.0.1",
+        "npm:eslint-plugin-react-refresh@~0.5.2",
+        "npm:eslint@^9.39.4",
+        "npm:globals@^17.4.0",
+        "npm:jsdom@^25.0.1",
+        "npm:jszip@^3.10.1",
+        "npm:lucide-react@^1.7.0",
+        "npm:react-dom@^19.2.4",
+        "npm:react-router@^7.13.2",
+        "npm:react@^19.2.4",
+        "npm:tailwindcss@^4.2.2",
+        "npm:vite@^8.0.1",
+        "npm:vitest@^2.1.9"
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run --reporter=verbose",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:functions": "deno test --allow-net --allow-env supabase/functions/",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/supabase/functions/chat/github.test.ts
+++ b/supabase/functions/chat/github.test.ts
@@ -1,0 +1,287 @@
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from 'jsr:@std/assert@1'
+import { createIssue, listRepos } from './github.ts'
+
+interface MockCall {
+  url: string
+  init?: RequestInit
+}
+
+function installFetchMock(
+  responder: (call: MockCall) => Response | Promise<Response>,
+): { calls: MockCall[]; restore: () => void } {
+  const calls: MockCall[] = []
+  const original = globalThis.fetch
+  // deno-lint-ignore no-explicit-any
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url
+    const call: MockCall = { url, init }
+    calls.push(call)
+    return await responder(call)
+  }) as typeof fetch
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original
+    },
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// ─── listRepos ──────────────────────────────────────────────────────────────
+
+Deno.test('listRepos — builds correct URL with all four query params', async () => {
+  const { calls, restore } = installFetchMock(() => jsonResponse(200, []))
+  try {
+    await listRepos('tok')
+  } finally {
+    restore()
+  }
+  assertEquals(calls.length, 1)
+  const url = new URL(calls[0].url)
+  assertEquals(url.origin + url.pathname, 'https://api.github.com/user/repos')
+  assertEquals(url.searchParams.get('affiliation'), 'owner')
+  assertEquals(url.searchParams.get('type'), 'owner')
+  assertEquals(url.searchParams.get('sort'), 'pushed')
+  assertEquals(url.searchParams.get('per_page'), '50')
+})
+
+Deno.test('listRepos — sets Authorization and Accept headers', async () => {
+  const { calls, restore } = installFetchMock(() => jsonResponse(200, []))
+  try {
+    await listRepos('mytoken')
+  } finally {
+    restore()
+  }
+  const headers = new Headers(calls[0].init?.headers)
+  assertEquals(headers.get('Authorization'), 'Bearer mytoken')
+  assertEquals(headers.get('Accept'), 'application/vnd.github+json')
+})
+
+Deno.test('listRepos — returns parsed JSON array', async () => {
+  const repos = [
+    { name: 'r1', full_name: 'lucasfe/r1' },
+    { name: 'r2', full_name: 'lucasfe/r2' },
+  ]
+  const { restore } = installFetchMock(() => jsonResponse(200, repos))
+  try {
+    const out = await listRepos('tok')
+    assertEquals(out, repos)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('listRepos — surfaces 401 with GitHub error message', async () => {
+  const { restore } = installFetchMock(() =>
+    jsonResponse(401, { message: 'Bad credentials' }),
+  )
+  try {
+    const err = await assertRejects(() => listRepos('bad'), Error)
+    assertStringIncludes(err.message, '401')
+    assertStringIncludes(err.message, 'Bad credentials')
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('listRepos — surfaces 5xx with GitHub error message', async () => {
+  const { restore } = installFetchMock(() =>
+    jsonResponse(503, { message: 'Service Unavailable' }),
+  )
+  try {
+    const err = await assertRejects(() => listRepos('tok'), Error)
+    assertStringIncludes(err.message, '503')
+    assertStringIncludes(err.message, 'Service Unavailable')
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('listRepos — rejects empty token at the boundary', async () => {
+  await assertRejects(() => listRepos(''), Error, 'GitHub token is required')
+})
+
+Deno.test('listRepos — rejects whitespace-only token at the boundary', async () => {
+  await assertRejects(() => listRepos('   '), Error, 'GitHub token is required')
+})
+
+Deno.test('listRepos — rejects non-array response shape', async () => {
+  const { restore } = installFetchMock(() =>
+    jsonResponse(200, { not: 'an array' }),
+  )
+  try {
+    await assertRejects(() => listRepos('tok'), Error, 'non-array')
+  } finally {
+    restore()
+  }
+})
+
+// ─── createIssue ────────────────────────────────────────────────────────────
+
+Deno.test('createIssue — POSTs to /repos/{owner}/{repo}/issues', async () => {
+  const { calls, restore } = installFetchMock(() =>
+    jsonResponse(201, { html_url: 'https://github.com/lucasfe/r1/issues/1', number: 1 }),
+  )
+  try {
+    await createIssue('tok', 'lucasfe/r1', 'Hi', 'Body')
+  } finally {
+    restore()
+  }
+  assertEquals(calls.length, 1)
+  assertEquals(calls[0].url, 'https://api.github.com/repos/lucasfe/r1/issues')
+  assertEquals(calls[0].init?.method, 'POST')
+})
+
+Deno.test('createIssue — sends JSON body with exactly title and body', async () => {
+  const { calls, restore } = installFetchMock(() =>
+    jsonResponse(201, { html_url: 'https://github.com/lucasfe/r1/issues/2', number: 2 }),
+  )
+  try {
+    await createIssue('tok', 'lucasfe/r1', 'My Title', 'My Body')
+  } finally {
+    restore()
+  }
+  const body = JSON.parse(String(calls[0].init?.body ?? ''))
+  assertEquals(body, { title: 'My Title', body: 'My Body' })
+})
+
+Deno.test('createIssue — sets Authorization, Accept, Content-Type headers', async () => {
+  const { calls, restore } = installFetchMock(() =>
+    jsonResponse(201, { html_url: 'https://github.com/lucasfe/r1/issues/3', number: 3 }),
+  )
+  try {
+    await createIssue('tok', 'lucasfe/r1', 'T', 'B')
+  } finally {
+    restore()
+  }
+  const headers = new Headers(calls[0].init?.headers)
+  assertEquals(headers.get('Authorization'), 'Bearer tok')
+  assertEquals(headers.get('Accept'), 'application/vnd.github+json')
+  assertEquals(headers.get('Content-Type'), 'application/json')
+})
+
+Deno.test('createIssue — returns { url, number } from response', async () => {
+  const { restore } = installFetchMock(() =>
+    jsonResponse(201, {
+      html_url: 'https://github.com/lucasfe/r1/issues/42',
+      number: 42,
+    }),
+  )
+  try {
+    const out = await createIssue('tok', 'lucasfe/r1', 'T', 'B')
+    assertEquals(out, {
+      url: 'https://github.com/lucasfe/r1/issues/42',
+      number: 42,
+    })
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('createIssue — surfaces 404 with GitHub error message', async () => {
+  const { restore } = installFetchMock(() =>
+    jsonResponse(404, { message: 'Not Found' }),
+  )
+  try {
+    const err = await assertRejects(
+      () => createIssue('tok', 'lucasfe/missing', 'T', 'B'),
+      Error,
+    )
+    assertStringIncludes(err.message, '404')
+    assertStringIncludes(err.message, 'Not Found')
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('createIssue — surfaces 422 with GitHub validation message', async () => {
+  const { restore } = installFetchMock(() =>
+    jsonResponse(422, { message: 'Validation Failed' }),
+  )
+  try {
+    const err = await assertRejects(
+      () => createIssue('tok', 'lucasfe/r1', 'T', 'B'),
+      Error,
+    )
+    assertStringIncludes(err.message, '422')
+    assertStringIncludes(err.message, 'Validation Failed')
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('createIssue — rejects empty token at the boundary', async () => {
+  await assertRejects(
+    () => createIssue('', 'lucasfe/r1', 'T', 'B'),
+    Error,
+    'GitHub token is required',
+  )
+})
+
+Deno.test('createIssue — rejects empty repo at the boundary', async () => {
+  await assertRejects(
+    () => createIssue('tok', '', 'T', 'B'),
+    Error,
+    'repo is required',
+  )
+})
+
+Deno.test('createIssue — rejects empty title at the boundary', async () => {
+  await assertRejects(
+    () => createIssue('tok', 'lucasfe/r1', '', 'B'),
+    Error,
+    'title is required',
+  )
+})
+
+Deno.test('createIssue — rejects empty body at the boundary', async () => {
+  await assertRejects(
+    () => createIssue('tok', 'lucasfe/r1', 'T', ''),
+    Error,
+    'body is required',
+  )
+})
+
+Deno.test('createIssue — rejects unexpected response shape', async () => {
+  const { restore } = installFetchMock(() => jsonResponse(201, { unexpected: true }))
+  try {
+    await assertRejects(
+      () => createIssue('tok', 'lucasfe/r1', 'T', 'B'),
+      Error,
+      'unexpected response shape',
+    )
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('createIssue — falls back to text when GitHub returns no JSON message', async () => {
+  const { restore } = installFetchMock(
+    () => new Response('plain text error', { status: 500 }),
+  )
+  try {
+    const err = await assertRejects(
+      () => createIssue('tok', 'lucasfe/r1', 'T', 'B'),
+      Error,
+    )
+    assert(err.message.includes('500'))
+  } finally {
+    restore()
+  }
+})

--- a/supabase/functions/chat/github.ts
+++ b/supabase/functions/chat/github.ts
@@ -1,0 +1,111 @@
+// GitHub REST API client for the chat Edge Function.
+//
+// Deep, narrow module: knows everything about talking to GitHub (URL building,
+// auth + accept headers, JSON parsing, surfacing non-2xx as typed errors with
+// the GitHub error message intact). Does NOT read tokens or any global state —
+// the token is always passed in as the first argument so a future swap to a
+// GitHub App or OAuth flow is a one-module change.
+
+const GITHUB_API_BASE = 'https://api.github.com'
+const ACCEPT_HEADER = 'application/vnd.github+json'
+
+export interface GithubRepo {
+  // Raw upstream shape — the filter module narrows this to the slim view the
+  // LLM reasons about. Keeping the type loose here avoids drifting from
+  // GitHub's actual response surface.
+  name: string
+  full_name: string
+  description: string | null
+  pushed_at: string
+  archived: boolean
+  fork: boolean
+  size: number
+  [key: string]: unknown
+}
+
+export interface CreateIssueResult {
+  url: string
+  number: number
+}
+
+function assertToken(token: unknown): asserts token is string {
+  if (typeof token !== 'string' || token.trim().length === 0) {
+    throw new Error('GitHub token is required.')
+  }
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: ACCEPT_HEADER,
+  }
+}
+
+async function extractGithubError(res: Response): Promise<string> {
+  try {
+    const data = await res.json()
+    if (data && typeof data.message === 'string' && data.message.length > 0) {
+      return data.message
+    }
+    return JSON.stringify(data)
+  } catch {
+    try {
+      return await res.text()
+    } catch {
+      return ''
+    }
+  }
+}
+
+export async function listRepos(token: string): Promise<GithubRepo[]> {
+  assertToken(token)
+  const url =
+    `${GITHUB_API_BASE}/user/repos` +
+    `?affiliation=owner&type=owner&sort=pushed&per_page=50`
+  const res = await fetch(url, { headers: authHeaders(token) })
+  if (!res.ok) {
+    const message = await extractGithubError(res)
+    throw new Error(`GitHub listRepos failed (${res.status}): ${message}`)
+  }
+  const data = await res.json()
+  if (!Array.isArray(data)) {
+    throw new Error('GitHub listRepos returned a non-array response.')
+  }
+  return data as GithubRepo[]
+}
+
+export async function createIssue(
+  token: string,
+  repo: string,
+  title: string,
+  body: string,
+): Promise<CreateIssueResult> {
+  assertToken(token)
+  if (typeof repo !== 'string' || repo.trim().length === 0) {
+    throw new Error('repo is required (expected "owner/name").')
+  }
+  if (typeof title !== 'string' || title.trim().length === 0) {
+    throw new Error('title is required.')
+  }
+  if (typeof body !== 'string' || body.length === 0) {
+    throw new Error('body is required.')
+  }
+  const url = `${GITHUB_API_BASE}/repos/${repo}/issues`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      ...authHeaders(token),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ title, body }),
+  })
+  if (!res.ok) {
+    const message = await extractGithubError(res)
+    throw new Error(`GitHub createIssue failed (${res.status}): ${message}`)
+  }
+  const data = await res.json()
+  if (!data || typeof data.html_url !== 'string' || typeof data.number !== 'number') {
+    throw new Error('GitHub createIssue returned an unexpected response shape.')
+  }
+  return { url: data.html_url, number: data.number }
+}

--- a/supabase/functions/chat/githubFilters.test.ts
+++ b/supabase/functions/chat/githubFilters.test.ts
@@ -1,0 +1,105 @@
+import { assertEquals } from 'jsr:@std/assert@1'
+import { filterAndSlim } from './githubFilters.ts'
+
+const baseRepo = {
+  name: 'project',
+  full_name: 'lucasfe/project',
+  description: 'A project',
+  pushed_at: '2026-04-01T00:00:00Z',
+  archived: false,
+  fork: false,
+  size: 100,
+  // Extra fields that must be dropped:
+  owner: { login: 'lucasfe' },
+  default_branch: 'main',
+  topics: ['ai'],
+  license: null,
+}
+
+Deno.test('filterAndSlim — excludes archived repos', () => {
+  const out = filterAndSlim([{ ...baseRepo, archived: true }])
+  assertEquals(out, [])
+})
+
+Deno.test('filterAndSlim — excludes fork repos', () => {
+  const out = filterAndSlim([{ ...baseRepo, fork: true }])
+  assertEquals(out, [])
+})
+
+Deno.test('filterAndSlim — excludes empty repos with size 0', () => {
+  const out = filterAndSlim([{ ...baseRepo, size: 0 }])
+  assertEquals(out, [])
+})
+
+Deno.test('filterAndSlim — keeps healthy repos', () => {
+  const out = filterAndSlim([baseRepo])
+  assertEquals(out, [
+    {
+      name: 'project',
+      full_name: 'lucasfe/project',
+      description: 'A project',
+      pushed_at: '2026-04-01T00:00:00Z',
+    },
+  ])
+})
+
+Deno.test('filterAndSlim — strips extra fields, keeps only slim shape', () => {
+  const [out] = filterAndSlim([baseRepo])
+  assertEquals(Object.keys(out).sort(), [
+    'description',
+    'full_name',
+    'name',
+    'pushed_at',
+  ])
+})
+
+Deno.test('filterAndSlim — preserves null description', () => {
+  const out = filterAndSlim([{ ...baseRepo, description: null }])
+  assertEquals(out[0].description, null)
+})
+
+Deno.test('filterAndSlim — coerces non-string description to null', () => {
+  const out = filterAndSlim([{ ...baseRepo, description: undefined }])
+  assertEquals(out[0].description, null)
+})
+
+Deno.test('filterAndSlim — drops entries without name or full_name', () => {
+  const out = filterAndSlim([
+    { ...baseRepo, name: undefined },
+    { ...baseRepo, full_name: undefined },
+  ])
+  assertEquals(out, [])
+})
+
+Deno.test('filterAndSlim — mixed input keeps only the survivors in order', () => {
+  const repos = [
+    { ...baseRepo, name: 'alpha', full_name: 'lucasfe/alpha' },
+    { ...baseRepo, name: 'archived-one', full_name: 'lucasfe/archived-one', archived: true },
+    { ...baseRepo, name: 'beta', full_name: 'lucasfe/beta' },
+    { ...baseRepo, name: 'forked', full_name: 'lucasfe/forked', fork: true },
+    { ...baseRepo, name: 'empty', full_name: 'lucasfe/empty', size: 0 },
+    { ...baseRepo, name: 'gamma', full_name: 'lucasfe/gamma' },
+  ]
+  const out = filterAndSlim(repos)
+  assertEquals(
+    out.map((r) => r.full_name),
+    ['lucasfe/alpha', 'lucasfe/beta', 'lucasfe/gamma'],
+  )
+})
+
+Deno.test('filterAndSlim — empty array returns empty array', () => {
+  assertEquals(filterAndSlim([]), [])
+})
+
+Deno.test('filterAndSlim — non-array input returns empty array', () => {
+  // deno-lint-ignore no-explicit-any
+  assertEquals(filterAndSlim(null as any), [])
+  // deno-lint-ignore no-explicit-any
+  assertEquals(filterAndSlim(undefined as any), [])
+})
+
+Deno.test('filterAndSlim — skips null / non-object entries', () => {
+  // deno-lint-ignore no-explicit-any
+  const out = filterAndSlim([null as any, baseRepo])
+  assertEquals(out.length, 1)
+})

--- a/supabase/functions/chat/githubFilters.ts
+++ b/supabase/functions/chat/githubFilters.ts
@@ -1,0 +1,47 @@
+// Pure repo filter for the GitHub Issue Creator agent.
+//
+// Takes the raw array from the GitHub /user/repos response and returns the
+// slim, filtered list the agent reasons about. Excludes archived repos
+// (cannot accept new issues), forks (issues belong on the upstream), and
+// empty repos with size === 0 (clutter without value). Maps survivors to the
+// minimal shape so the LLM's working set stays compact.
+
+export interface SlimRepo {
+  name: string
+  full_name: string
+  description: string | null
+  pushed_at: string
+}
+
+export interface RawRepo {
+  name?: unknown
+  full_name?: unknown
+  description?: unknown
+  pushed_at?: unknown
+  archived?: unknown
+  fork?: unknown
+  size?: unknown
+  [key: string]: unknown
+}
+
+export function filterAndSlim(repos: readonly RawRepo[]): SlimRepo[] {
+  if (!Array.isArray(repos)) return []
+  const out: SlimRepo[] = []
+  for (const repo of repos) {
+    if (!repo || typeof repo !== 'object') continue
+    if (repo.archived === true) continue
+    if (repo.fork === true) continue
+    if (repo.size === 0) continue
+    if (typeof repo.name !== 'string' || typeof repo.full_name !== 'string') continue
+    if (typeof repo.pushed_at !== 'string') continue
+    const description =
+      typeof repo.description === 'string' ? repo.description : null
+    out.push({
+      name: repo.name,
+      full_name: repo.full_name,
+      description,
+      pushed_at: repo.pushed_at,
+    })
+  }
+  return out
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,6 +11,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.js',
     css: false,
-    exclude: ['e2e/**', '**/node_modules/**', 'packages/**'],
+    exclude: ['e2e/**', '**/node_modules/**', 'packages/**', 'supabase/functions/**'],
   },
 })


### PR DESCRIPTION
Closes #46

Lays the testable foundation for the GitHub Issue Creator agent (PRD #45). After this slice merges, the modules and their tests exist but no caller wires them up — the user-visible app is unchanged. The next slice (#47) wires them into the executor and adds the agent to the catalog.

## What's in this slice

- `supabase/functions/chat/github.ts` — deep, narrow module with `listRepos(token)` and `createIssue(token, repo, title, body)`. Token is always the first argument; nothing reads global state. Non-2xx responses surface as Errors that carry the GitHub error message intact. Empty / missing token, repo, title, or body are rejected at the boundary.
- `supabase/functions/chat/githubFilters.ts` — pure `filterAndSlim(repos)` that drops archived repos, forks, and size-zero repos, then maps survivors to `{ name, full_name, description, pushed_at }` only.
- `supabase/functions/chat/github.test.ts` — 20 tests with a mocked `fetch`: URL building, header shape, JSON body shape, 401/404/422/5xx error surfacing, missing-token rejection, and unexpected-shape guards.
- `supabase/functions/chat/githubFilters.test.ts` — 12 pure tests covering archived/fork/empty exclusion, slim-shape mapping, mixed-input integration, and edge cases (null/undefined input, missing fields).
- `package.json` — new `test:functions` script: `deno test --allow-net --allow-env supabase/functions/`.
- `vitest.config.js` — exclude `supabase/functions/**` so vitest does not try to run the Deno tests.
- `CLAUDE.md` — short subsection explaining frontend (`npm test`) vs Edge Function (`npm run test:functions`) tests and that Deno is required locally.
- `deno.lock` — JSR lockfile for `@std/assert`.

## Out of scope (per the PRD and the issue's guard)

Did NOT modify `executor.ts`, the `tools` / `agents` tables, `agents.json`, `agentContent.js`, `ralph.sh`, `start-ralph.sh`, `PROMPT.md`, `.claude/`, `vercel.json`, or anything under `packages/`. Those land in the next slice or are out of scope entirely.

## Verification

- `npm test` → 129 tests pass (16 files).
- `npm run test:functions` → 32 tests pass.
- `npm run lint` → 0 errors.