### PR TITLE
feat(ralph): TDD red-green-refactor enforcement in resolution loop

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -53,6 +53,26 @@ a tmux session named `ralph`. Watch it live with `tmux attach -t ralph`,
 detach with `Ctrl+B` then `D`, or tail per-issue logs in
 `logs/ralph-issue-*.log`.
 
+## How Ralph resolves issues
+
+Each iteration follows a **TDD red → green → refactor** loop, baked
+into the prompt Claude receives:
+
+1. **Red** — write a failing test that captures the issue's expected
+   behavior, then run `TEST_CMD` and confirm it fails for the right
+   reason (the behavior is not yet implemented).
+2. **Green** — implement the minimum code that makes the new test pass,
+   then run `TEST_CMD` again and confirm every test passes.
+3. **Refactor** — tighten names, remove duplication, and improve the
+   design while keeping the suite green.
+
+The new/updated tests and the implementation land in the same commit
+so the TDD pair is reviewable together. The PR body documents the
+TDD steps (tests added, failing names before, green suite result
+after). TDD is skipped only for changes with zero behavioral impact:
+pure documentation, plain configuration, or dependency bumps without
+logic changes — and the skip is justified in the PR body.
+
 ## What survives an update
 
 `ralph init` and any future Ralph update mechanism (`npm i -g


### PR DESCRIPTION
## Summary

Bump-trigger PR for `@lucasfe/ralph` to ship the TDD prompt enforcement that landed in main via PR #180 but didn't generate an npm release.

The actual TDD prompt change is already in main (`packages/ralph/templates/prompt-base.md`, `packages/ralph/lib/build-prompt.test.js`). It was originally introduced by PR #185 (`feat(ralph): enforce TDD red-green-refactor in issue resolution prompt`), squashed into dev, then squashed again into main as `chore: dev → main rollforward (#180)`. release-please reads only the squash subject — and `chore:` does not bump.

This PR documents the TDD step in `packages/ralph/README.md` so:
- Users discover the behavior without reading `prompt-base.md`
- The `feat(ralph):` PR title gives release-please the signal it needs to bump `0.3.0-rc.1 → 0.4.0-rc.1` and publish to npm

## Changes

- `packages/ralph/README.md` — new "How Ralph resolves issues" section documenting the red → green → refactor loop, when TDD is skipped, and what goes in the PR body.

## Follow-up

A separate PR should fix `auto-pr.yml` to derive the rollforward title from the highest-impact CC type in dev's commits (`feat:` > `fix:` > `chore:`), so future Ralph features automatically trigger a release without a hand-rolled bump-trigger PR like this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)