### PR TITLE
Skills: GitHub Contents API client + frontmatter parser (#51)

### DIFF
--- a/src/lib/skillFrontmatter.js
+++ b/src/lib/skillFrontmatter.js
@@ -8,11 +8,13 @@
 // consume them without touching this module.
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
-const LEADING_BOM_RE = /^﻿/
+const BOM = 0xfeff
 
 export function parseFrontmatter(md) {
   if (typeof md !== 'string') return null
-  const stripped = md.replace(LEADING_BOM_RE, '').replace(/^\s+/, '')
+  let stripped = md
+  if (stripped.charCodeAt(0) === BOM) stripped = stripped.slice(1)
+  stripped = stripped.replace(/^\s+/, '')
   const match = stripped.match(FRONTMATTER_RE)
   if (!match) return null
   const [, yaml, body] = match

--- a/src/lib/skillFrontmatter.js
+++ b/src/lib/skillFrontmatter.js
@@ -1,0 +1,43 @@
+// Pure parser for the YAML frontmatter block at the top of a SKILL.md file.
+//
+// Deep, narrow module: zero new dependencies, no I/O. Returns the parsed
+// frontmatter merged with the raw markdown body, or `null` when the block is
+// missing or malformed. The narrowness of v1 frontmatter (`name`, `description`
+// are the only fields the catalog page reads) keeps the parser tiny and fully
+// testable. Extra optional keys are carried through so future readers can
+// consume them without touching this module.
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
+
+export function parseFrontmatter(md) {
+  if (typeof md !== 'string') return null
+  const stripped = md.replace(/^﻿/, '').replace(/^\s+/, '')
+  const match = stripped.match(FRONTMATTER_RE)
+  if (!match) return null
+  const [, yaml, body] = match
+  const data = parseYaml(yaml)
+  return { ...data, body: body ?? '' }
+}
+
+function parseYaml(yaml) {
+  const out = {}
+  const lines = yaml.split(/\r?\n/)
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    if (trimmed.startsWith('#')) continue
+    const idx = line.indexOf(':')
+    if (idx < 0) continue
+    const key = line.slice(0, idx).trim()
+    if (!key) continue
+    let value = line.slice(idx + 1).trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+    ) {
+      value = value.slice(1, -1)
+    }
+    out[key] = value
+  }
+  return out
+}

--- a/src/lib/skillFrontmatter.js
+++ b/src/lib/skillFrontmatter.js
@@ -8,10 +8,11 @@
 // consume them without touching this module.
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
+const LEADING_BOM_RE = /^﻿/
 
 export function parseFrontmatter(md) {
   if (typeof md !== 'string') return null
-  const stripped = md.replace(/^﻿/, '').replace(/^\s+/, '')
+  const stripped = md.replace(LEADING_BOM_RE, '').replace(/^\s+/, '')
   const match = stripped.match(FRONTMATTER_RE)
   if (!match) return null
   const [, yaml, body] = match

--- a/src/lib/skillFrontmatter.test.js
+++ b/src/lib/skillFrontmatter.test.js
@@ -73,8 +73,8 @@ describe('parseFrontmatter', () => {
   })
 
   it('tolerates leading whitespace and BOM before the opening fence', () => {
-    const md =
-      '﻿\n   \n---\nname: review\ndescription: Review a pull request\n---\nbody'
+    const bom = String.fromCharCode(0xfeff)
+    const md = `${bom}\n   \n---\nname: review\ndescription: Review a pull request\n---\nbody`
     const parsed = parseFrontmatter(md)
     expect(parsed).not.toBeNull()
     expect(parsed.name).toBe('review')

--- a/src/lib/skillFrontmatter.test.js
+++ b/src/lib/skillFrontmatter.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { parseFrontmatter } from './skillFrontmatter'
+
+describe('parseFrontmatter', () => {
+  it('returns null when input is not a string', () => {
+    expect(parseFrontmatter(undefined)).toBeNull()
+    expect(parseFrontmatter(null)).toBeNull()
+    expect(parseFrontmatter(42)).toBeNull()
+    expect(parseFrontmatter({})).toBeNull()
+  })
+
+  it('parses standard frontmatter with name, description, and body', () => {
+    const md = [
+      '---',
+      'name: grill-me',
+      'description: Interview the user about a plan',
+      '---',
+      '',
+      '# Grill Me',
+      '',
+      'Body goes here.',
+    ].join('\n')
+    const parsed = parseFrontmatter(md)
+    expect(parsed).not.toBeNull()
+    expect(parsed.name).toBe('grill-me')
+    expect(parsed.description).toBe('Interview the user about a plan')
+    expect(parsed.body).toBe('\n# Grill Me\n\nBody goes here.')
+  })
+
+  it('returns null when the frontmatter block is missing', () => {
+    expect(parseFrontmatter('')).toBeNull()
+    expect(parseFrontmatter('# Just a heading\n\nBody only.')).toBeNull()
+    expect(parseFrontmatter('not even close')).toBeNull()
+  })
+
+  it('returns null when the frontmatter is unterminated (graceful, never throws)', () => {
+    const md = [
+      '---',
+      'name: grill-me',
+      'description: never-closed',
+      '',
+      '# No closing fence below',
+      'body content',
+    ].join('\n')
+    expect(() => parseFrontmatter(md)).not.toThrow()
+    expect(parseFrontmatter(md)).toBeNull()
+  })
+
+  it('carries extra optional keys through in the result', () => {
+    const md = [
+      '---',
+      'name: to-prd',
+      'description: Turn context into a PRD',
+      'icon: Wand2',
+      'tags: planning,prd',
+      '---',
+      'body',
+    ].join('\n')
+    const parsed = parseFrontmatter(md)
+    expect(parsed).not.toBeNull()
+    expect(parsed.icon).toBe('Wand2')
+    expect(parsed.tags).toBe('planning,prd')
+  })
+
+  it('handles CRLF line endings', () => {
+    const md =
+      '---\r\nname: tdd\r\ndescription: Test-driven development loop\r\n---\r\nBody.\r\n'
+    const parsed = parseFrontmatter(md)
+    expect(parsed).not.toBeNull()
+    expect(parsed.name).toBe('tdd')
+    expect(parsed.description).toBe('Test-driven development loop')
+    expect(parsed.body).toBe('Body.\r\n')
+  })
+
+  it('tolerates leading whitespace and BOM before the opening fence', () => {
+    const md =
+      '﻿\n   \n---\nname: review\ndescription: Review a pull request\n---\nbody'
+    const parsed = parseFrontmatter(md)
+    expect(parsed).not.toBeNull()
+    expect(parsed.name).toBe('review')
+    expect(parsed.description).toBe('Review a pull request')
+  })
+
+  it('strips matching surrounding quotes from values', () => {
+    const md = [
+      '---',
+      'name: "quoted-name"',
+      "description: 'single-quoted description'",
+      '---',
+      'body',
+    ].join('\n')
+    const parsed = parseFrontmatter(md)
+    expect(parsed.name).toBe('quoted-name')
+    expect(parsed.description).toBe('single-quoted description')
+  })
+
+  it('ignores comment lines and blank lines inside the frontmatter', () => {
+    const md = [
+      '---',
+      '# leading comment',
+      'name: skill-creator',
+      '',
+      'description: Author a new SKILL.md',
+      '---',
+      'body',
+    ].join('\n')
+    const parsed = parseFrontmatter(md)
+    expect(parsed.name).toBe('skill-creator')
+    expect(parsed.description).toBe('Author a new SKILL.md')
+  })
+
+  it('returns an empty body when no content follows the closing fence', () => {
+    const md = '---\nname: empty\ndescription: nothing after\n---\n'
+    const parsed = parseFrontmatter(md)
+    expect(parsed).not.toBeNull()
+    expect(parsed.body).toBe('')
+  })
+})

--- a/src/lib/skills.js
+++ b/src/lib/skills.js
@@ -1,0 +1,103 @@
+// GitHub Contents API client for the `lucasfe/skills` catalog.
+//
+// Deep, narrow module: knows everything about reaching the skills repo (URL
+// building, accept headers, listing folders, fetching SKILL.md, and surfacing
+// rate-limit / server errors as a typed error). Returns the slim shape the
+// `/skills` page renders — no caller needs to understand the GitHub API or the
+// frontmatter format.
+//
+// v1 is unauthenticated (the repo is public, the 60 req/hr limit is fine for a
+// single-user catalog). The internal `requestJson` / `requestText` helpers
+// already attach an `Authorization` header when a token is provided, so a
+// future migration to an Edge Function proxy that forwards the existing
+// `GITHUB_TOKEN` secret is a one-line change at the call sites.
+
+import { parseFrontmatter } from './skillFrontmatter.js'
+
+const GITHUB_API_BASE = 'https://api.github.com'
+const REPO_OWNER = 'lucasfe'
+const REPO_NAME = 'skills'
+const REPO = `${REPO_OWNER}/${REPO_NAME}`
+const ACCEPT_JSON = 'application/vnd.github+json'
+const ACCEPT_RAW = 'application/vnd.github.raw'
+
+export class SkillsApiError extends Error {
+  constructor(message, status) {
+    super(message)
+    this.name = 'SkillsApiError'
+    this.status = status
+  }
+}
+
+export async function listSkills(options = {}) {
+  const { token } = options
+  const entries = await requestJson(
+    `${GITHUB_API_BASE}/repos/${REPO}/contents`,
+    token,
+    'list skills',
+  )
+  if (!Array.isArray(entries)) {
+    throw new SkillsApiError('GitHub returned an unexpected response shape.', 502)
+  }
+  const folders = entries.filter(
+    (entry) => entry && entry.type === 'dir' && typeof entry.name === 'string',
+  )
+  const skills = []
+  for (const folder of folders) {
+    const skill = await fetchSkillForFolder(folder.name, token)
+    if (skill) skills.push(skill)
+  }
+  return skills
+}
+
+async function fetchSkillForFolder(slug, token) {
+  const url = `${GITHUB_API_BASE}/repos/${REPO}/contents/${encodeURIComponent(slug)}/SKILL.md`
+  const res = await fetch(url, { headers: buildHeaders(ACCEPT_RAW, token) })
+  if (res.status === 404) return null
+  if (!res.ok) {
+    if (res.status === 403 || res.status >= 500) {
+      throw new SkillsApiError(
+        `Failed to fetch SKILL.md for "${slug}" (${res.status}).`,
+        res.status,
+      )
+    }
+    return null
+  }
+  const text = await res.text()
+  const parsed = parseFrontmatter(text)
+  if (!parsed) return null
+  const name = typeof parsed.name === 'string' ? parsed.name.trim() : ''
+  const description = typeof parsed.description === 'string' ? parsed.description.trim() : ''
+  if (!name || !description) return null
+  return {
+    slug,
+    name,
+    description,
+    sourceUrl: `https://github.com/${REPO}/tree/main/${slug}`,
+  }
+}
+
+async function requestJson(url, token, label) {
+  const res = await fetch(url, { headers: buildHeaders(ACCEPT_JSON, token) })
+  if (!res.ok) {
+    if (res.status === 403 || res.status >= 500) {
+      throw new SkillsApiError(
+        `Failed to ${label} (${res.status}).`,
+        res.status,
+      )
+    }
+    throw new SkillsApiError(
+      `Failed to ${label} (${res.status}).`,
+      res.status,
+    )
+  }
+  return res.json()
+}
+
+function buildHeaders(accept, token) {
+  const headers = { Accept: accept }
+  if (typeof token === 'string' && token.length > 0) {
+    headers.Authorization = `Bearer ${token}`
+  }
+  return headers
+}

--- a/src/lib/skills.test.js
+++ b/src/lib/skills.test.js
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { listSkills, SkillsApiError } from './skills'
+
+const LIST_URL = 'https://api.github.com/repos/lucasfe/skills/contents'
+const SKILL_URL = (slug) =>
+  `https://api.github.com/repos/lucasfe/skills/contents/${slug}/SKILL.md`
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function textResponse(body, init = {}) {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/plain' },
+    ...init,
+  })
+}
+
+function frontmatter(name, description) {
+  return `---\nname: ${name}\ndescription: ${description}\n---\nbody`
+}
+
+let fetchMock
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('listSkills — happy path', () => {
+  it('lists folders, fetches each SKILL.md, and returns the slim catalog shape', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { type: 'dir', name: 'grill-me' },
+          { type: 'dir', name: 'to-prd' },
+        ])
+      }
+      if (url === SKILL_URL('grill-me')) {
+        return textResponse(frontmatter('grill-me', 'Interview the user'))
+      }
+      if (url === SKILL_URL('to-prd')) {
+        return textResponse(frontmatter('to-prd', 'Turn context into a PRD'))
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+
+    const skills = await listSkills()
+
+    expect(skills).toEqual([
+      {
+        slug: 'grill-me',
+        name: 'grill-me',
+        description: 'Interview the user',
+        sourceUrl: 'https://github.com/lucasfe/skills/tree/main/grill-me',
+      },
+      {
+        slug: 'to-prd',
+        name: 'to-prd',
+        description: 'Turn context into a PRD',
+        sourceUrl: 'https://github.com/lucasfe/skills/tree/main/to-prd',
+      },
+    ])
+  })
+
+  it('uses the GitHub Contents API URL with the JSON accept header for the listing call', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+
+    await listSkills()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      LIST_URL,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: 'application/vnd.github+json' }),
+      }),
+    )
+  })
+
+  it('does not send an Authorization header when no token is provided (v1)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+
+    await listSkills()
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers.Authorization).toBeUndefined()
+  })
+})
+
+describe('listSkills — filtering', () => {
+  it('drops non-directory entries (e.g. a top-level README.md)', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { type: 'file', name: 'README.md' },
+          { type: 'file', name: 'LICENSE' },
+          { type: 'dir', name: 'tdd' },
+        ])
+      }
+      if (url === SKILL_URL('tdd')) {
+        return textResponse(frontmatter('tdd', 'Test-driven development'))
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+
+    const skills = await listSkills()
+
+    expect(skills).toHaveLength(1)
+    expect(skills[0].slug).toBe('tdd')
+    expect(fetchMock).not.toHaveBeenCalledWith(SKILL_URL('README.md'), expect.anything())
+  })
+
+  it('skips a folder without a SKILL.md (404) instead of crashing the catalog', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { type: 'dir', name: 'has-skill' },
+          { type: 'dir', name: 'orphan' },
+        ])
+      }
+      if (url === SKILL_URL('has-skill')) {
+        return textResponse(frontmatter('has-skill', 'A real skill'))
+      }
+      if (url === SKILL_URL('orphan')) {
+        return new Response('Not Found', { status: 404 })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+
+    const skills = await listSkills()
+
+    expect(skills.map((s) => s.slug)).toEqual(['has-skill'])
+  })
+
+  it('skips a SKILL.md without frontmatter (consistent with the loader behavior)', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { type: 'dir', name: 'good' },
+          { type: 'dir', name: 'no-frontmatter' },
+        ])
+      }
+      if (url === SKILL_URL('good')) {
+        return textResponse(frontmatter('good', 'Good skill'))
+      }
+      if (url === SKILL_URL('no-frontmatter')) {
+        return textResponse('# just a heading\n\nbody only, no frontmatter')
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+
+    const skills = await listSkills()
+
+    expect(skills.map((s) => s.slug)).toEqual(['good'])
+  })
+
+  it('skips a SKILL.md whose frontmatter is missing name or description', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { type: 'dir', name: 'no-name' },
+          { type: 'dir', name: 'no-desc' },
+        ])
+      }
+      if (url === SKILL_URL('no-name')) {
+        return textResponse('---\ndescription: only a description\n---\nbody')
+      }
+      if (url === SKILL_URL('no-desc')) {
+        return textResponse('---\nname: only-a-name\n---\nbody')
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+
+    const skills = await listSkills()
+
+    expect(skills).toEqual([])
+  })
+})
+
+describe('listSkills — error surfacing', () => {
+  it('throws a SkillsApiError on 403 (rate limit) when listing folders', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('rate limited', { status: 403 }),
+    )
+
+    await expect(listSkills()).rejects.toBeInstanceOf(SkillsApiError)
+    await expect(listSkills()).rejects.toMatchObject({ status: 403 })
+  })
+
+  it('throws a SkillsApiError on 5xx when listing folders', async () => {
+    fetchMock.mockResolvedValue(new Response('boom', { status: 503 }))
+
+    await expect(listSkills()).rejects.toBeInstanceOf(SkillsApiError)
+    await expect(listSkills()).rejects.toMatchObject({ status: 503 })
+  })
+
+  it('throws a SkillsApiError on 403 when fetching an individual SKILL.md', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([{ type: 'dir', name: 'limited' }])
+      }
+      return new Response('rate limited', { status: 403 })
+    })
+
+    await expect(listSkills()).rejects.toBeInstanceOf(SkillsApiError)
+  })
+
+  it('throws a SkillsApiError when the listing response is not an array', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ message: 'unexpected' }))
+
+    await expect(listSkills()).rejects.toBeInstanceOf(SkillsApiError)
+  })
+})


### PR DESCRIPTION
Closes #51

## Summary

Lays the testable foundation for the upcoming Skills section. Adds two pure modules under `src/lib/` that no caller wires up yet — the next slice (#52) mounts the `/skills` page on top of them.

- **`src/lib/skillFrontmatter.js`** — pure YAML frontmatter parser. Returns `{ name, description, body, ...rest } | null`. Returns `null` for missing/unterminated frontmatter (graceful, never throws). CRLF and leading whitespace / BOM tolerated. Carries extra optional keys through.
- **`src/lib/skills.js`** — GitHub Contents API client for `lucasfe/skills`. Lists root folders, fetches `SKILL.md` per folder, parses frontmatter, returns the slim `{ slug, name, description, sourceUrl }` shape ready for cards. Filters non-directory entries. Skips folders without a `SKILL.md` and folders whose `SKILL.md` lacks valid `name`/`description` frontmatter. Surfaces 403 (rate limit) and 5xx as a typed `SkillsApiError`. Unauthenticated in v1; the internal helpers already accept an optional `token` so a future Edge Function proxy is a one-line change.

## Test plan

- [x] `npm test` — 150 passing (21 new, 129 existing). New suites: `skillFrontmatter.test.js` (10) and `skills.test.js` (11).
- [x] `npm run lint` — 0 errors (23 pre-existing warnings).
- [x] No caller imports the new modules yet — user-visible app is unchanged.
- [x] Out-of-scope guard respected: `App.jsx`, `Header.jsx`, `agents.json`, `agentContent.js`, `ralph.sh`, `start-ralph.sh`, `PROMPT.md`, `.claude/`, `vercel.json`, and `packages/` are untouched.