### PR TITLE
docs(ralph): document startup WhatsApp ping and RALPH_STARTUP_MESSAGE override

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,20 +1,8 @@
-# Copy to `.env.local` and fill in the values.
+# Copy to `.env.local` and fill in the values to receive WhatsApp
+# notifications via CallMeBot when Ralph finishes a run.
 #
-# --- App (Vite) ---
-#
-# Supabase project credentials. Required for auth + edge functions.
-VITE_SUPABASE_URL=
-VITE_SUPABASE_ANON_KEY=
-
-# Comma-separated list of email addresses allowed to access the app.
-# Empty or missing => no one is allowed in (fail-closed). Whitespace
-# and case are ignored: "Foo@X.com, bar@x.com" matches "foo@x.com".
-VITE_ALLOWED_EMAILS=
-
-# --- Ralph (loop runner) ---
-#
-# Optional. Used by ralph-notify.sh to send a WhatsApp ping via CallMeBot
-# when Ralph finishes a run. Get your key from:
+# Get your key by following:
 #   https://www.callmebot.com/blog/free-api-whatsapp-messages/
+
 CALLMEBOT_KEY=
 WHATSAPP_PHONE=

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,8 +1,20 @@
-# Copy to `.env.local` and fill in the values to receive WhatsApp
-# notifications via CallMeBot when Ralph finishes a run.
+# Copy to `.env.local` and fill in the values.
 #
-# Get your key by following:
-#   https://www.callmebot.com/blog/free-api-whatsapp-messages/
+# --- App (Vite) ---
+#
+# Supabase project credentials. Required for auth + edge functions.
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
 
+# Comma-separated list of email addresses allowed to access the app.
+# Empty or missing => no one is allowed in (fail-closed). Whitespace
+# and case are ignored: "Foo@X.com, bar@x.com" matches "foo@x.com".
+VITE_ALLOWED_EMAILS=
+
+# --- Ralph (loop runner) ---
+#
+# Optional. Used by ralph-notify.sh to send a WhatsApp ping via CallMeBot
+# when Ralph finishes a run. Get your key from:
+#   https://www.callmebot.com/blog/free-api-whatsapp-messages/
 CALLMEBOT_KEY=
 WHATSAPP_PHONE=

--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -77,9 +77,10 @@ The config is plain bash; edit it in any editor. On the next
 
 ## Notification setup
 
-Ralph posts a one-line summary at the end of every run. Stdout (visible
-via `tmux attach -t ralph`) is always populated; the other channels
-are opt-in.
+Ralph posts a one-line summary at the end of every run, and a startup
+ping when `ralph start` successfully launches the tmux session. Stdout
+(visible via `tmux attach -t ralph`) is always populated; the other
+channels are opt-in.
 
 ### WhatsApp via CallMeBot (built-in)
 
@@ -92,7 +93,19 @@ are opt-in.
    WHATSAPP_PHONE=<your-phone-with-country-code>
    ```
 3. `.env.local` is added to `.gitignore` automatically. Done — the next
-   run will message you when it finishes.
+   `ralph start` will message you when the loop boots, and again when
+   it finishes.
+
+To customize the startup message body (e.g. include the host name or
+environment), set `RALPH_STARTUP_MESSAGE` in `.env.local`:
+
+```bash
+RALPH_STARTUP_MESSAGE=🟢 Ralph started on prod-runner-1
+```
+
+When unset, the default `🟢 Ralph started and is active.` is used.
+Failures sending the startup ping log a warning and never abort
+`ralph start`; missing credentials skip the ping silently.
 
 [callmebot]: https://www.callmebot.com/blog/free-api-whatsapp-messages/
 


### PR DESCRIPTION
## Summary

The startup WhatsApp ping (already implemented and tested in `packages/ralph/lib/commands/start.js`) was not documented in the Ralph package README. Visitors could not discover the new behavior or the configurable `RALPH_STARTUP_MESSAGE` env var without reading the source.

## Changes

- Updates `packages/ralph/README.md` Notification setup section to mention the startup ping alongside the end-of-run summary.
- Documents `RALPH_STARTUP_MESSAGE` with an example value and the default fallback.
- Notes the failure semantics (silent skip when credentials are missing; warning-only when CallMeBot fails).

No code or test changes — the implementation already exists. CHANGELOG entry for this slice is already in place under `[0.1.0] - Unreleased`.

## Test plan

- [x] `npm test` (root) — 178 pass
- [x] `cd packages/ralph && npm test` — 136 pass
- [x] `npm run lint` — 0 errors

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)