### PR TITLE
feat: dynamic agent usage metrics on agent cards (#147)

### DIFF
--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -107,7 +107,7 @@ export default function AgentCard({ agent, viewMode }) {
         <span className="text-[10px] font-medium text-text-muted bg-bg-input px-2 py-0.5 rounded-full">{categorySlug}</span>
         <span className="flex items-center gap-1 text-[11px] font-medium text-accent-green bg-accent-green/10 px-2 py-0.5 rounded-full">
           <Icons.Download size={10} />
-          {(agent.popularity * 243).toLocaleString()}
+          {(agent.usage_count ?? 0).toLocaleString()}
         </span>
       </div>
     </Link>

--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -45,7 +45,7 @@ export default function AgentCard({ agent, viewMode }) {
           ))}
           <span className="flex items-center gap-1 text-[11px] font-medium text-accent-green bg-accent-green/10 px-2 py-0.5 rounded-full">
             <Icons.Download size={10} />
-            {(agent.popularity * 243).toLocaleString()}
+            {(agent.usage_count ?? 0).toLocaleString()}
           </span>
         </div>
         <button

--- a/src/components/AgentCard.test.jsx
+++ b/src/components/AgentCard.test.jsx
@@ -37,11 +37,15 @@ describe('AgentCard', () => {
     expect(screen.getByText('CSS')).toBeInTheDocument()
   })
 
-  it('displays formatted download count from popularity', () => {
+  it('displays the persisted usage count', () => {
     renderWithProviders(<AgentCard agent={mockAgent} viewMode="grid" />)
-    // 98 * 243 = 23,814
-    const expected = (98 * 243).toLocaleString()
-    expect(screen.getByText(expected)).toBeInTheDocument()
+    expect(screen.getByText((1234).toLocaleString())).toBeInTheDocument()
+  })
+
+  it('falls back to 0 when usage_count is missing', () => {
+    const agent = { ...mockAgent, usage_count: undefined }
+    renderWithProviders(<AgentCard agent={agent} viewMode="grid" />)
+    expect(screen.getByText('0')).toBeInTheDocument()
   })
 
   it('shows category slug', () => {

--- a/src/components/AgentCard.test.jsx
+++ b/src/components/AgentCard.test.jsx
@@ -8,6 +8,7 @@ vi.mock('../lib/api', () => ({
   fetchAgents: vi.fn().mockResolvedValue([]),
   fetchTeams: vi.fn().mockResolvedValue([]),
   fetchTools: vi.fn().mockResolvedValue([]),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 const mockAgent = {
@@ -19,6 +20,7 @@ const mockAgent = {
   icon: 'Monitor',
   color: 'blue',
   popularity: 98,
+  usage_count: 1234,
 }
 
 describe('AgentCard', () => {

--- a/src/components/AgentDraftCard.test.jsx
+++ b/src/components/AgentDraftCard.test.jsx
@@ -9,6 +9,7 @@ const apiMock = vi.hoisted(() => ({
   fetchTeams: vi.fn(),
   fetchTools: vi.fn().mockResolvedValue([]),
   createAgent: vi.fn(),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 vi.mock('../lib/api', () => apiMock)

--- a/src/components/AgentEditCard.test.jsx
+++ b/src/components/AgentEditCard.test.jsx
@@ -9,6 +9,7 @@ const apiMock = vi.hoisted(() => ({
   fetchTeams: vi.fn(),
   fetchTools: vi.fn().mockResolvedValue([]),
   updateAgent: vi.fn(),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 vi.mock('../lib/api', () => apiMock)

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -18,7 +18,7 @@ const WELCOME_MESSAGE = {
 const INITIAL_MESSAGES = [WELCOME_MESSAGE]
 
 export default function AiAssistant({ open, onClose }) {
-  const { agents, tools } = useData()
+  const { agents, tools, bumpAgentUsage } = useData()
   const [messages, setMessages] = useState(INITIAL_MESSAGES)
   const [input, setInput] = useState('')
   const [isStreaming, setIsStreaming] = useState(false)

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -527,6 +527,15 @@ export default function AiAssistant({ open, onClose }) {
     })
     setIsStreaming(true)
 
+    // Bump every unique agent referenced in the plan once the user approves.
+    // We bump on approval rather than per-step start because the executor is
+    // server-side and approval is the authoritative "this run is happening"
+    // signal we have on the client.
+    const planAgents = Array.isArray(target.plan?.steps)
+      ? [...new Set(target.plan.steps.map((s) => s?.agent_id).filter(Boolean))]
+      : []
+    planAgents.forEach((id) => bumpAgentUsage?.(id, 'orchestrator_invoke'))
+
     const session = startSession({
       mode: 'execute',
       messages: target.outgoingSnapshot || [],

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -464,6 +464,10 @@ export default function AiAssistant({ open, onClose }) {
     setInput('')
     setIsStreaming(true)
 
+    if (selectedAgentId) {
+      bumpAgentUsage?.(selectedAgentId, 'orchestrator_invoke')
+    }
+
     const session = startSession({
       mode: 'chat',
       messages: outgoing,

--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -20,6 +20,7 @@ vi.mock('../lib/api', () => ({
   fetchTools: vi.fn().mockResolvedValue([]),
   createAgent: vi.fn().mockResolvedValue({ id: 'mock' }),
   updateAgent: vi.fn().mockResolvedValue({ id: 'frontend-developer' }),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 // Controllable mock of the orchestration engine. The fake Session drains a

--- a/src/components/CreateAgentPage.test.jsx
+++ b/src/components/CreateAgentPage.test.jsx
@@ -34,6 +34,7 @@ vi.mock('../lib/api', () => ({
   fetchTeams: vi.fn().mockResolvedValue([]),
   fetchTools: vi.fn().mockResolvedValue(mockTools),
   createAgent: vi.fn().mockResolvedValue({ id: 'test-agent' }),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 const { createAgent } = await import('../lib/api')

--- a/src/components/CreateTeamPage.test.jsx
+++ b/src/components/CreateTeamPage.test.jsx
@@ -25,6 +25,7 @@ vi.mock('../lib/api', () => ({
   }),
   createTeam: vi.fn().mockResolvedValue({ id: 'new-team' }),
   updateTeam: vi.fn().mockResolvedValue({ id: 'test-team' }),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 const { createTeam, updateTeam } = await import('../lib/api')

--- a/src/components/SkillCard.test.jsx
+++ b/src/components/SkillCard.test.jsx
@@ -8,6 +8,7 @@ vi.mock('../lib/api', () => ({
   fetchAgents: vi.fn().mockResolvedValue([]),
   fetchTeams: vi.fn().mockResolvedValue([]),
   fetchTools: vi.fn().mockResolvedValue([]),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 const mockSkill = {

--- a/src/components/SkillsPage.test.jsx
+++ b/src/components/SkillsPage.test.jsx
@@ -7,6 +7,7 @@ vi.mock('../lib/api', () => ({
   fetchAgents: vi.fn().mockResolvedValue([]),
   fetchTeams: vi.fn().mockResolvedValue([]),
   fetchTools: vi.fn().mockResolvedValue([]),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 vi.mock('../lib/skills', () => ({

--- a/src/components/TeamCard.test.jsx
+++ b/src/components/TeamCard.test.jsx
@@ -9,6 +9,7 @@ vi.mock('../lib/api', () => ({
   ]),
   fetchTeams: vi.fn().mockResolvedValue([]),
   fetchTools: vi.fn().mockResolvedValue([]),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
 const mockTeam = {

--- a/src/context/DataContext.jsx
+++ b/src/context/DataContext.jsx
@@ -72,8 +72,25 @@ export function DataProvider({ children }) {
     }
   }
 
+  // Optimistically bump the local counter and fire-and-forget the RPC. We
+  // don't refetch on the response: a refetch would race with rapid sequential
+  // bumps (e.g. adding several agents to the cart in a row) and re-order the
+  // list. The optimistic update keeps the UI in sync with the user's actions
+  // and matches what the next full reload will show.
+  const bumpAgentUsage = useCallback((agentId, event) => {
+    if (!agentId) return
+    setAgents((prev) =>
+      prev.map((a) =>
+        a.id === agentId
+          ? { ...a, usage_count: (a.usage_count ?? 0) + 1 }
+          : a,
+      ),
+    )
+    trackAgentUsage(agentId, event)
+  }, [])
+
   return (
-    <DataContext.Provider value={{ agents, teams, tools, loading, error, refreshAgents, refreshTeams, refreshTools }}>
+    <DataContext.Provider value={{ agents, teams, tools, loading, error, refreshAgents, refreshTeams, refreshTools, bumpAgentUsage }}>
       {children}
     </DataContext.Provider>
   )

--- a/src/context/DataContext.jsx
+++ b/src/context/DataContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback } from 'react'
-import { fetchAgents, fetchTeams, fetchTools } from '../lib/api'
+import { fetchAgents, fetchTeams, fetchTools, trackAgentUsage } from '../lib/api'
 
 const DataContext = createContext()
 

--- a/src/context/StackContext.jsx
+++ b/src/context/StackContext.jsx
@@ -1,15 +1,22 @@
 import { createContext, useContext, useState } from 'react'
+import { useData } from './DataContext'
 
 const StackContext = createContext()
 
 export function StackProvider({ children }) {
   const [stack, setStack] = useState([])
   const [panelOpen, setPanelOpen] = useState(false)
+  // DataContext is optional in tests that render StackProvider in isolation,
+  // so guard against an undefined context.
+  const data = useData()
+  const bumpAgentUsage = data?.bumpAgentUsage
 
   const toggleAgent = (agentId) => {
-    setStack((prev) =>
-      prev.includes(agentId) ? prev.filter((id) => id !== agentId) : [...prev, agentId]
-    )
+    setStack((prev) => {
+      if (prev.includes(agentId)) return prev.filter((id) => id !== agentId)
+      bumpAgentUsage?.(agentId, 'cart_add')
+      return [...prev, agentId]
+    })
   }
 
   const removeAgent = (agentId) => {
@@ -22,7 +29,12 @@ export function StackProvider({ children }) {
   }
 
   const addAgents = (agentIds) => {
-    setStack((prev) => [...new Set([...prev, ...agentIds])])
+    setStack((prev) => {
+      const existing = new Set(prev)
+      const added = agentIds.filter((id) => !existing.has(id))
+      added.forEach((id) => bumpAgentUsage?.(id, 'cart_add'))
+      return [...prev, ...added]
+    })
   }
 
   const removeAgents = (agentIds) => {

--- a/src/context/StackContext.test.jsx
+++ b/src/context/StackContext.test.jsx
@@ -104,4 +104,51 @@ describe('StackContext', () => {
     act(() => result.current.removeAgents(['b', 'x', 'y']))
     expect(result.current.stack).toEqual(['a'])
   })
+
+  describe('with DataProvider — usage tracking', () => {
+    it('toggleAgent bumps usage_count once on add and not on remove', async () => {
+      const api = await import('../lib/api')
+      api.trackAgentUsage.mockClear()
+
+      const { result } = renderHook(
+        () => ({ stack: useStack(), data: useData() }),
+        { wrapper: dataWrapper },
+      )
+
+      act(() => result.current.stack.toggleAgent('frontend-developer'))
+      expect(api.trackAgentUsage).toHaveBeenCalledTimes(1)
+      expect(api.trackAgentUsage).toHaveBeenCalledWith(
+        'frontend-developer',
+        'cart_add',
+      )
+      const bumped = result.current.data.agents.find((a) => a.id === 'frontend-developer')
+      expect(bumped?.usage_count).toBe(1)
+
+      act(() => result.current.stack.toggleAgent('frontend-developer'))
+      // Removing must not bump again.
+      expect(api.trackAgentUsage).toHaveBeenCalledTimes(1)
+    })
+
+    it('addAgents only bumps newly added IDs', async () => {
+      const api = await import('../lib/api')
+      api.trackAgentUsage.mockClear()
+
+      const { result } = renderHook(
+        () => ({ stack: useStack(), data: useData() }),
+        { wrapper: dataWrapper },
+      )
+
+      act(() => result.current.stack.addAgents(['frontend-developer']))
+      act(() =>
+        result.current.stack.addAgents(['frontend-developer', 'backend-developer']),
+      )
+
+      // First call adds frontend-developer (1 bump). Second call adds only
+      // backend-developer (1 bump). Frontend-developer is already in the
+      // stack and must not be bumped again.
+      expect(api.trackAgentUsage).toHaveBeenCalledTimes(2)
+      expect(api.trackAgentUsage).toHaveBeenNthCalledWith(1, 'frontend-developer', 'cart_add')
+      expect(api.trackAgentUsage).toHaveBeenNthCalledWith(2, 'backend-developer', 'cart_add')
+    })
+  })
 })

--- a/src/context/StackContext.test.jsx
+++ b/src/context/StackContext.test.jsx
@@ -114,6 +114,7 @@ describe('StackContext', () => {
         () => ({ stack: useStack(), data: useData() }),
         { wrapper: dataWrapper },
       )
+      await waitFor(() => expect(result.current.data.agents.length).toBeGreaterThan(0))
 
       act(() => result.current.stack.toggleAgent('frontend-developer'))
       expect(api.trackAgentUsage).toHaveBeenCalledTimes(1)
@@ -137,6 +138,7 @@ describe('StackContext', () => {
         () => ({ stack: useStack(), data: useData() }),
         { wrapper: dataWrapper },
       )
+      await waitFor(() => expect(result.current.data.agents.length).toBeGreaterThan(0))
 
       act(() => result.current.stack.addAgents(['frontend-developer']))
       act(() =>

--- a/src/context/StackContext.test.jsx
+++ b/src/context/StackContext.test.jsx
@@ -1,9 +1,28 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { StackProvider, useStack } from './StackContext'
+import { DataProvider, useData } from './DataContext'
+
+vi.mock('../lib/api', () => ({
+  fetchAgents: vi.fn().mockResolvedValue([
+    { id: 'frontend-developer', name: 'Frontend Dev', usage_count: 0 },
+    { id: 'backend-developer', name: 'Backend Dev', usage_count: 0 },
+  ]),
+  fetchTeams: vi.fn().mockResolvedValue([]),
+  fetchTools: vi.fn().mockResolvedValue([]),
+  trackAgentUsage: vi.fn().mockResolvedValue(1),
+}))
 
 function wrapper({ children }) {
   return <StackProvider>{children}</StackProvider>
+}
+
+function dataWrapper({ children }) {
+  return (
+    <DataProvider>
+      <StackProvider>{children}</StackProvider>
+    </DataProvider>
+  )
 }
 
 describe('StackContext', () => {

--- a/src/context/StackContext.test.jsx
+++ b/src/context/StackContext.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { StackProvider, useStack } from './StackContext'
 import { DataProvider, useData } from './DataContext'
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -10,11 +10,33 @@ export async function fetchAgents() {
   requireSupabase()
   const { data, error } = await supabase
     .from('agents')
-    .select('id, name, category, description, tags, icon, color, featured, popularity, tools, model, capabilities, content')
+    .select('id, name, category, description, tags, icon, color, featured, popularity, tools, model, capabilities, content, usage_count')
     .order('popularity', { ascending: false })
 
   if (error) throw error
   return data
+}
+
+// Fire-and-forget: bumps the persistent usage counter for an agent. The
+// `event` label is currently advisory (both events bump the same counter) but
+// is forwarded so it shows up in Supabase's request logs for ad-hoc analytics.
+// Resolves with the new count on success and `null` on failure — callers
+// should not block UI on this and should not surface the error to the user.
+export async function trackAgentUsage(agentId, event) {
+  if (!agentId || !supabase) return null
+  try {
+    const { data, error } = await supabase.rpc('increment_agent_usage', {
+      p_agent_id: agentId,
+    })
+    if (error) {
+      console.warn(`[trackAgentUsage] ${event || 'unknown'} for ${agentId} failed:`, error.message)
+      return null
+    }
+    return typeof data === 'number' ? data : null
+  } catch (err) {
+    console.warn(`[trackAgentUsage] ${event || 'unknown'} for ${agentId} threw:`, err)
+    return null
+  }
 }
 
 export async function fetchAgent(id) {

--- a/src/lib/api.test.js
+++ b/src/lib/api.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { trackAgentUsage } from './api'
+import { supabase } from './supabase'
+
+describe('trackAgentUsage', () => {
+  let warnSpy
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns null and skips the RPC when agentId is empty', async () => {
+    const rpc = vi.spyOn(supabase, 'rpc')
+    const result = await trackAgentUsage('', 'cart_add')
+    expect(result).toBeNull()
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('forwards agent_id to the increment_agent_usage RPC', async () => {
+    const rpc = vi
+      .spyOn(supabase, 'rpc')
+      .mockResolvedValue({ data: 7, error: null })
+    const result = await trackAgentUsage('frontend-developer', 'cart_add')
+    expect(rpc).toHaveBeenCalledWith('increment_agent_usage', {
+      p_agent_id: 'frontend-developer',
+    })
+    expect(result).toBe(7)
+  })
+
+  it('returns null and warns on RPC errors instead of throwing', async () => {
+    vi.spyOn(supabase, 'rpc').mockResolvedValue({
+      data: null,
+      error: { message: 'rls denied' },
+    })
+    const result = await trackAgentUsage('frontend-developer', 'orchestrator_invoke')
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('returns null and warns when the RPC throws synchronously', async () => {
+    vi.spyOn(supabase, 'rpc').mockImplementation(() => {
+      throw new Error('boom')
+    })
+    const result = await trackAgentUsage('frontend-developer', 'cart_add')
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('returns null when the RPC payload is not numeric', async () => {
+    vi.spyOn(supabase, 'rpc').mockResolvedValue({ data: null, error: null })
+    const result = await trackAgentUsage('frontend-developer', 'cart_add')
+    expect(result).toBeNull()
+  })
+})

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -15,8 +15,35 @@ create table if not exists agents (
   tools text[] not null default '{}',
   model text not null default 'claude-sonnet-4-6',
   capabilities text[] not null default '{}',
+  usage_count integer not null default 0,
   created_at timestamptz not null default now()
 );
+
+-- Backfill for existing deployments where the column did not exist yet.
+alter table agents add column if not exists usage_count integer not null default 0;
+
+-- Atomic increment for agent usage. SECURITY DEFINER lets unauthenticated
+-- clients bump the counter without granting blanket write access on the row,
+-- which keeps RLS in place for everything else (name, content, etc.).
+create or replace function increment_agent_usage(p_agent_id text)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  new_count integer;
+begin
+  update agents
+     set usage_count = usage_count + 1
+   where id = p_agent_id
+   returning usage_count into new_count;
+  return new_count;
+end;
+$$;
+
+revoke all on function increment_agent_usage(text) from public;
+grant execute on function increment_agent_usage(text) to anon, authenticated;
 
 -- Teams table
 create table if not exists teams (


### PR DESCRIPTION
Closes #147

## Summary

Replaces the hardcoded `popularity * 243` download count on agent cards with a live `usage_count` persisted in Postgres and bumped optimistically on two events:

- **`cart_add`** — when an agent is added to the user's stack (`StackContext.toggleAgent` / `addAgents`).
- **`orchestrator_invoke`** — when the AI Assistant sends a message with a selected agent or when the user approves a multi-step plan for execution. For plan execution, every unique agent in `plan.steps` is bumped once on approval (the executor is server-side, so approval is the authoritative client-side "this run is happening" signal).

## Backend

- New column `agents.usage_count integer not null default 0` (added via `add_agent_usage_count_and_increment_rpc` migration, applied to live DB).
- New Postgres function `increment_agent_usage(p_agent_id text)` — `SECURITY DEFINER` so unauthenticated/authenticated clients can bump the counter atomically without granting blanket update rights on the row. Returns the new count.
- `EXECUTE` revoked from `public`, granted to `anon` + `authenticated`.

## Frontend

- `src/lib/api.js` — adds `trackAgentUsage(agentId, event)`. Fire-and-forget, swallows errors with a `console.warn` so the UI never blocks on telemetry. The `event` label is forwarded for log readability but both events bump the same counter.
- `src/context/DataContext.jsx` — exposes `bumpAgentUsage(agentId, event)` which optimistically increments the local agent's `usage_count` and fires the RPC. Optimistic so rapid sequential bumps (e.g. adding several agents to the cart) don't get re-ordered by a refetch.
- `src/context/StackContext.jsx` — calls `bumpAgentUsage` only on the add branch of `toggleAgent` and only for newly-added IDs in `addAgents` (no double counting).
- `src/components/AiAssistant.jsx` — bumps `selectedAgentId` on chat send and bumps every unique `plan.steps[].agent_id` on plan approval.
- `src/components/AgentCard.jsx` — renders `agent.usage_count ?? 0` in both grid and list views.

## Tests

- `src/lib/api.test.js` — covers the empty-id guard, the happy path, the error path, the throw path, and the non-numeric-payload path.
- `src/context/StackContext.test.jsx` — adds a "with DataProvider" suite verifying `toggleAgent` bumps once on add (not on remove) and `addAgents` only bumps newly-added IDs.
- `src/components/AgentCard.test.jsx` — replaces the popularity-based display test with a `usage_count` test plus a missing-value fallback test.
- All 8 existing test files that mock `../lib/api` updated with `trackAgentUsage: vi.fn().mockResolvedValue(null)`.

Total: 22 test files, 186 tests, all green.

## Test plan

- [x] `npm test` — 186/186 passing
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [x] `npm run test:functions` — 47/47 passing
- [x] Migration applied to live Supabase DB (`add_agent_usage_count_and_increment_rpc`)