### PR TITLE
docs: document main branch protection for pr-title gate (#104)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,33 @@ GitHub Actions reserves the `GITHUB_` secret/variable prefix, so the keys here a
 - **CI pipeline** (`.github/workflows/ci.yml`): Lint → Test → Build on every push, plus a `pr-title` job that gates `dev → main` PRs on a Conventional Commits title
 - **Auto-PR** (`.github/workflows/auto-pr.yml`): Creates/updates a single PR from `dev → main` on every push
 
+### Branch protection on `main`
+
+The `main` branch is protected by a GitHub branch protection rule that requires the `PR Title` status check (produced by the `pr-title` job in `.github/workflows/ci.yml`) to pass before merge. This is what guarantees every squash-merge into `main` carries a Conventional Commits title — the precondition release-please relies on to bump the right SemVer segment.
+
+The rule is configured manually (one-time) under **Settings → Branches → Branch protection rules → `main`**:
+
+1. Branch name pattern: `main`.
+2. Enable **Require status checks to pass before merging**.
+3. Add `PR Title` to the list of required status checks (it appears once the `pr-title` job has run at least once on a PR).
+4. Leave **Require branches to be up to date before merging** OFF (no need to force-rebase before merge).
+5. Save.
+
+Equivalent one-shot via the API (requires admin token):
+
+```bash
+gh api -X PUT repos/lucasfe/agenthub/branches/main/protection --input - <<'JSON'
+{
+  "required_status_checks": { "strict": false, "contexts": ["PR Title"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+```
+
+To verify the rule is in place: `gh api repos/lucasfe/agenthub/branches/main/protection --jq '.required_status_checks.contexts'` should return `["PR Title"]`.
+
 ## Releasing Ralph
 
 `@lucasfe/ralph` (the `packages/ralph/` package) is published to npm by an automated [release-please](https://github.com/googleapis/release-please) pipeline. There is no manual version bump, no manual `CHANGELOG.md` edit, and no manual `git tag`. The flow is:


### PR DESCRIPTION
Closes #104

## Summary

Slice 1 of the release-please pipeline (parent #95): documents the manual branch protection rule that backs the existing `pr-title` CI job and verifies the rule is active on `main`.

The `pr-title` workflow job and the existing CLAUDE.md mention of the gate were already merged with #106. This slice closes the loop by:

1. **Configuring branch protection on `main` via API** so the `PR Title` status check is required before merge. Verified with:
   ```
   gh api repos/lucasfe/agenthub/branches/main/protection --jq '.required_status_checks.contexts'
   → ["PR Title"]
   ```
2. **Adding a `Branch protection on main` subsection** to `CLAUDE.md` with both the UI step-list and the equivalent API one-shot, plus a verification command — so the rule can be reproduced or audited later.

## Manual configuration step-list (already applied)

Equivalent UI flow under **Settings → Branches → Branch protection rules → `main`**:

1. Branch name pattern: `main`.
2. Enable **Require status checks to pass before merging**.
3. Add `PR Title` to the list of required status checks.
4. Leave **Require branches to be up to date before merging** OFF.
5. Save.

## Acceptance criteria

- [x] `pr-title` job exists on `pull_request` events with default Conventional Commits types (already in place from #106).
- [x] Branch protection on `main` requires the `PR Title` status check (verified via API call above).
- [x] `CLAUDE.md` documents the gate (existing mention) and now also documents the manual setup steps.
- [x] No other workflows modified.

## Test plan

- [x] `npm test` — 178/178 passing.
- [x] `npm run lint` — 0 errors.
- [x] Verify branch protection: `gh api repos/lucasfe/agenthub/branches/main/protection --jq '.required_status_checks.contexts'` returns `["PR Title"]`.
- [ ] Once this PR is squash-merged into `dev`, the next `dev → main` PR will be auto-opened with the squash title — confirming the gate fires on a non-conventional title (e.g. `dev → main`) and passes on a conventional one.