### PR TITLE
fix(ralph): preserve user-authored files across init re-runs

### DIFF
--- a/packages/ralph/CHANGELOG.md
+++ b/packages/ralph/CHANGELOG.md
@@ -69,6 +69,15 @@ and shipped across slices #14–#23.
 - Vitest infrastructure with `memfs` for hermetic tests on
   `detect-stack`, `init`, `doctor`, `interpolate`, `update-check`,
   `state`, `paths`, and the start/stop/env utilities.
+- `ralph init --reset-prompt` flag for the rare case where the user
+  wants to wipe `PROMPT.md` back to the package template after editing
+  it. Default behavior is unchanged: `PROMPT.md` is preserved on
+  re-run. The skip message now includes the `--reset-prompt` hint so
+  users discover the opt-in. Tests in `lib/init.test.js` lock down the
+  user-authored vs Ralph-authored file split: `.env.local`,
+  `ralph-notify.sh`, `PROMPT.md` (without the flag), and
+  `ralph.config.sh` are guaranteed untouched on re-run, so a future
+  template-management refactor cannot silently overwrite credentials.
 
 ### Configuration
 

--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -53,6 +53,28 @@ a tmux session named `ralph`. Watch it live with `tmux attach -t ralph`,
 detach with `Ctrl+B` then `D`, or tail per-issue logs in
 `logs/ralph-issue-*.log`.
 
+## What survives an update
+
+`ralph init` and any future Ralph update mechanism (`npm i -g
+@lucasfe/ralph@latest`, re-run of `ralph init`, future `ralph upgrade`)
+treat user-authored config files as read-only. Running an update will
+never silently overwrite credentials, secrets, or your project notes.
+
+| File | Status on re-run | How to overwrite |
+| --- | --- | --- |
+| `.env.local` | **Never written or modified.** Ralph only writes `.env.local.example` (a template you copy from). | Edit by hand; Ralph stays out of it. |
+| `ralph-notify.sh` | **Never written or modified.** Ralph only writes `ralph-notify.sh.example`. | Edit by hand. |
+| `PROMPT.md` | Preserved on re-run; Ralph prints `PROMPT.md already exists — leaving it alone (pass --reset-prompt to overwrite)`. | `ralph init --reset-prompt` |
+| `ralph.config.sh` | Preserved on re-run. | Delete the file and re-run `ralph init`. |
+| `.claude/commands/ralph.md` | Preserved on re-run. | Delete the file and re-run `ralph init`. |
+| `.env.local.example` | Overwritten on every run (it is a template, not a credential store). | n/a |
+| `ralph-notify.sh.example` | Overwritten on every run (template). | n/a |
+| `.gitignore` | Ralph appends missing entries idempotently; existing lines are untouched. | n/a |
+
+The split is enforced by automated tests in
+`packages/ralph/lib/init.test.js`, so a future template-management
+refactor cannot silently break the invariant.
+
 ## Configuration reference
 
 `ralph init` writes `ralph.config.sh` at the repo root. It is meant to

--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -21,9 +21,10 @@ program
 program
   .command('init')
   .description('Initialize Ralph in the current project (config + templates + slash command)')
-  .action(async () => {
+  .option('--reset-prompt', 'Overwrite an existing PROMPT.md with the package template')
+  .action(async (opts) => {
     try {
-      await initCommand()
+      await initCommand({ resetPrompt: Boolean(opts.resetPrompt) })
     } catch (e) {
       if (e instanceof InitAbort) {
         process.exit(e.exitCode ?? 1)

--- a/packages/ralph/lib/commands/init.js
+++ b/packages/ralph/lib/commands/init.js
@@ -22,6 +22,7 @@ export async function initCommand({
   stderr = process.stderr,
   exec = execa,
   fs: fsImpl,
+  resetPrompt = false,
 } = {}) {
   const fs = wrapFs(fsImpl)
   const out = (m) => stdout.write(m + '\n')
@@ -60,6 +61,8 @@ export async function initCommand({
     path: join(projectRoot, 'PROMPT.md'),
     body: readTemplate('PROMPT.md'),
     label: 'PROMPT.md',
+    force: resetPrompt,
+    resetHint: '--reset-prompt',
   })
 
   writeAlways({
@@ -171,13 +174,19 @@ function writeConfig({ fs, out, path, vars }) {
   out('✅ Wrote ralph.config.sh')
 }
 
-function writeIfAbsent({ fs, out, path, body, label }) {
-  if (fs.existsSync(path)) {
-    out(`ℹ️  ${label} already exists — leaving it alone.`)
+function writeIfAbsent({ fs, out, path, body, label, force = false, resetHint }) {
+  const exists = fs.existsSync(path)
+  if (exists && !force) {
+    const hint = resetHint ? ` (pass ${resetHint} to overwrite)` : ''
+    out(`ℹ️  ${label} already exists — leaving it alone${hint}.`)
     return
   }
   fs.writeFileSync(path, body)
-  out(`✅ Wrote ${label}`)
+  if (exists && force) {
+    out(`✅ Reset ${label} to package template`)
+  } else {
+    out(`✅ Wrote ${label}`)
+  }
 }
 
 function writeAlways({ fs, out, path, body, label }) {

--- a/packages/ralph/lib/init.test.js
+++ b/packages/ralph/lib/init.test.js
@@ -320,7 +320,102 @@ describe('initCommand — .gitignore idempotency', () => {
     expect(vol.readFileSync(`${PROJECT}/PROMPT.md`, 'utf8')).toBe(
       '# my custom prompt',
     )
-    expect(stdout.output()).toContain('PROMPT.md already exists')
+    const out = stdout.output()
+    expect(out).toContain('PROMPT.md already exists')
+    expect(out).toContain('--reset-prompt')
+  })
+})
+
+const credentialsFile =
+  'CALLMEBOT_KEY=secret-key\nWHATSAPP_PHONE=+1234567890\nRALPH_STARTUP_MESSAGE=hello\n'
+
+describe('initCommand — protects user-authored files', () => {
+  it('never writes or modifies an existing .env.local', async () => {
+    const { vol, run } = setup({
+      files: { [`${PROJECT}/.env.local`]: credentialsFile },
+    })
+    await run()
+    expect(vol.readFileSync(`${PROJECT}/.env.local`, 'utf8')).toBe(
+      credentialsFile,
+    )
+  })
+
+  it('never creates .env.local from scratch', async () => {
+    const { vol, run } = setup()
+    await run()
+    expect(vol.existsSync(`${PROJECT}/.env.local`)).toBe(false)
+  })
+
+  it('never overwrites an existing ralph-notify.sh hook script', async () => {
+    const customHook =
+      '#!/bin/bash\n# my custom slack hook\ncurl -X POST $SLACK_WEBHOOK ...\n'
+    const { vol, run } = setup({
+      files: { [`${PROJECT}/ralph-notify.sh`]: customHook },
+    })
+    await run()
+    expect(vol.readFileSync(`${PROJECT}/ralph-notify.sh`, 'utf8')).toBe(
+      customHook,
+    )
+  })
+
+  it('never creates ralph-notify.sh (only the .example template)', async () => {
+    const { vol, run } = setup()
+    await run()
+    expect(vol.existsSync(`${PROJECT}/ralph-notify.sh`)).toBe(false)
+    expect(vol.existsSync(`${PROJECT}/ralph-notify.sh.example`)).toBe(true)
+  })
+})
+
+describe('initCommand — --reset-prompt flag', () => {
+  it('overwrites PROMPT.md with the package template when resetPrompt is true', async () => {
+    const { vol } = setup({
+      files: { [`${PROJECT}/PROMPT.md`]: '# my custom prompt' },
+    })
+    const stdout = makeStream()
+    await initCommand({
+      cwd: PROJECT,
+      stdout,
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      resetPrompt: true,
+    })
+    const after = vol.readFileSync(`${PROJECT}/PROMPT.md`, 'utf8')
+    expect(after).not.toBe('# my custom prompt')
+    expect(after).toContain('Project context for Ralph')
+    expect(stdout.output()).toContain('Reset PROMPT.md')
+  })
+
+  it('still emits the regular "Wrote" message when PROMPT.md is absent and resetPrompt is true', async () => {
+    const { vol } = setup()
+    const stdout = makeStream()
+    await initCommand({
+      cwd: PROJECT,
+      stdout,
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      resetPrompt: true,
+    })
+    expect(stdout.output()).toContain('Wrote PROMPT.md')
+    expect(stdout.output()).not.toContain('Reset PROMPT.md')
+  })
+
+  it('does not affect .env.local even when resetPrompt is true', async () => {
+    const { vol } = setup({
+      files: { [`${PROJECT}/.env.local`]: credentialsFile },
+    })
+    await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      resetPrompt: true,
+    })
+    expect(vol.readFileSync(`${PROJECT}/.env.local`, 'utf8')).toBe(
+      credentialsFile,
+    )
   })
 })
 


### PR DESCRIPTION
Closes #98

## Summary

- Add `--reset-prompt` flag to `ralph init` for explicit `PROMPT.md` overwrite (default behavior is preserved: re-running `ralph init` does not touch `PROMPT.md`).
- Update the skip message so users discover the opt-in: `ℹ️  PROMPT.md already exists — leaving it alone (pass --reset-prompt to overwrite).`
- Lock down the user-authored vs Ralph-authored file split with tests in `lib/init.test.js`. The protected set is `.env.local`, `ralph-notify.sh`, `PROMPT.md` (default), and `ralph.config.sh` — none of these can be silently overwritten by `ralph init` going forward.
- Document the "what survives an update" invariant in the package README and CHANGELOG so it is discoverable, not just enforced in code.

## Test plan

- [x] `cd packages/ralph && npm test` — 143 tests pass (24 in `init.test.js`, including 7 new ones).
- [x] `npm test` (root) — 178 tests pass.
- [x] Manual review of skip message wording when re-running `ralph init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)