### PR TITLE
feat(ralph): TDD red-green-refactor enforcement in resolution loop

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -55,7 +55,7 @@ detach with `Ctrl+B` then `D`, or tail per-issue logs in
 
 ## How Ralph resolves issues
 
-Each iteration follows a **TDD red → green → refactor** loop, baked
+Every iteration follows a **TDD red → green → refactor** loop, baked
 into the prompt Claude receives:
 
 1. **Red** — write a failing test that captures the issue's expected


### PR DESCRIPTION
Bump-trigger PR for @lucasfe/ralph (0.3.0-rc.1 → 0.4.0-rc.1).

The TDD prompt enforcement landed in main via PR #180 squashed as 'chore: dev → main rollforward', and PR #198 squashed as 'auto: update README' — neither subject triggers release-please.

This PR will be squashed with explicit '--subject feat(ralph):' so release-please sees the bump signal and publishes 0.4.0-rc.1 to npm.