### PR TITLE
feat: agent selector next to chat bar in AI Assistant (#79)

### DIFF
--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
-import { Sparkles, X, Send, Loader2, Maximize2, Minimize2 } from 'lucide-react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { Sparkles, X, Send, Loader2, Maximize2, Minimize2, Bot, ChevronDown } from 'lucide-react'
 import { startSession, isOrchestrationConfigured } from '../lib/orchestration'
 import Markdown from '../lib/markdown'
 import AgentDraftCard from './AgentDraftCard'

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -901,6 +901,125 @@ function countMissingRequired(plan, stepAnswers) {
   return count
 }
 
+// Compact dropdown that lets the user pick which agent should drive the
+// next message. Renders next to the chat input. The default ("Auto") falls
+// back to the server-side router/planner that classifies the message and
+// chooses a path. Picking a specific agent forwards `selectedAgentId` to
+// the orchestration session, which short-circuits the router on the server.
+function AgentSelector({ agents, selectedAgentId, onChange, disabled }) {
+  const [open, setOpen] = useState(false)
+  const buttonRef = useRef(null)
+  const menuRef = useRef(null)
+
+  const sortedAgents = useMemo(() => {
+    if (!Array.isArray(agents)) return []
+    return [...agents].sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+  }, [agents])
+
+  const selected = useMemo(
+    () => sortedAgents.find((a) => a.id === selectedAgentId) || null,
+    [sortedAgents, selectedAgentId],
+  )
+
+  useEffect(() => {
+    if (!open) return
+    const handleClickOutside = (e) => {
+      if (
+        !buttonRef.current?.contains(e.target) &&
+        !menuRef.current?.contains(e.target)
+      ) {
+        setOpen(false)
+      }
+    }
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('mousedown', handleClickOutside)
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('mousedown', handleClickOutside)
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  const label = selected ? selected.name : 'Auto'
+
+  return (
+    <div className="relative shrink-0">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label="Select agent"
+        title={selected ? `Agent: ${selected.name}` : 'Auto (router decides)'}
+        className="flex items-center gap-1 px-2 py-1.5 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card border border-transparent hover:border-border-subtle transition-colors disabled:opacity-40 disabled:cursor-not-allowed max-w-[140px]"
+      >
+        <Bot size={14} />
+        <span className="truncate">{label}</span>
+        <ChevronDown size={12} className="shrink-0 opacity-70" />
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          role="listbox"
+          aria-label="Agent options"
+          className="absolute bottom-full left-0 mb-2 w-64 max-h-72 overflow-y-auto bg-bg-sidebar border border-border-subtle rounded-xl shadow-xl z-10 py-1"
+        >
+          <button
+            type="button"
+            role="option"
+            aria-selected={selectedAgentId == null}
+            onClick={() => {
+              onChange(null)
+              setOpen(false)
+            }}
+            className={`w-full text-left px-3 py-2 text-xs hover:bg-bg-input transition-colors ${
+              selectedAgentId == null
+                ? 'text-text-primary font-medium'
+                : 'text-text-secondary'
+            }`}
+          >
+            <div>Auto</div>
+            <div className="text-[10px] text-text-muted">
+              Let the router pick the best path
+            </div>
+          </button>
+          {sortedAgents.length > 0 && (
+            <div className="my-1 mx-3 border-t border-border-subtle" />
+          )}
+          {sortedAgents.map((agent) => (
+            <button
+              key={agent.id}
+              type="button"
+              role="option"
+              aria-selected={selectedAgentId === agent.id}
+              onClick={() => {
+                onChange(agent.id)
+                setOpen(false)
+              }}
+              className={`w-full text-left px-3 py-2 text-xs hover:bg-bg-input transition-colors ${
+                selectedAgentId === agent.id
+                  ? 'text-text-primary font-medium'
+                  : 'text-text-secondary'
+              }`}
+            >
+              <div className="truncate">{agent.name}</div>
+              {agent.category && (
+                <div className="text-[10px] text-text-muted truncate">
+                  {agent.category}
+                </div>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // Serialize a previous assistant tool call as a short text summary, so the
 // next outgoing request gives Claude enough context to iterate without having
 // to re-send the full tool_use block (which would require tool_result).

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -23,6 +23,9 @@ export default function AiAssistant({ open, onClose }) {
   const [input, setInput] = useState('')
   const [isStreaming, setIsStreaming] = useState(false)
   const [fullscreen, setFullscreen] = useState(false)
+  // null means "Auto" (let the router classify and pick the best path).
+  // A string is the explicit agent.id the user wants to drive the conversation.
+  const [selectedAgentId, setSelectedAgentId] = useState(null)
   // Which assistant message (by index) is currently opened in the side
   // review panel. null means no panel is open. One panel at a time.
   const [reviewPanelMsgIdx, setReviewPanelMsgIdx] = useState(null)

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -695,17 +695,23 @@ export default function AiAssistant({ open, onClose }) {
           className="border-t border-border-subtle p-4 shrink-0"
         >
           <div
-            className={`flex items-end gap-2 bg-bg-input border border-border-subtle rounded-xl px-3 py-2 focus-within:border-border-hover transition-colors ${
+            className={`flex items-end gap-2 bg-bg-input border border-border-subtle rounded-xl px-2 py-2 focus-within:border-border-hover transition-colors ${
               fullscreen ? 'max-w-3xl mx-auto' : ''
             }`}
           >
+            <AgentSelector
+              agents={agents}
+              selectedAgentId={selectedAgentId}
+              onChange={setSelectedAgentId}
+              disabled={isStreaming}
+            />
             <input
               ref={inputRef}
               type="text"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder="Type a message..."
-              className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none py-1.5"
+              className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none py-1.5 min-w-0"
               disabled={isStreaming}
             />
             <button

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -434,6 +434,7 @@ export default function AiAssistant({ open, onClose }) {
       messages: outgoing,
       agents,
       tools,
+      selectedAgentId,
     })
     sessionRef.current = { session, messageIdx: assistantIdx }
     subscribeSession(session, assistantIdx)

--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -198,6 +198,63 @@ describe('AiAssistant', () => {
     expect(call.agents.find((a) => a.id === 'frontend-developer')).toBeTruthy()
   })
 
+  it('forwards selectedAgentId to startSession when an agent is picked next to the chat bar', async () => {
+    scriptSession([
+      { type: 'router.classified', mode: 'chat' },
+      { type: 'chat.text', value: 'hi from frontend' },
+      { type: 'chat.done' },
+    ])
+
+    const user = userEvent.setup()
+    renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+    // Wait for agents to load so the selector lists at least one option.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Select agent')).toBeInTheDocument()
+    })
+
+    // Open the selector and pick the agent.
+    await user.click(screen.getByLabelText('Select agent'))
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('option', { name: /Frontend Developer/ }))
+
+    // The trigger now reflects the selection.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Select agent').textContent).toMatch(/Frontend Developer/)
+    })
+
+    await user.type(screen.getByPlaceholderText('Type a message...'), 'oi')
+    await user.click(screen.getByLabelText('Send message'))
+
+    await waitFor(() => {
+      expect(orchestrationMock.startSession).toHaveBeenCalled()
+    })
+    const call = orchestrationMock.startSession.mock.calls[0][0]
+    expect(call.selectedAgentId).toBe('frontend-developer')
+  })
+
+  it('defaults selectedAgentId to null when the user keeps "Auto"', async () => {
+    scriptSession([
+      { type: 'chat.text', value: 'auto reply' },
+      { type: 'chat.done' },
+    ])
+
+    const user = userEvent.setup()
+    renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+    await user.type(screen.getByPlaceholderText('Type a message...'), 'oi')
+    await user.click(screen.getByLabelText('Send message'))
+
+    await waitFor(() => {
+      expect(orchestrationMock.startSession).toHaveBeenCalled()
+    })
+    const call = orchestrationMock.startSession.mock.calls[0][0]
+    expect(call.selectedAgentId).toBeNull()
+    expect(screen.getByLabelText('Select agent').textContent).toMatch(/Auto/)
+  })
+
   it('shows an error bubble when the session emits chat.error', async () => {
     scriptSession([{ type: 'chat.error', error: 'boom' }])
 

--- a/src/lib/orchestration/engine.js
+++ b/src/lib/orchestration/engine.js
@@ -89,6 +89,7 @@ export function startSession({
   plan,
   originalTask,
   stepAnswers,
+  selectedAgentId,
 }) {
   const session = new Session({ mode })
   session.status = SESSION_STATUS.STREAMING
@@ -105,6 +106,7 @@ export function startSession({
     plan,
     originalTask,
     stepAnswers,
+    selectedAgentId,
     signal: session.signal,
     onEvent: (evt) => {
       // Ensure every event carries the session_id the caller expects.

--- a/src/lib/orchestration/stream.js
+++ b/src/lib/orchestration/stream.js
@@ -95,6 +95,7 @@ export async function streamOrchestration({
         plan: plan || undefined,
         original_task: originalTask || undefined,
         step_answers: stepAnswers || undefined,
+        selected_agent_id: selectedAgentId || undefined,
       }),
       signal,
     })

--- a/src/lib/orchestration/stream.js
+++ b/src/lib/orchestration/stream.js
@@ -45,6 +45,7 @@ export async function streamOrchestration({
   plan,
   originalTask,
   stepAnswers,
+  selectedAgentId,
   signal,
   onEvent,
 }) {

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -703,6 +703,7 @@ Deno.serve(async (req: Request) => {
     plan?: { steps?: unknown[] }
     original_task?: string
     step_answers?: Record<string, Record<string, string>>
+    selected_agent_id?: string
   }
   try {
     body = await req.json()

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -816,9 +816,13 @@ Deno.serve(async (req: Request) => {
         }
 
         // Router: classify the latest user message unless this is a refinement
-        // call (which is always a task re-plan by definition).
+        // call (which is always a task re-plan by definition). When the user
+        // explicitly picked an agent next to the chat bar, skip the router
+        // entirely and force the chat branch with that agent's persona.
         let classification: 'chat' | 'crud' | 'task'
-        if (isRefinement) {
+        if (selectedAgent) {
+          classification = 'chat'
+        } else if (isRefinement) {
           classification = 'task'
         } else if (lastUser) {
           classification = await classifyIntent(lastUser.content, apiKey)
@@ -826,14 +830,16 @@ Deno.serve(async (req: Request) => {
           classification = 'chat'
         }
         console.log(
-          `[router] session=${sessionId} mode=${mode} classified=${classification} refinement=${isRefinement}`,
+          `[router] session=${sessionId} mode=${mode} classified=${classification} refinement=${isRefinement} selected_agent=${selectedAgent?.id ?? 'none'}`,
         )
         emit('router.classified', { mode: classification })
 
         // Route: task → planner, everything else → chat branch.
         // `mode: 'planned'` forces the planner regardless of classification.
+        // An explicit agent selection always wins — never go to the planner.
         const goPlanner =
-          mode === 'planned' || classification === 'task' || isRefinement
+          !selectedAgent &&
+          (mode === 'planned' || classification === 'task' || isRefinement)
 
         if (goPlanner) {
           await runPlannerBranch(emit, {

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -177,6 +177,17 @@ function buildSystemPrompt(agentsContext: unknown): string {
   return `${BASE_SYSTEM_PROMPT}\n\n## Existing Agents\n\n${lines.join('\n')}`
 }
 
+// When the user explicitly picks an agent next to the chat bar, we drop the
+// hub-assistant persona and let that agent drive the conversation directly.
+// The agent's `content` (its full markdown system prompt) becomes the system
+// prompt; the router/planner is bypassed for the rest of this turn.
+function buildSelectedAgentSystemPrompt(agent: any): string {
+  if (!agent || typeof agent !== 'object') return BASE_SYSTEM_PROMPT
+  const content = typeof agent.content === 'string' ? agent.content.trim() : ''
+  const header = `You are "${agent.name || agent.id}", an AI agent inside Lucas AI Hub. Reply in the same language the user used. Stay in character — do not mention this hub's other agents unless the user asks.`
+  return content ? `${header}\n\n${content}` : header
+}
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -759,7 +759,16 @@ Deno.serve(async (req: Request) => {
   const toolsContextRaw = Array.isArray(body.tools_context)
     ? (body.tools_context as any[])
     : []
-  const systemPrompt = buildSystemPrompt(agentsContextRaw)
+  const selectedAgentId =
+    typeof body.selected_agent_id === 'string' && body.selected_agent_id
+      ? body.selected_agent_id
+      : null
+  const selectedAgent = selectedAgentId
+    ? agentsContextRaw.find((a: any) => a && a.id === selectedAgentId) || null
+    : null
+  const systemPrompt = selectedAgent
+    ? buildSelectedAgentSystemPrompt(selectedAgent)
+    : buildSystemPrompt(agentsContextRaw)
   const lastUser = [...cleanMessages].reverse().find((m) => m.role === 'user')
   const isRefinement = Boolean(
     body.refinement && (body.refinement.previous_plan || body.refinement.instructions),


### PR DESCRIPTION
Closes #79

## Summary

Restores explicit agent selection next to the chat bar in the AI Assistant.

- New compact dropdown left of the input lets the user pick any agent from the hub (or stay on "Auto").
- "Auto" preserves today's behavior — the Haiku router classifies the message and routes to chat/crud/task.
- Picking a specific agent forwards `selectedAgentId` through the orchestration session; the `chat` Edge Function bypasses the router and runs the chat branch with that agent's full markdown system prompt as the persona.
- The selection persists across messages until cleared.

## Files

- `src/components/AiAssistant.jsx` — adds `selectedAgentId` state and an `AgentSelector` dropdown inside the input bar.
- `src/lib/orchestration/engine.js`, `src/lib/orchestration/stream.js` — pass `selectedAgentId` → request body field `selected_agent_id`.
- `supabase/functions/chat/index.ts` — when `selected_agent_id` matches an agent in the request's `agents_context`, swap the system prompt for that agent's `content` and force the chat branch (skip router and planner).
- `src/components/AiAssistant.test.jsx` — covers the "Auto" default and the explicit-pick path.

## Test plan

- [x] `npm test` (177 passed, including 2 new)
- [x] `npm run test:functions` (41 passed)
- [x] `npm run lint` (0 errors)