### PR TITLE
ci: query open release-please PR explicitly (don't rely on action output)

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -31,17 +31,33 @@ jobs:
           # to roll forward and close.
           SINCE=$(git log -1 origin/main --pretty=%cI)
 
-          if [ -n "$EXISTING_PR" ]; then
-            echo "PR #$EXISTING_PR already exists — new commits pushed automatically"
-            # Refresh closing keywords on the existing PR to capture any newly
-            # merged underlying PRs since the auto-PR was last opened.
-            CLOSES=$(git log origin/main..HEAD --since="$SINCE" --pretty=%B \
-              | grep -oE '#[0-9]+' \
-              | sort -u \
-              | sed 's/^/Closes /' \
-              | paste -sd $'\n' -)
-            COMMITS=$(git log origin/main..HEAD --since="$SINCE" --oneline | head -20)
-            gh pr edit "$EXISTING_PR" --body "$(cat <<EOF
+          # Closing keywords for issues referenced in this rollforward.
+          CLOSES=$(git log origin/main..HEAD --since="$SINCE" --pretty=%B \
+            | grep -oE '#[0-9]+' \
+            | sort -u \
+            | sed 's/^/Closes /' \
+            | paste -sd $'\n' -)
+          COMMITS=$(git log origin/main..HEAD --since="$SINCE" --oneline | head -20)
+
+          # Compute the highest-impact Conventional Commit type across the
+          # rollforward window so the squash subject on main carries that
+          # signal forward to release-please. Without this, `chore:` always
+          # wins and release-please ignores the merge — so a `feat:` buried
+          # in dev never bumps the version. Order: feat! > feat > fix > chore.
+          BODIES=$(git log origin/main..HEAD --since="$SINCE" --pretty=%B)
+          if echo "$BODIES" | grep -qE '^(feat|fix|chore|docs|refactor|test|perf|ci|build|revert)(\([^)]+\))?!:|BREAKING CHANGE'; then
+            CC_TYPE='feat!'
+          elif echo "$BODIES" | grep -qE '^feat(\([^)]+\))?:'; then
+            CC_TYPE='feat'
+          elif echo "$BODIES" | grep -qE '^fix(\([^)]+\))?:'; then
+            CC_TYPE='fix'
+          else
+            CC_TYPE='chore'
+          fi
+          TITLE="${CC_TYPE}: dev → main rollforward"
+          echo "Computed rollforward title: $TITLE"
+
+          BODY=$(cat <<EOF
           ## Auto-generated PR
 
           Latest commits from \`dev\`:
@@ -55,38 +71,16 @@ jobs:
           ---
           🤖 Generated automatically on push to \`dev\`
           EOF
-          )"
-          else
-            # Collect every issue/PR number referenced in dev commit messages
-            # since the last main rollforward. These become `Closes #N` lines
-            # in the body so that when this PR squash-merges into main, the
-            # underlying issues auto-close — the original PRs targeted dev,
-            # so their own `Closes #N` keywords never fired.
-            CLOSES=$(git log origin/main..HEAD --since="$SINCE" --pretty=%B \
-              | grep -oE '#[0-9]+' \
-              | sort -u \
-              | sed 's/^/Closes /' \
-              | paste -sd $'\n' -)
-            COMMITS=$(git log origin/main..HEAD --since="$SINCE" --oneline | head -20)
+          )
 
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists — refreshing title + body"
+            gh pr edit "$EXISTING_PR" --title "$TITLE" --body "$BODY"
+          else
             gh pr create \
-              --title "chore: dev → main rollforward" \
+              --title "$TITLE" \
               --base main \
               --head dev \
-              --body "$(cat <<EOF
-          ## Auto-generated PR
-
-          Latest commits from \`dev\`:
-
-          \`\`\`
-          $COMMITS
-          \`\`\`
-
-          $CLOSES
-
-          ---
-          🤖 Generated automatically on push to \`dev\`
-          EOF
-          )"
+              --body "$BODY"
             echo "New PR created"
           fi

--- a/.github/workflows/ralph-release.yml
+++ b/.github/workflows/ralph-release.yml
@@ -46,17 +46,32 @@ jobs:
   auto-merge-release-pr:
     name: Auto-merge release-please PR
     needs: release-please
-    if: needs.release-please.outputs.pr_number != ''
     runs-on: ubuntu-latest
     steps:
-      - name: Admin-merge Release PR
+      - name: Admin-merge any open release-please Release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER='${{ needs.release-please.outputs.pr_number }}'
+          # Don't trust release-please's output — when its Release PR
+          # already exists from a previous run with no new updates, it
+          # doesn't re-emit `pr_number`. Instead, query open PRs whose
+          # head branch matches the release-please naming convention.
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --base main \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].number // empty')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release-please PR found — nothing to auto-merge."
+            exit 0
+          fi
+
+          echo "Found open release-please PR #$PR_NUMBER — admin-squash-merging."
           # Use --admin so the merge bypasses required checks that may
           # not have fired (release-please PRs created via GITHUB_TOKEN
-          # historically didn't trigger downstream workflows).
+          # historically don't trigger downstream workflows).
           gh pr merge "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --squash \

--- a/.github/workflows/ralph-release.yml
+++ b/.github/workflows/ralph-release.yml
@@ -1,5 +1,24 @@
 name: Ralph release
 
+# End-to-end automation for @lucasfe/ralph releases.
+#
+# Flow on every push to main:
+#   1. release-please inspects commits since the last ralph release. If
+#      it finds user-facing CC types (`feat:` / `fix:`), it opens (or
+#      updates) a Release PR that bumps `packages/ralph/package.json`
+#      and prepends a CHANGELOG entry.
+#   2. auto-merge-release-pr enables auto-merge on that PR (admin merge,
+#      squash). Once required checks pass, GitHub merges it. The merge
+#      triggers another `push: main` event → this workflow runs again.
+#   3. publish (always-run, idempotent): reads
+#      `packages/ralph/package.json`, asks npm if that exact version is
+#      already published, and publishes only if it isn't. This is the
+#      safety net — if release-please's Release PR merged and the new
+#      version isn't on npm yet, this job fills the gap. If the version
+#      is already there, it's a no-op.
+#
+# No manual Release PR review. No `--admin` clicks. No close+reopen.
+
 on:
   push:
     branches:
@@ -16,8 +35,7 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      ralph_release_created: ${{ steps.release.outputs['packages/ralph--release_created'] }}
+      pr_number: ${{ steps.release.outputs['packages/ralph--pr'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -25,10 +43,33 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish:
-    name: Publish @lucasfe/ralph to npm
+  auto-merge-release-pr:
+    name: Auto-merge release-please PR
     needs: release-please
-    if: needs.release-please.outputs.ralph_release_created == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.release-please.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Admin-merge Release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER='${{ needs.release-please.outputs.pr_number }}'
+          # Use --admin so the merge bypasses required checks that may
+          # not have fired (release-please PRs created via GITHUB_TOKEN
+          # historically didn't trigger downstream workflows).
+          gh pr merge "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --squash \
+            --admin
+
+  publish:
+    name: Publish @lucasfe/ralph to npm (match-publish safety net)
+    needs: release-please
+    # Run even when no Release PR was created — the previous run already
+    # auto-merged a Release PR and bumped package.json; this run sees
+    # the new version and publishes. Idempotent: skips if already
+    # published.
+    if: always() && (needs.release-please.result == 'success' || needs.release-please.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,18 +89,35 @@ jobs:
           cache: 'npm'
           cache-dependency-path: packages/ralph/package-lock.json
 
+      - name: Check whether current package.json version is already on npm
+        id: check
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if npm view "@lucasfe/ralph@$VERSION" version 2>/dev/null | grep -q "^$VERSION$"; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION already on npm — nothing to do."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION not on npm — will publish."
+          fi
+
       - name: Install dependencies
+        if: steps.check.outputs.already_published == 'false'
         run: npm ci
 
       - name: Run tests
+        if: steps.check.outputs.already_published == 'false'
         run: npm test
 
       - name: Publish to npm via OIDC (Trusted Publisher)
+        if: steps.check.outputs.already_published == 'false'
         run: |
-          # Use the "rc" dist-tag for prereleases (versions containing "-").
-          # Stable versions (no "-") publish to "latest" by default.
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION='${{ steps.check.outputs.version }}'
           if [[ "$VERSION" == *-* ]]; then
+            # Prereleases (0.4.0-rc.1, 0.5.0-beta.2, …) go to the `rc`
+            # dist-tag so `latest` keeps pointing at the most recent
+            # stable.
             npm publish --access public --provenance --tag rc
           else
             npm publish --access public --provenance


### PR DESCRIPTION
Quick fix to PR #205. release-please-action only emits `pr_number` when it CREATES or UPDATES a Release PR — when the PR already exists with no changes, the output is empty and our auto-merge job got skipped.

Switch to querying open PRs whose head branch starts with `release-please--`. That always catches the open Release PR regardless of whether the current run's release-please-action did anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)