### PR TITLE
Ralph: send WhatsApp message on startup (#84)

### DIFF
--- a/packages/ralph/CHANGELOG.md
+++ b/packages/ralph/CHANGELOG.md
@@ -55,6 +55,13 @@ and shipped across slices #14–#23.
   `./ralph-notify.sh` hook called with
   `(msg, status, ok_count, fail_count, duration_min)`; stdout
   always prints the summary. (slice #9)
+- Startup WhatsApp ping: after `ralph start` successfully launches
+  the tmux session, sends a WhatsApp notification announcing Ralph
+  is online. Reuses the existing `CALLMEBOT_KEY` / `WHATSAPP_PHONE`
+  credentials; the message body is configurable via
+  `RALPH_STARTUP_MESSAGE` (defaults to a short "Ralph started" line).
+  Skipped silently when credentials are absent; failures log a
+  warning and never abort startup.
 - Update check: `ralph start` runs `npm view @lucasfe/ralph version`
   with a 5s timeout, warns once per release, and stores
   `last_seen_release` in `.ralph/state.json` to dedupe the warning.

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -81,8 +81,12 @@ export async function startCommand({
   }
   const callmebotKey = env.CALLMEBOT_KEY ?? process.env.CALLMEBOT_KEY ?? ''
   const whatsappPhone = env.WHATSAPP_PHONE ?? process.env.WHATSAPP_PHONE ?? ''
+  const startupMessage =
+    env.RALPH_STARTUP_MESSAGE ??
+    process.env.RALPH_STARTUP_MESSAGE ??
+    DEFAULT_STARTUP_MESSAGE
   if (!callmebotKey || !whatsappPhone) {
-    out('ℹ️  CALLMEBOT_KEY/WHATSAPP_PHONE ausentes; notificação WhatsApp será pulada.')
+    out('ℹ️  CALLMEBOT_KEY/WHATSAPP_PHONE ausentes; notificações WhatsApp serão puladas.')
   }
 
   // 4. gh authenticated

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -39,6 +39,7 @@ export async function startCommand({
   update = checkForUpdate,
   readSt = readState,
   writeSt = writeState,
+  sendWa = sendWhatsappMessage,
 } = {}) {
   const out = (msg) => stdout.write(msg + '\n')
   const err = (msg) => stderr.write(msg + '\n')

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -224,6 +224,21 @@ export async function startCommand({
   out('   Listar:         tmux ls')
   out(`   Matar:          tmux kill-session -t ${TMUX_SESSION}`)
   out('   Logs:           logs/ralph-issue-*.log')
+
+  // Startup notification — best effort, never blocks startup or surfaces stack traces.
+  if (callmebotKey && whatsappPhone) {
+    const waResult = await sendWa({
+      phone: whatsappPhone,
+      apiKey: callmebotKey,
+      message: startupMessage,
+    })
+    if (waResult?.ok) {
+      out('📲 Notificação WhatsApp de startup enviada.')
+    } else {
+      out(`⚠️  Notificação WhatsApp de startup falhou: ${waResult?.reason ?? 'unknown'}.`)
+    }
+  }
+
   return { exitCode: 0, started: true, count: Number(count) }
 }
 

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -11,10 +11,12 @@ import { checkDeps } from '../deps.js'
 import { detectPlatform } from '../platform.js'
 import { readState, writeState } from '../state.js'
 import { checkForUpdate } from '../update-check.js'
+import { sendWhatsappMessage } from '../utils/whatsapp.js'
 
 const TMUX_SESSION = 'ralph'
 const SEARCH_QUERY =
   'state:open -label:claude-working -label:claude-failed -label:do-not-ralph'
+const DEFAULT_STARTUP_MESSAGE = '🟢 Ralph started and is active.'
 
 class StartAbort extends Error {
   constructor(message, exitCode = 1) {

--- a/packages/ralph/lib/utils/whatsapp.js
+++ b/packages/ralph/lib/utils/whatsapp.js
@@ -1,0 +1,37 @@
+const ENDPOINT = 'https://api.callmebot.com/whatsapp.php'
+const DEFAULT_TIMEOUT_MS = 5000
+
+export async function sendWhatsappMessage({
+  phone,
+  apiKey,
+  message,
+  fetchImpl = typeof fetch === 'function' ? fetch : null,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  if (!phone || !apiKey) return { ok: false, reason: 'missing_credentials' }
+  if (!message) return { ok: false, reason: 'missing_message' }
+  if (typeof fetchImpl !== 'function') return { ok: false, reason: 'missing_fetch' }
+
+  const url =
+    `${ENDPOINT}?phone=${encodeURIComponent(phone)}` +
+    `&text=${encodeURIComponent(message)}` +
+    `&apikey=${encodeURIComponent(apiKey)}`
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetchImpl(url, { signal: controller.signal })
+    if (!res || !res.ok) {
+      const status = res?.status ?? 'unknown'
+      return { ok: false, reason: `http_${status}` }
+    }
+    return { ok: true }
+  } catch (err) {
+    const reason = err?.name === 'AbortError' ? 'timeout' : 'network_error'
+    return { ok: false, reason }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export { ENDPOINT as CALLMEBOT_ENDPOINT, DEFAULT_TIMEOUT_MS }

--- a/packages/ralph/lib/utils/whatsapp.test.js
+++ b/packages/ralph/lib/utils/whatsapp.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { sendWhatsappMessage, CALLMEBOT_ENDPOINT } from './whatsapp.js'
+
+function makeFetch(handler) {
+  const calls = []
+  const fn = async (url, opts) => {
+    calls.push({ url, opts })
+    return handler(url, opts)
+  }
+  fn.calls = calls
+  return fn
+}
+
+describe('sendWhatsappMessage', () => {
+  it('returns missing_credentials when phone or apiKey is empty', async () => {
+    const noop = makeFetch(() => ({ ok: true, status: 200 }))
+    expect(await sendWhatsappMessage({ phone: '', apiKey: 'k', message: 'm', fetchImpl: noop }))
+      .toEqual({ ok: false, reason: 'missing_credentials' })
+    expect(await sendWhatsappMessage({ phone: '+1', apiKey: '', message: 'm', fetchImpl: noop }))
+      .toEqual({ ok: false, reason: 'missing_credentials' })
+    expect(noop.calls).toHaveLength(0)
+  })
+
+  it('returns missing_message when message is empty', async () => {
+    const noop = makeFetch(() => ({ ok: true, status: 200 }))
+    const res = await sendWhatsappMessage({
+      phone: '+1',
+      apiKey: 'k',
+      message: '',
+      fetchImpl: noop,
+    })
+    expect(res).toEqual({ ok: false, reason: 'missing_message' })
+    expect(noop.calls).toHaveLength(0)
+  })
+
+  it('returns missing_fetch when no fetch implementation is available', async () => {
+    const res = await sendWhatsappMessage({
+      phone: '+1',
+      apiKey: 'k',
+      message: 'hi',
+      fetchImpl: null,
+    })
+    expect(res).toEqual({ ok: false, reason: 'missing_fetch' })
+  })
+
+  it('builds the CallMeBot URL with url-encoded params and reports ok on 2xx', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: true, status: 200 }))
+    const res = await sendWhatsappMessage({
+      phone: '+5511999999999',
+      apiKey: 'secret-key',
+      message: 'Ralph started & is active',
+      fetchImpl,
+    })
+    expect(res).toEqual({ ok: true })
+    expect(fetchImpl.calls).toHaveLength(1)
+    const url = fetchImpl.calls[0].url
+    expect(url.startsWith(CALLMEBOT_ENDPOINT + '?')).toBe(true)
+    expect(url).toContain('phone=%2B5511999999999')
+    expect(url).toContain('text=Ralph%20started%20%26%20is%20active')
+    expect(url).toContain('apikey=secret-key')
+  })
+
+  it('returns http_<status> when CallMeBot responds with a non-ok status', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: false, status: 500 }))
+    const res = await sendWhatsappMessage({
+      phone: '+1',
+      apiKey: 'k',
+      message: 'hi',
+      fetchImpl,
+    })
+    expect(res).toEqual({ ok: false, reason: 'http_500' })
+  })
+
+  it('returns network_error when fetch rejects', async () => {
+    const fetchImpl = makeFetch(() => {
+      throw new Error('boom')
+    })
+    const res = await sendWhatsappMessage({
+      phone: '+1',
+      apiKey: 'k',
+      message: 'hi',
+      fetchImpl,
+    })
+    expect(res).toEqual({ ok: false, reason: 'network_error' })
+  })
+
+  it('returns timeout when fetch is aborted by the timeout signal', async () => {
+    const fetchImpl = (_url, opts) =>
+      new Promise((_resolve, reject) => {
+        opts.signal.addEventListener('abort', () => {
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+        })
+      })
+    const res = await sendWhatsappMessage({
+      phone: '+1',
+      apiKey: 'k',
+      message: 'hi',
+      fetchImpl,
+      timeoutMs: 5,
+    })
+    expect(res).toEqual({ ok: false, reason: 'timeout' })
+  })
+})

--- a/packages/ralph/templates/env.local.example
+++ b/packages/ralph/templates/env.local.example
@@ -1,8 +1,12 @@
 # Copy to `.env.local` and fill in the values to receive WhatsApp
-# notifications via CallMeBot when Ralph finishes a run.
+# notifications via CallMeBot when Ralph starts and when it finishes a run.
 #
 # Get your key by following:
 #   https://www.callmebot.com/blog/free-api-whatsapp-messages/
 
 CALLMEBOT_KEY=
 WHATSAPP_PHONE=
+
+# Optional: customize the WhatsApp message sent when Ralph starts.
+# Defaults to "🟢 Ralph started and is active." when unset.
+# RALPH_STARTUP_MESSAGE=

--- a/packages/ralph/test/commands/start.test.js
+++ b/packages/ralph/test/commands/start.test.js
@@ -225,6 +225,132 @@ describe('startCommand', () => {
     expect(deps.exec.calls.some((c) => c.startsWith('npm view'))).toBe(false)
   })
 
+  it('sends WhatsApp startup notification with default message when credentials are present', async () => {
+    const deps = baseDeps()
+    const cwd = '/repo'
+    deps.exists = (p) => p.endsWith('.env.local')
+    deps.loadEnv = () => ({ CALLMEBOT_KEY: 'k', WHATSAPP_PHONE: '+1' })
+    const waCalls = []
+    deps.sendWa = async (args) => {
+      waCalls.push(args)
+      return { ok: true }
+    }
+    deps.exec = makeExec({
+      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph --limit 100 --json number -q . | length':
+        { exitCode: 0, stdout: '2', stderr: '' },
+      [`tmux new -d -s ralph cd '${cwd}' && bash '${RALPH_TEMPLATE}'`]: {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+    })
+    await startCommand({ ...deps, cwd })
+    expect(waCalls).toHaveLength(1)
+    expect(waCalls[0]).toEqual({
+      phone: '+1',
+      apiKey: 'k',
+      message: '🟢 Ralph started and is active.',
+    })
+    expect(deps.stdout.output()).toContain('Notificação WhatsApp de startup enviada.')
+  })
+
+  it('uses RALPH_STARTUP_MESSAGE override from .env.local when provided', async () => {
+    const deps = baseDeps()
+    const cwd = '/repo'
+    deps.exists = (p) => p.endsWith('.env.local')
+    deps.loadEnv = () => ({
+      CALLMEBOT_KEY: 'k',
+      WHATSAPP_PHONE: '+1',
+      RALPH_STARTUP_MESSAGE: 'custom hello',
+    })
+    const waCalls = []
+    deps.sendWa = async (args) => {
+      waCalls.push(args)
+      return { ok: true }
+    }
+    deps.exec = makeExec({
+      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph --limit 100 --json number -q . | length':
+        { exitCode: 0, stdout: '1', stderr: '' },
+      [`tmux new -d -s ralph cd '${cwd}' && bash '${RALPH_TEMPLATE}'`]: {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+    })
+    await startCommand({ ...deps, cwd })
+    expect(waCalls[0].message).toBe('custom hello')
+  })
+
+  it('skips WhatsApp startup notification when credentials are missing', async () => {
+    const deps = baseDeps()
+    const cwd = '/repo'
+    let waCalled = false
+    deps.sendWa = async () => {
+      waCalled = true
+      return { ok: true }
+    }
+    deps.exec = makeExec({
+      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph --limit 100 --json number -q . | length':
+        { exitCode: 0, stdout: '1', stderr: '' },
+      [`tmux new -d -s ralph cd '${cwd}' && bash '${RALPH_TEMPLATE}'`]: {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+    })
+    await startCommand({ ...deps, cwd })
+    expect(waCalled).toBe(false)
+    expect(deps.stdout.output()).toContain('notificações WhatsApp serão puladas')
+  })
+
+  it('logs a warning but does not abort when WhatsApp startup notification fails', async () => {
+    const deps = baseDeps()
+    const cwd = '/repo'
+    deps.exists = (p) => p.endsWith('.env.local')
+    deps.loadEnv = () => ({ CALLMEBOT_KEY: 'k', WHATSAPP_PHONE: '+1' })
+    deps.sendWa = async () => ({ ok: false, reason: 'http_500' })
+    deps.exec = makeExec({
+      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph --limit 100 --json number -q . | length':
+        { exitCode: 0, stdout: '1', stderr: '' },
+      [`tmux new -d -s ralph cd '${cwd}' && bash '${RALPH_TEMPLATE}'`]: {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      },
+    })
+    const result = await startCommand({ ...deps, cwd })
+    expect(result.started).toBe(true)
+    expect(deps.stdout.output()).toContain('Notificação WhatsApp de startup falhou: http_500')
+  })
+
   it('does not print warning or write state when remote version is not newer', async () => {
     const deps = baseDeps()
     const cwd = '/repo'

--- a/packages/ralph/test/commands/start.test.js
+++ b/packages/ralph/test/commands/start.test.js
@@ -319,7 +319,16 @@ describe('startCommand', () => {
         stderr: '',
       },
     })
-    await startCommand({ ...deps, cwd })
+    const savedKey = process.env.CALLMEBOT_KEY
+    const savedPhone = process.env.WHATSAPP_PHONE
+    delete process.env.CALLMEBOT_KEY
+    delete process.env.WHATSAPP_PHONE
+    try {
+      await startCommand({ ...deps, cwd })
+    } finally {
+      if (savedKey !== undefined) process.env.CALLMEBOT_KEY = savedKey
+      if (savedPhone !== undefined) process.env.WHATSAPP_PHONE = savedPhone
+    }
     expect(waCalled).toBe(false)
     expect(deps.stdout.output()).toContain('notificações WhatsApp serão puladas')
   })


### PR DESCRIPTION
Closes #84

## Summary

Adds a startup WhatsApp notification to `ralph start`. After the tmux session launches successfully, Ralph sends a CallMeBot WhatsApp ping announcing it is online — reusing the existing `CALLMEBOT_KEY` / `WHATSAPP_PHONE` secrets that already power the end-of-run notification.

- New module `packages/ralph/lib/utils/whatsapp.js` — narrow CallMeBot HTTP client using native `fetch`, dependency-injected for tests, never throws (returns `{ ok, reason }`), 5s abort timeout.
- `startCommand` calls it at the very end of a successful launch. Failures log a warning but do not abort startup. Skipped silently when credentials are absent.
- Message body is configurable via `RALPH_STARTUP_MESSAGE` (`.env.local` or shell env). Default: `"🟢 Ralph started and is active."`
- `templates/env.local.example` and CHANGELOG updated; `.env.local.example` at the project root is intentionally left untouched (matches the no-touch list).

## Test plan

- [x] `npm test` (Ralph package) — 136 passing, including 7 new `whatsapp` unit tests and 4 new `startCommand` integration tests covering: success path, env-var override, missing creds skip, and HTTP-failure warning
- [x] `npm test` (frontend) — 177 passing
- [x] `npm run lint` — 0 errors (warnings unchanged)