### PR TITLE
feat(ralph): enforce TDD red-green-refactor in issue resolution prompt

### DIFF
--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -92,4 +92,34 @@ describe('buildPrompt', () => {
     buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
     expect(stderr.calls).toHaveLength(0)
   })
+
+  describe('TDD workflow', () => {
+    it('instructs the agent to write a failing test before implementing the fix', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/TDD/)
+      expect(out).toMatch(/red.{0,3}green.{0,3}refactor/i)
+      expect(out).toMatch(/write.+failing.+test/i)
+    })
+
+    it('tells the agent to confirm the test fails before writing implementation', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/confirm.+(fail|red)/i)
+    })
+
+    it('asks the PR body to document the TDD process (tests added, before/after results)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/document.+TDD/i)
+      expect(out).toMatch(/PR (body|description)/i)
+    })
+
+    it('allows skipping TDD only for changes with no code impact (docs, config)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/skip.+TDD|TDD.+(only|skip)/i)
+      expect(out).toMatch(/docs|documentation|config/i)
+    })
+  })
 })

--- a/packages/ralph/templates/prompt-base.md
+++ b/packages/ralph/templates/prompt-base.md
@@ -23,17 +23,46 @@ operations.
 
 3. **Prepare branch**: `git checkout {{DEV_BRANCH}} && git pull && git checkout -b issue-N`
 
-4. **Resolve**: read the issue title and body, implement the solution.
-   Use Read/Edit/Write as needed. Follow the conventions in
-   `CLAUDE.md`.
+4. **Resolve via TDD**: read the issue title and body, then follow the
+   red → green → refactor loop. Tests come first, always.
+   1. **Red**: write a failing test that captures the expected behavior
+      described by the issue's acceptance criteria. Run `{{TEST_CMD}}`
+      and confirm the new test fails for the right reason — the
+      behavior is not yet implemented.
+   2. **Green**: implement the minimum code required to make the new
+      test pass. Run `{{TEST_CMD}}` again and confirm every test passes.
+   3. **Refactor**: tighten names, remove duplication, and improve the
+      design while keeping the suite green.
+
+   Record the test file paths you added or modified and the
+   before/after suite results — you will paste them into the PR body in
+   step 7. Skip TDD only for changes with zero behavioral impact on
+   code: pure documentation edits, plain configuration tweaks, or
+   dependency bumps without logic changes. When you skip, explain why
+   in the PR body. Use Read/Edit/Write as needed and follow the
+   conventions in `CLAUDE.md`.
 
 5. **Validate locally**: run `{{TEST_CMD}}` and `{{LINT_CMD}}` (skip
    the empty ones). If they fail, fix and re-run. Repeat up to 3 times;
    if they still fail, go to "Failed".
 
-6. **Commit + push**: `git add <specific files> && git commit -m "fix: <description> (#N)" && git push -u origin issue-N`
+6. **Commit + push**: `git add <specific files> && git commit -m "fix: <description> (#N)" && git push -u origin issue-N`. Stage both the new/updated tests and the implementation in the same commit so the TDD pair is reviewable together.
 
-7. **Open PR**: `gh pr create --base {{PR_TARGET}} --head issue-N --title "<title>" --body "Closes #N"`
+7. **Open PR**: `gh pr create --base {{PR_TARGET}} --head issue-N --title "<title>" --body "<body>"`. The PR body must close the issue and document the TDD process. Use this template:
+
+   ```
+   Closes #N
+
+   ## TDD
+   - Tests added/modified: <relative file paths>
+   - Before implementation (red): <failing test names + summary of failure>
+   - After implementation (green): <suite result, e.g. "all 143 tests pass">
+
+   ## Notes
+   <anything else worth flagging for review>
+   ```
+
+   If TDD was skipped per step 4, replace the TDD block with `## TDD\n- Skipped: <reason — must be docs/config/dep-bump only>`.
 
 8. **Auto-merge + wait**:
    - `gh pr merge <pr> --auto --{{MERGE_STRATEGY}} --delete-branch`


### PR DESCRIPTION
Closes #148

## TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js` (4 new assertions in a new `TDD workflow` describe block).
- Before implementation (red): the 4 new tests failed because `prompt-base.md` did not mention TDD, the red-green-refactor loop, the failing-test confirmation step, or the PR-body documentation requirement.
- After implementation (green): full Ralph suite is green — `vitest run` reports `Test Files 14 passed (14)` / `Tests 147 passed (147)`. Root frontend suite also green: `Test Files 22 passed (22)` / `Tests 186 passed (186)`. `npm run lint` reports 0 errors.

## Summary
Updates `packages/ralph/templates/prompt-base.md` so every Ralph-driven fix follows red → green → refactor:
- Step 4 (Resolve) is now an explicit TDD loop: write a failing test first, confirm it fails for the right reason, implement the minimum code to go green, then refactor.
- TDD can only be skipped for changes with zero behavioral impact (docs / config / dep bump). The skip must be justified in the PR body.
- Step 6 (Commit) tells the agent to stage tests + implementation together so the TDD pair is reviewable.
- Step 7 (Open PR) now requires the PR body to document tests added/modified plus before/after suite results, with a fallback line for justified TDD skips.

The change ships as a template update inside `@lucasfe/ralph` so any project using the published Ralph CLI inherits the new workflow on the next `ralph init` (or `--reset-prompt`).