### PR TITLE
fix(chat): bypass orchestration when an agent is explicitly selected

### DIFF
--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -816,14 +816,38 @@ Deno.serve(async (req: Request) => {
           return
         }
 
-        // Router: classify the latest user message unless this is a refinement
-        // call (which is always a task re-plan by definition). When the user
-        // explicitly picked an agent next to the chat bar, skip the router
-        // entirely and force the chat branch with that agent's persona.
-        let classification: 'chat' | 'crud' | 'task'
+        // Selected-agent mode: when the user explicitly picks an agent next
+        // to the chat bar, proxy the prompt directly to that agent — no
+        // classifier call, no planner, no orchestration hop. The chosen
+        // agent drives the conversation end-to-end with its own persona and
+        // tools. The router.classified event still fires (with the agent id
+        // attached) so consumers see the routing decision, but the bypass
+        // itself is unconditional and cannot fall through to the planner or
+        // the hub chat branch.
         if (selectedAgent) {
-          classification = 'chat'
-        } else if (isRefinement) {
+          console.log(
+            `[router] session=${sessionId} mode=${mode} direct=true selected_agent=${selectedAgent.id}`,
+          )
+          emit('router.classified', {
+            mode: 'chat',
+            selected_agent_id: selectedAgent.id,
+          })
+          await runSelectedAgentBranch(emit, {
+            agent: selectedAgent,
+            messages: cleanMessages,
+            systemPrompt,
+            agentsContext: agentsContextRaw,
+            toolsContext: toolsContextRaw,
+            apiKey,
+            userId,
+          })
+          return
+        }
+
+        // Router: classify the latest user message unless this is a refinement
+        // call (which is always a task re-plan by definition).
+        let classification: 'chat' | 'crud' | 'task'
+        if (isRefinement) {
           classification = 'task'
         } else if (lastUser) {
           classification = await classifyIntent(lastUser.content, apiKey)
@@ -831,20 +855,14 @@ Deno.serve(async (req: Request) => {
           classification = 'chat'
         }
         console.log(
-          `[router] session=${sessionId} mode=${mode} classified=${classification} refinement=${isRefinement} selected_agent=${selectedAgent?.id ?? 'none'}`,
+          `[router] session=${sessionId} mode=${mode} classified=${classification} refinement=${isRefinement}`,
         )
         emit('router.classified', { mode: classification })
 
         // Route: task → planner, everything else → chat branch.
         // `mode: 'planned'` forces the planner regardless of classification.
-        // An explicit agent selection always wins — never go to the planner.
-        // It also wins over the legacy chat branch: the selected-agent branch
-        // wires up the agent's own tools and runs them server-side, instead of
-        // exposing the hub-assistant tools (draft_agent / update_agent) to a
-        // persona that doesn't know what to do with them.
         const goPlanner =
-          !selectedAgent &&
-          (mode === 'planned' || classification === 'task' || isRefinement)
+          mode === 'planned' || classification === 'task' || isRefinement
 
         if (goPlanner) {
           await runPlannerBranch(emit, {
@@ -854,16 +872,6 @@ Deno.serve(async (req: Request) => {
             refinement: body.refinement,
             originalTask: lastUser?.content || '',
             apiKey,
-          })
-        } else if (selectedAgent) {
-          await runSelectedAgentBranch(emit, {
-            agent: selectedAgent,
-            messages: cleanMessages,
-            systemPrompt,
-            agentsContext: agentsContextRaw,
-            toolsContext: toolsContextRaw,
-            apiKey,
-            userId,
           })
         } else {
           await runChatBranch(emit, {


### PR DESCRIPTION
Closes #85

## Problem

When a user explicitly picks an agent next to the chat bar, the prompt
should land on that agent immediately. The previous flow short-circuited
the planner via a `!selectedAgent` guard but still walked the entire
orchestration code path: classification ladder, refinement check,
dispatcher fallthrough. The "skip orchestration" intent was scattered
across three conditions, and the router event misleadingly reported a
classification mode without naming the agent that was actually chosen.

## Fix

Restructure `supabase/functions/chat/index.ts` so the selected-agent
path is an explicit early return immediately after the execute-mode
guard. When `selected_agent_id` is set:

- No `classifyIntent` call (was already skipped, now structurally
  guaranteed — there is no code path back into the classifier).
- No planner branch, no chat-branch fallthrough.
- The `router.classified` event still fires for backward compatibility,
  but now carries `selected_agent_id` so consumers can see exactly
  which agent took the call.

Routing for the unselected case (Auto) is unchanged; the planner /
chat-branch dispatcher just no longer needs to special-case the
selected-agent escape.

## Tests

- `npm test` — 178 passed (frontend, no behavior change for Auto path).
- `npm run test:functions` — 47 passed (selectedAgentBranch suite still
  green; the upstream contract it depends on is unchanged).
- `npm run lint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)