### PR TITLE
feat: GitHub Issue Creator agent in catalog (#47)

### DIFF
--- a/src/data/agentContent.js
+++ b/src/data/agentContent.js
@@ -463,6 +463,56 @@ For every significant decision, document:
 - User consent and data privacy compliance
 - Escalation procedures for edge cases
 - Ongoing monitoring for emerging risks`,
+
+  'github-issue-creator': `You are the GitHub Issue Creator for Lucas's personal projects. You turn free-text descriptions of ideas, bugs, and follow-ups into clean GitHub issues filed in the right repository, after the user explicitly approves each one.
+
+## Mandatory first step
+
+ALWAYS call the \`list_github_repos\` tool exactly once at the very start of every new conversation, before doing anything else. The result grounds you in Lucas's current owned repos. Do not rely on stored memory of repo names — they may be out of date or the repo may not exist anymore. If the tool reports it is not configured, tell the user the GitHub token is missing and stop.
+
+## Choosing the right repo
+
+After listing, match the user's free-text description against repo \`name\` and \`description\`:
+
+- If exactly one repo plausibly matches, use it.
+- If two or more repos plausibly match, ask ONE short disambiguation question naming the candidates (e.g. "É no \`agenthub\` ou no \`lucasfe.com\`?").
+- When matches tie on relevance, bias toward the repo with the most recent \`pushed_at\` — Lucas is most likely talking about whatever he was just working on.
+- If nothing plausibly matches, ask the user to name the repo explicitly.
+
+Never guess silently. Confirm the target before drafting.
+
+## Drafting the issue
+
+Once the repo is settled, draft a clean Markdown body. Pick the shape that fits:
+
+- **Feature-shaped requests** ("add X", "support Y", "we should...") — use these sections: \`## Context\`, \`## Acceptance criteria\` (a short bulleted list), and an optional \`## Notes\`.
+- **Bug reports** — use \`## What happens\`, \`## Expected\`, and \`## Steps to reproduce\` if known.
+- **Thought-capture or rough idea** — a few prose paragraphs are fine; do not force a heavyweight structure on a small note.
+
+The title should be short, imperative, and specific. Avoid vague titles like "improvements".
+
+## Preview before approval
+
+BEFORE invoking \`create_github_issue\`, send a chat message that surfaces:
+
+- The chosen \`repo\` (full \`owner/name\`)
+- The proposed \`title\`
+- A preview of the \`body\`
+
+Keep the preview compact but faithful to what you'll submit. Then call \`create_github_issue\`. The tool requires explicit user approval — Lucas will see an Approve button. If he declines and gives feedback, revise the draft and propose again; do not retry the same payload.
+
+## After creation
+
+When the tool returns successfully, your final message must be a short Markdown line containing the issue URL, e.g. \`Issue criada: https://github.com/owner/repo/issues/42\`. Nothing more.
+
+If the tool returns an error (token missing, validation failed, rate limited), surface the error verbatim and stop — don't loop.
+
+## What not to do
+
+- Do not invent labels, assignees, or milestones; the tool only accepts \`repo\`, \`title\`, and \`body\`.
+- Do not call \`create_github_issue\` without an explicit preview message immediately before it.
+- Do not skip the initial \`list_github_repos\` call, even if the user names a repo directly — verify it exists in Lucas's current owned repos first.
+- Reply in the same language Lucas wrote in (Portuguese in, Portuguese out).`,
 }
 
 export default agentContent

--- a/src/data/agents.json
+++ b/src/data/agents.json
@@ -218,5 +218,17 @@
     "color": "amber",
     "featured": false,
     "popularity": 71
+  },
+  {
+    "id": "github-issue-creator",
+    "name": "GitHub Issue Creator",
+    "category": "AI Specialists",
+    "description": "Captures ideas and bug reports from chat and turns them into well-formed GitHub issues in the right repo, with a one-click approval before posting.",
+    "tags": ["GitHub", "Issues", "Productivity"],
+    "icon": "Github",
+    "color": "purple",
+    "featured": false,
+    "popularity": 75,
+    "tools": ["list_github_repos", "create_github_issue"]
   }
 ]

--- a/supabase/functions/chat/executor.test.ts
+++ b/supabase/functions/chat/executor.test.ts
@@ -1,0 +1,277 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from 'jsr:@std/assert@1'
+import { TOOL_HANDLERS } from './executor.ts'
+
+interface MockCall {
+  url: string
+  init?: RequestInit
+}
+
+function installFetchMock(
+  responder: (call: MockCall) => Response | Promise<Response>,
+): { calls: MockCall[]; restore: () => void } {
+  const calls: MockCall[] = []
+  const original = globalThis.fetch
+  // deno-lint-ignore no-explicit-any
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url
+    const call: MockCall = { url, init }
+    calls.push(call)
+    return await responder(call)
+  }) as typeof fetch
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original
+    },
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function withGithubToken(token: string | null): () => void {
+  const previous = Deno.env.get('GITHUB_TOKEN')
+  if (token === null) {
+    Deno.env.delete('GITHUB_TOKEN')
+  } else {
+    Deno.env.set('GITHUB_TOKEN', token)
+  }
+  return () => {
+    if (previous === undefined) {
+      Deno.env.delete('GITHUB_TOKEN')
+    } else {
+      Deno.env.set('GITHUB_TOKEN', previous)
+    }
+  }
+}
+
+function makeCtx() {
+  return {
+    signal: new AbortController().signal,
+    agentsContext: [],
+    stepId: 0,
+    toolCallId: 'test',
+  }
+}
+
+// ─── list_github_repos ──────────────────────────────────────────────────────
+
+Deno.test('list_github_repos — returns slim repos on happy path', async () => {
+  const restoreToken = withGithubToken('tok')
+  const { restore } = installFetchMock(() =>
+    jsonResponse(200, [
+      {
+        name: 'agenthub',
+        full_name: 'lucasfe/agenthub',
+        description: 'AI hub',
+        pushed_at: '2026-04-20T00:00:00Z',
+        archived: false,
+        fork: false,
+        size: 1200,
+        owner: { login: 'lucasfe' },
+        default_branch: 'main',
+      },
+      {
+        name: 'archived-thing',
+        full_name: 'lucasfe/archived-thing',
+        description: null,
+        pushed_at: '2024-01-01T00:00:00Z',
+        archived: true,
+        fork: false,
+        size: 500,
+      },
+      {
+        name: 'fork-of-something',
+        full_name: 'lucasfe/fork-of-something',
+        description: null,
+        pushed_at: '2025-01-01T00:00:00Z',
+        archived: false,
+        fork: true,
+        size: 500,
+      },
+    ]),
+  )
+  try {
+    const result = await TOOL_HANDLERS.list_github_repos({}, makeCtx())
+    assert(result.ok)
+    assertEquals(result.result, {
+      repos: [
+        {
+          name: 'agenthub',
+          full_name: 'lucasfe/agenthub',
+          description: 'AI hub',
+          pushed_at: '2026-04-20T00:00:00Z',
+        },
+      ],
+    })
+    assertStringIncludes(result.summary ?? '', '1 owned repo')
+  } finally {
+    restore()
+    restoreToken()
+  }
+})
+
+Deno.test('list_github_repos — returns missing-token error when GITHUB_TOKEN is unset', async () => {
+  const restoreToken = withGithubToken(null)
+  try {
+    const result = await TOOL_HANDLERS.list_github_repos({}, makeCtx())
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'GITHUB_TOKEN')
+    // Result payload carries the structured error code so the LLM can
+    // reason about the failure in the same shape as other gated tools.
+    assertEquals(
+      (result.result as { error?: string } | undefined)?.error,
+      'not_configured',
+    )
+  } finally {
+    restoreToken()
+  }
+})
+
+Deno.test('list_github_repos — surfaces upstream GitHub error', async () => {
+  const restoreToken = withGithubToken('tok')
+  const { restore } = installFetchMock(() =>
+    jsonResponse(401, { message: 'Bad credentials' }),
+  )
+  try {
+    const result = await TOOL_HANDLERS.list_github_repos({}, makeCtx())
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'Bad credentials')
+  } finally {
+    restore()
+    restoreToken()
+  }
+})
+
+// ─── create_github_issue ────────────────────────────────────────────────────
+
+Deno.test('create_github_issue — returns { url, number } on happy path', async () => {
+  const restoreToken = withGithubToken('tok')
+  const { calls, restore } = installFetchMock(() =>
+    jsonResponse(201, {
+      html_url: 'https://github.com/lucasfe/agenthub/issues/99',
+      number: 99,
+    }),
+  )
+  try {
+    const result = await TOOL_HANDLERS.create_github_issue(
+      { repo: 'lucasfe/agenthub', title: 'Bug', body: 'Something broke' },
+      makeCtx(),
+    )
+    assert(result.ok)
+    assertEquals(result.result, {
+      url: 'https://github.com/lucasfe/agenthub/issues/99',
+      number: 99,
+    })
+    assertEquals(
+      calls[0].url,
+      'https://api.github.com/repos/lucasfe/agenthub/issues',
+    )
+    assertEquals(calls[0].init?.method, 'POST')
+  } finally {
+    restore()
+    restoreToken()
+  }
+})
+
+Deno.test('create_github_issue — returns missing-token error when GITHUB_TOKEN is unset', async () => {
+  const restoreToken = withGithubToken(null)
+  try {
+    const result = await TOOL_HANDLERS.create_github_issue(
+      { repo: 'lucasfe/agenthub', title: 'Bug', body: 'Body' },
+      makeCtx(),
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'GITHUB_TOKEN')
+    assertEquals(
+      (result.result as { error?: string } | undefined)?.error,
+      'not_configured',
+    )
+  } finally {
+    restoreToken()
+  }
+})
+
+Deno.test('create_github_issue — rejects empty repo before hitting GitHub', async () => {
+  const restoreToken = withGithubToken('tok')
+  let fetchCalled = false
+  const { restore } = installFetchMock(() => {
+    fetchCalled = true
+    return jsonResponse(201, {})
+  })
+  try {
+    const result = await TOOL_HANDLERS.create_github_issue(
+      { repo: '', title: 'T', body: 'B' },
+      makeCtx(),
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'repo')
+    assertEquals(fetchCalled, false)
+  } finally {
+    restore()
+    restoreToken()
+  }
+})
+
+Deno.test('create_github_issue — rejects missing title', async () => {
+  const restoreToken = withGithubToken('tok')
+  const { restore } = installFetchMock(() => jsonResponse(201, {}))
+  try {
+    const result = await TOOL_HANDLERS.create_github_issue(
+      { repo: 'lucasfe/agenthub', body: 'B' },
+      makeCtx(),
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'title')
+  } finally {
+    restore()
+    restoreToken()
+  }
+})
+
+Deno.test('create_github_issue — rejects whitespace-only body', async () => {
+  const restoreToken = withGithubToken('tok')
+  const { restore } = installFetchMock(() => jsonResponse(201, {}))
+  try {
+    const result = await TOOL_HANDLERS.create_github_issue(
+      { repo: 'lucasfe/agenthub', title: 'T', body: '   ' },
+      makeCtx(),
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'body')
+  } finally {
+    restore()
+    restoreToken()
+  }
+})
+
+Deno.test('create_github_issue — surfaces upstream 422 validation error', async () => {
+  const restoreToken = withGithubToken('tok')
+  const { restore } = installFetchMock(() =>
+    jsonResponse(422, { message: 'Validation Failed' }),
+  )
+  try {
+    const result = await TOOL_HANDLERS.create_github_issue(
+      { repo: 'lucasfe/agenthub', title: 'T', body: 'B' },
+      makeCtx(),
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'Validation Failed')
+  } finally {
+    restore()
+    restoreToken()
+  }
+})

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -374,6 +374,7 @@ async function createGoogleSlides(
       speaker_notes?: string
       layout?: string
     }>
+    share_with_email?: string
   },
   ctx: ToolContext,
 ): Promise<ToolResult> {

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -15,6 +15,9 @@
 //
 // deno-lint-ignore-file no-explicit-any
 
+import { createIssue, listRepos } from './github.ts'
+import { filterAndSlim } from './githubFilters.ts'
+
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const DEFAULT_STEP_MODEL = 'claude-sonnet-4-6'
 const ANALYZER_MODEL = Deno.env.get('ANALYZER_MODEL') || 'claude-sonnet-4-6'

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -650,12 +650,19 @@ function getAvailableTools(): Set<string> {
   if (!Deno.env.get('TAVILY_API_KEY')) {
     available.delete('web_search')
   }
+  if (!Deno.env.get('GITHUB_TOKEN')) {
+    available.delete('list_github_repos')
+    available.delete('create_github_issue')
+  }
   return available
 }
 
 function describeUnavailableReason(toolId: string): string {
   if (toolId === 'web_search') {
     return 'TAVILY_API_KEY is not configured in the Edge Function secrets.'
+  }
+  if (toolId === 'list_github_repos' || toolId === 'create_github_issue') {
+    return 'GITHUB_TOKEN is not configured in the Edge Function secrets.'
   }
   return 'Tool is not available in this environment.'
 }

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -560,6 +560,76 @@ async function createGoogleSlides(
   }
 }
 
+// ─── GitHub Issue Creator tools ─────────────────────────────────────────────
+
+const MISSING_GITHUB_TOKEN_ERROR =
+  'GitHub Issue Creator is not configured. Set GITHUB_TOKEN in the Edge Function secrets to enable this tool.'
+
+async function listGithubRepos(
+  _input: Record<string, unknown>,
+  _ctx: ToolContext,
+): Promise<ToolResult> {
+  const token = Deno.env.get('GITHUB_TOKEN')
+  if (!token) {
+    return {
+      ok: false,
+      error: MISSING_GITHUB_TOKEN_ERROR,
+      result: { error: 'not_configured' },
+    }
+  }
+  try {
+    const repos = await listRepos(token)
+    const slim = filterAndSlim(repos)
+    return {
+      ok: true,
+      result: { repos: slim },
+      summary: `Found ${slim.length} owned repo${slim.length === 1 ? '' : 's'}`,
+    }
+  } catch (err) {
+    return { ok: false, error: (err as Error).message }
+  }
+}
+
+async function createGithubIssue(
+  input: { repo?: unknown; title?: unknown; body?: unknown },
+  _ctx: ToolContext,
+): Promise<ToolResult> {
+  const repo = typeof input.repo === 'string' ? input.repo.trim() : ''
+  const title = typeof input.title === 'string' ? input.title.trim() : ''
+  const body = typeof input.body === 'string' ? input.body.trim() : ''
+  if (!repo) {
+    return {
+      ok: false,
+      error:
+        'create_github_issue requires a non-empty `repo` (e.g. "owner/name").',
+    }
+  }
+  if (!title) {
+    return { ok: false, error: 'create_github_issue requires a non-empty `title`.' }
+  }
+  if (!body) {
+    return { ok: false, error: 'create_github_issue requires a non-empty `body`.' }
+  }
+  const token = Deno.env.get('GITHUB_TOKEN')
+  if (!token) {
+    return {
+      ok: false,
+      error: MISSING_GITHUB_TOKEN_ERROR,
+      result: { error: 'not_configured' },
+    }
+  }
+  try {
+    const result = await createIssue(token, repo, title, body)
+    return {
+      ok: true,
+      result,
+      summary: `Created issue #${result.number} in ${repo}`,
+    }
+  } catch (err) {
+    return { ok: false, error: (err as Error).message }
+  }
+}
+
 export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   web_search: webSearch,
   fetch_url: fetchUrl,
@@ -568,6 +638,8 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   read_agent: readAgent,
   save_artifact: saveArtifact,
   create_google_slides: createGoogleSlides,
+  list_github_repos: listGithubRepos,
+  create_github_issue: createGithubIssue,
 }
 
 // Which tools are functional in the current environment. Some tools depend on

--- a/supabase/seed-tools.sql
+++ b/supabase/seed-tools.sql
@@ -1,0 +1,149 @@
+-- Seed for the GitHub Issue Creator agent (issue #47).
+--
+-- Run this in the Supabase SQL Editor on the live project AFTER the PR
+-- merges to dev. The Edge Function picks up new rows on its next cold
+-- start; no redeploy is required.
+--
+-- Prerequisite (issue #48): the `GITHUB_TOKEN` Edge Function secret must
+-- be set, otherwise both tools below return a structured "not_configured"
+-- error instead of doing real work.
+--
+-- This file is idempotent: re-running it is a no-op.
+
+-- =============================================================================
+-- TOOLS
+-- =============================================================================
+
+INSERT INTO tools (id, name, description, icon, category, input_schema, requires_approval, enabled)
+VALUES (
+  'list_github_repos',
+  'List GitHub repos',
+  'Returns the slim list of GitHub repositories that the configured token owns. Filters out archived repos, forks, and empty repos. Call this once at the start of an issue-creation conversation to ground the agent in current repo names.',
+  'Github',
+  'github',
+  '{"type":"object","properties":{},"additionalProperties":false}'::jsonb,
+  false,
+  true
+)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  icon = EXCLUDED.icon,
+  category = EXCLUDED.category,
+  input_schema = EXCLUDED.input_schema,
+  requires_approval = EXCLUDED.requires_approval,
+  enabled = EXCLUDED.enabled;
+
+INSERT INTO tools (id, name, description, icon, category, input_schema, requires_approval, enabled)
+VALUES (
+  'create_github_issue',
+  'Create GitHub issue',
+  'Creates a new issue in a GitHub repository owned by the configured token. The repo must be passed as "owner/name". This is a write action — execution is gated behind explicit user approval in the chat UI.',
+  'GitPullRequest',
+  'github',
+  '{"type":"object","required":["repo","title","body"],"properties":{"repo":{"type":"string","description":"Target repository as \"owner/name\" (must be in the list returned by list_github_repos)."},"title":{"type":"string","description":"Short, imperative issue title."},"body":{"type":"string","description":"Markdown body. Use Context / Acceptance criteria / Notes sections for feature-shaped requests."}},"additionalProperties":false}'::jsonb,
+  true,
+  true
+)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  icon = EXCLUDED.icon,
+  category = EXCLUDED.category,
+  input_schema = EXCLUDED.input_schema,
+  requires_approval = EXCLUDED.requires_approval,
+  enabled = EXCLUDED.enabled;
+
+-- =============================================================================
+-- AGENT
+-- =============================================================================
+--
+-- The agent's `content` (system prompt) below must stay in sync with the
+-- entry in src/data/agentContent.js — that file is the source of truth for
+-- the static fallback. If you edit one, edit the other.
+
+INSERT INTO agents (
+  id, name, category, description, tags, icon, color, featured, popularity,
+  content, tools, model, capabilities
+) VALUES (
+  'github-issue-creator',
+  'GitHub Issue Creator',
+  'AI Specialists',
+  'Captures ideas and bug reports from chat and turns them into well-formed GitHub issues in the right repo, with a one-click approval before posting.',
+  ARRAY['GitHub', 'Issues', 'Productivity'],
+  'Github',
+  'purple',
+  false,
+  75,
+  $prompt$You are the GitHub Issue Creator for Lucas's personal projects. You turn free-text descriptions of ideas, bugs, and follow-ups into clean GitHub issues filed in the right repository, after the user explicitly approves each one.
+
+## Mandatory first step
+
+ALWAYS call the `list_github_repos` tool exactly once at the very start of every new conversation, before doing anything else. The result grounds you in Lucas's current owned repos. Do not rely on stored memory of repo names — they may be out of date or the repo may not exist anymore. If the tool reports it is not configured, tell the user the GitHub token is missing and stop.
+
+## Choosing the right repo
+
+After listing, match the user's free-text description against repo `name` and `description`:
+
+- If exactly one repo plausibly matches, use it.
+- If two or more repos plausibly match, ask ONE short disambiguation question naming the candidates (e.g. "É no `agenthub` ou no `lucasfe.com`?").
+- When matches tie on relevance, bias toward the repo with the most recent `pushed_at` — Lucas is most likely talking about whatever he was just working on.
+- If nothing plausibly matches, ask the user to name the repo explicitly.
+
+Never guess silently. Confirm the target before drafting.
+
+## Drafting the issue
+
+Once the repo is settled, draft a clean Markdown body. Pick the shape that fits:
+
+- **Feature-shaped requests** ("add X", "support Y", "we should...") — use these sections: `## Context`, `## Acceptance criteria` (a short bulleted list), and an optional `## Notes`.
+- **Bug reports** — use `## What happens`, `## Expected`, and `## Steps to reproduce` if known.
+- **Thought-capture or rough idea** — a few prose paragraphs are fine; do not force a heavyweight structure on a small note.
+
+The title should be short, imperative, and specific. Avoid vague titles like "improvements".
+
+## Preview before approval
+
+BEFORE invoking `create_github_issue`, send a chat message that surfaces:
+
+- The chosen `repo` (full `owner/name`)
+- The proposed `title`
+- A preview of the `body`
+
+Keep the preview compact but faithful to what you'll submit. Then call `create_github_issue`. The tool requires explicit user approval — Lucas will see an Approve button. If he declines and gives feedback, revise the draft and propose again; do not retry the same payload.
+
+## After creation
+
+When the tool returns successfully, your final message must be a short Markdown line containing the issue URL, e.g. `Issue criada: https://github.com/owner/repo/issues/42`. Nothing more.
+
+If the tool returns an error (token missing, validation failed, rate limited), surface the error verbatim and stop — don't loop.
+
+## What not to do
+
+- Do not invent labels, assignees, or milestones; the tool only accepts `repo`, `title`, and `body`.
+- Do not call `create_github_issue` without an explicit preview message immediately before it.
+- Do not skip the initial `list_github_repos` call, even if the user names a repo directly — verify it exists in Lucas's current owned repos first.
+- Reply in the same language Lucas wrote in (Portuguese in, Portuguese out).$prompt$,
+  ARRAY['list_github_repos', 'create_github_issue'],
+  'claude-sonnet-4-6',
+  ARRAY[]::text[]
+)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  category = EXCLUDED.category,
+  description = EXCLUDED.description,
+  tags = EXCLUDED.tags,
+  icon = EXCLUDED.icon,
+  color = EXCLUDED.color,
+  featured = EXCLUDED.featured,
+  popularity = EXCLUDED.popularity,
+  content = EXCLUDED.content,
+  tools = EXCLUDED.tools,
+  model = EXCLUDED.model,
+  capabilities = EXCLUDED.capabilities;
+
+-- =============================================================================
+-- ROLLBACK (run if you want to remove this agent and its tools)
+-- =============================================================================
+-- DELETE FROM agents WHERE id = 'github-issue-creator';
+-- DELETE FROM tools WHERE id IN ('list_github_repos', 'create_github_issue');


### PR DESCRIPTION
Closes #47.

## Summary

Wires the deep modules from #46 into AgentHub end-to-end so a user can pick the new **GitHub Issue Creator** agent from the catalog, describe an issue in chat, and have it opened in the right repo after explicit approval.

- Adds `list_github_repos` (read-only) and `create_github_issue` (write, `requires_approval=true`) handlers to `TOOL_HANDLERS` in `supabase/functions/chat/executor.ts`. Both gate on `GITHUB_TOKEN` and surface a structured "not_configured" error when unset (mirroring the `web_search` / `create_google_slides` pattern).
- `create_github_issue` validates non-empty `repo` / `title` / `body` before calling GitHub.
- New `getAvailableTools` / `describeUnavailableReason` branches drop the GitHub tools from the sub-agent's toolset when the secret is missing.
- New agent `github-issue-creator` in `src/data/agents.json` and matching system prompt in `src/data/agentContent.js`, with `tools: ['list_github_repos', 'create_github_issue']`.
- New `supabase/functions/chat/executor.test.ts` covers happy / missing-token / empty-field paths for both handlers (9 tests). Fixes a pre-existing typing gap on `createGoogleSlides`'s `share_with_email` input that was hidden by the lack of an executor test file.

## SQL to run after merge

The new tools and agent rows live in the live Supabase database. Run the contents of `supabase/seed-tools.sql` in the Supabase SQL Editor on the prod project. The file is idempotent (uses `ON CONFLICT … DO UPDATE`), so re-running is safe.

## Rollback SQL

If you need to undo the seed:

```sql
DELETE FROM agents WHERE id = 'github-issue-creator';
DELETE FROM tools WHERE id IN ('list_github_repos', 'create_github_issue');
```

## Checklist after merge

- [ ] Merge this PR into `dev`.
- [ ] Run `supabase/seed-tools.sql` in the Supabase SQL Editor (prod).
- [ ] **The agent is non-functional until issue #48 (`[manual] Set GITHUB_TOKEN Edge Function secret`) is resolved.** Until then, both tools return a structured "GITHUB_TOKEN is not configured" error.
- [ ] Once the token is set, smoke-test by asking the agent in the AI Assistant chat to capture a quick test issue.

## Test plan

- [x] `npm test` — 129 frontend tests pass
- [x] `npm run test:functions` — 41 Deno tests pass (9 new in `executor.test.ts` + existing 32)
- [x] `npm run lint` — no errors (warnings unchanged)
- [x] `npm run build` — production bundle builds cleanly

## Out-of-scope guard

No changes touched `ralph.sh`, `start-ralph.sh`, `PROMPT.md`, anything under `.claude/`, `vercel.json`, or anything under `packages/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)