### PR TITLE
ci: auto-merge release-please PR + match-publish safety net + CC-typed rollforward

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -31,17 +31,33 @@ jobs:
           # to roll forward and close.
           SINCE=$(git log -1 origin/main --pretty=%cI)
 
-          if [ -n "$EXISTING_PR" ]; then
-            echo "PR #$EXISTING_PR already exists — new commits pushed automatically"
-            # Refresh closing keywords on the existing PR to capture any newly
-            # merged underlying PRs since the auto-PR was last opened.
-            CLOSES=$(git log origin/main..HEAD --since="$SINCE" --pretty=%B \
-              | grep -oE '#[0-9]+' \
-              | sort -u \
-              | sed 's/^/Closes /' \
-              | paste -sd $'\n' -)
-            COMMITS=$(git log origin/main..HEAD --since="$SINCE" --oneline | head -20)
-            gh pr edit "$EXISTING_PR" --body "$(cat <<EOF
+          # Closing keywords for issues referenced in this rollforward.
+          CLOSES=$(git log origin/main..HEAD --since="$SINCE" --pretty=%B \
+            | grep -oE '#[0-9]+' \
+            | sort -u \
+            | sed 's/^/Closes /' \
+            | paste -sd $'\n' -)
+          COMMITS=$(git log origin/main..HEAD --since="$SINCE" --oneline | head -20)
+
+          # Compute the highest-impact Conventional Commit type across the
+          # rollforward window so the squash subject on main carries that
+          # signal forward to release-please. Without this, `chore:` always
+          # wins and release-please ignores the merge — so a `feat:` buried
+          # in dev never bumps the version. Order: feat! > feat > fix > chore.
+          BODIES=$(git log origin/main..HEAD --since="$SINCE" --pretty=%B)
+          if echo "$BODIES" | grep -qE '^(feat|fix|chore|docs|refactor|test|perf|ci|build|revert)(\([^)]+\))?!:|BREAKING CHANGE'; then
+            CC_TYPE='feat!'
+          elif echo "$BODIES" | grep -qE '^feat(\([^)]+\))?:'; then
+            CC_TYPE='feat'
+          elif echo "$BODIES" | grep -qE '^fix(\([^)]+\))?:'; then
+            CC_TYPE='fix'
+          else
+            CC_TYPE='chore'
+          fi
+          TITLE="${CC_TYPE}: dev → main rollforward"
+          echo "Computed rollforward title: $TITLE"
+
+          BODY=$(cat <<EOF
           ## Auto-generated PR
 
           Latest commits from \`dev\`:
@@ -55,38 +71,16 @@ jobs:
           ---
           🤖 Generated automatically on push to \`dev\`
           EOF
-          )"
-          else
-            # Collect every issue/PR number referenced in dev commit messages
-            # since the last main rollforward. These become `Closes #N` lines
-            # in the body so that when this PR squash-merges into main, the
-            # underlying issues auto-close — the original PRs targeted dev,
-            # so their own `Closes #N` keywords never fired.
-            CLOSES=$(git log origin/main..HEAD --since="$SINCE" --pretty=%B \
-              | grep -oE '#[0-9]+' \
-              | sort -u \
-              | sed 's/^/Closes /' \
-              | paste -sd $'\n' -)
-            COMMITS=$(git log origin/main..HEAD --since="$SINCE" --oneline | head -20)
+          )
 
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists — refreshing title + body"
+            gh pr edit "$EXISTING_PR" --title "$TITLE" --body "$BODY"
+          else
             gh pr create \
-              --title "chore: dev → main rollforward" \
+              --title "$TITLE" \
               --base main \
               --head dev \
-              --body "$(cat <<EOF
-          ## Auto-generated PR
-
-          Latest commits from \`dev\`:
-
-          \`\`\`
-          $COMMITS
-          \`\`\`
-
-          $CLOSES
-
-          ---
-          🤖 Generated automatically on push to \`dev\`
-          EOF
-          )"
+              --body "$BODY"
             echo "New PR created"
           fi

--- a/.github/workflows/ralph-release.yml
+++ b/.github/workflows/ralph-release.yml
@@ -1,5 +1,24 @@
 name: Ralph release
 
+# End-to-end automation for @lucasfe/ralph releases.
+#
+# Flow on every push to main:
+#   1. release-please inspects commits since the last ralph release. If
+#      it finds user-facing CC types (`feat:` / `fix:`), it opens (or
+#      updates) a Release PR that bumps `packages/ralph/package.json`
+#      and prepends a CHANGELOG entry.
+#   2. auto-merge-release-pr enables auto-merge on that PR (admin merge,
+#      squash). Once required checks pass, GitHub merges it. The merge
+#      triggers another `push: main` event → this workflow runs again.
+#   3. publish (always-run, idempotent): reads
+#      `packages/ralph/package.json`, asks npm if that exact version is
+#      already published, and publishes only if it isn't. This is the
+#      safety net — if release-please's Release PR merged and the new
+#      version isn't on npm yet, this job fills the gap. If the version
+#      is already there, it's a no-op.
+#
+# No manual Release PR review. No `--admin` clicks. No close+reopen.
+
 on:
   push:
     branches:
@@ -16,8 +35,7 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      ralph_release_created: ${{ steps.release.outputs['packages/ralph--release_created'] }}
+      pr_number: ${{ steps.release.outputs['packages/ralph--pr'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -25,10 +43,33 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish:
-    name: Publish @lucasfe/ralph to npm
+  auto-merge-release-pr:
+    name: Auto-merge release-please PR
     needs: release-please
-    if: needs.release-please.outputs.ralph_release_created == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.release-please.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Admin-merge Release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER='${{ needs.release-please.outputs.pr_number }}'
+          # Use --admin so the merge bypasses required checks that may
+          # not have fired (release-please PRs created via GITHUB_TOKEN
+          # historically didn't trigger downstream workflows).
+          gh pr merge "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --squash \
+            --admin
+
+  publish:
+    name: Publish @lucasfe/ralph to npm (match-publish safety net)
+    needs: release-please
+    # Run even when no Release PR was created — the previous run already
+    # auto-merged a Release PR and bumped package.json; this run sees
+    # the new version and publishes. Idempotent: skips if already
+    # published.
+    if: always() && (needs.release-please.result == 'success' || needs.release-please.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,18 +89,35 @@ jobs:
           cache: 'npm'
           cache-dependency-path: packages/ralph/package-lock.json
 
+      - name: Check whether current package.json version is already on npm
+        id: check
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if npm view "@lucasfe/ralph@$VERSION" version 2>/dev/null | grep -q "^$VERSION$"; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION already on npm — nothing to do."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION not on npm — will publish."
+          fi
+
       - name: Install dependencies
+        if: steps.check.outputs.already_published == 'false'
         run: npm ci
 
       - name: Run tests
+        if: steps.check.outputs.already_published == 'false'
         run: npm test
 
       - name: Publish to npm via OIDC (Trusted Publisher)
+        if: steps.check.outputs.already_published == 'false'
         run: |
-          # Use the "rc" dist-tag for prereleases (versions containing "-").
-          # Stable versions (no "-") publish to "latest" by default.
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION='${{ steps.check.outputs.version }}'
           if [[ "$VERSION" == *-* ]]; then
+            # Prereleases (0.4.0-rc.1, 0.5.0-beta.2, …) go to the `rc`
+            # dist-tag so `latest` keeps pointing at the most recent
+            # stable.
             npm publish --access public --provenance --tag rc
           else
             npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Reworks the release pipeline to remove every manual step that's been failing this week.

### Problems this fixes

1. **`auto-pr.yml` always set rollforward title to `chore:`** — release-please reads the squash subject of merges to main; \`chore:\` doesn't bump. A \`feat(ralph)\` buried in dev never triggered a release.
2. **release-please's Release PR required manual \`--admin\` merge** — the PR was created via \`GITHUB_TOKEN\`, so downstream workflows (PR Title check) didn't fire, blocking auto-merge.
3. **The \`publish\` job was gated on \`ralph_release_created == 'true'\`** — fragile signal that fires only on the run that opens a release; if anything went wrong the version landed in main but never on npm.

### Changes

**\`.github/workflows/ralph-release.yml\`** — full rewrite:
- New \`auto-merge-release-pr\` job: when release-please opens a Release PR, immediately admin-squash-merge it. No human needed.
- New \`publish\` job logic: **match-publish** safety net — reads \`packages/ralph/package.json\` on every push to main, checks \`npm view\` for that exact version, and publishes only if it isn't already there. Idempotent.
- Drops the \`ralph_release_created\` gate entirely. The match-publish job runs after release-please and after every other push. If main's package.json version isn't on npm, it gets published.

**\`.github/workflows/auto-pr.yml\`**:
- Computes the highest-impact CC type (\`feat!\` > \`feat\` > \`fix\` > \`chore\`) across the rollforward window and uses it as the PR title prefix.
- A \`feat(ralph)\` PR merged into dev now produces a \`feat: dev → main rollforward\` PR title — release-please sees the \`feat\` and bumps the minor version.

### Repo settings already updated (out-of-band, via gh API)

- \`squash_merge_commit_title\` → \`PR_TITLE\` (was: \`COMMIT_OR_PR_TITLE\` — was using first commit's subject \`auto: update X\`)
- \`squash_merge_commit_message\` → \`PR_BODY\`
- \`allow_auto_merge\` → \`true\`

### Risk

Auto-merge of release-please PR removes the human review checkpoint. Mitigation: the match-publish job tests before publishing; npm provenance attestation is still required and fails loud if anything's off; reverting a bad release is a one-line PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)