### PR TITLE
ci: query open release-please PR explicitly in auto-merge job

### DIFF
--- a/.github/workflows/ralph-release.yml
+++ b/.github/workflows/ralph-release.yml
@@ -46,17 +46,32 @@ jobs:
   auto-merge-release-pr:
     name: Auto-merge release-please PR
     needs: release-please
-    if: needs.release-please.outputs.pr_number != ''
     runs-on: ubuntu-latest
     steps:
-      - name: Admin-merge Release PR
+      - name: Admin-merge any open release-please Release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER='${{ needs.release-please.outputs.pr_number }}'
+          # Don't trust release-please's output — when its Release PR
+          # already exists from a previous run with no new updates, it
+          # doesn't re-emit `pr_number`. Instead, query open PRs whose
+          # head branch matches the release-please naming convention.
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --base main \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].number // empty')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release-please PR found — nothing to auto-merge."
+            exit 0
+          fi
+
+          echo "Found open release-please PR #$PR_NUMBER — admin-squash-merging."
           # Use --admin so the merge bypasses required checks that may
           # not have fired (release-please PRs created via GITHUB_TOKEN
-          # historically didn't trigger downstream workflows).
+          # historically don't trigger downstream workflows).
           gh pr merge "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --squash \


### PR DESCRIPTION
Follow-up to #205. release-please-action only emits `pr_number` when it CREATES or UPDATES the Release PR — when the PR is unchanged, output is empty and the auto-merge job gets skipped.

Switch to querying open PRs with `release-please--*` head branch. Always catches the open Release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)