### PR TITLE
feat(ralph): add lib/lock.js with PID liveness + stale detection

### DIFF
--- a/packages/ralph/lib/lock.js
+++ b/packages/ralph/lib/lock.js
@@ -1,0 +1,119 @@
+import { createHash } from 'node:crypto'
+import {
+  existsSync as realExistsSync,
+  readFileSync as realReadFileSync,
+  unlinkSync as realUnlinkSync,
+  writeFileSync as realWriteFileSync,
+} from 'node:fs'
+
+const DEFAULT_STALE_AFTER_MS = 6 * 60 * 60 * 1000
+const DEFAULT_TMP_DIR = '/tmp'
+
+export function lockPathFor(repoPath, tmpDir = DEFAULT_TMP_DIR) {
+  const slug = createHash('sha256').update(repoPath).digest('hex').slice(0, 8)
+  return `${tmpDir}/ralph-cycle-${slug}.lock`
+}
+
+export function acquireLock(repoPath, options = {}) {
+  const {
+    pid = process.pid,
+    startedAt = new Date(),
+    staleAfterMs = DEFAULT_STALE_AFTER_MS,
+    fsImpl,
+    processKill = defaultProcessKill,
+    now = Date.now,
+    tmpDir = DEFAULT_TMP_DIR,
+  } = options
+  const fs = wrapFs(fsImpl)
+  const path = lockPathFor(repoPath, tmpDir)
+  const existing = readHolder(fs, path)
+  if (existing && !isStale(existing, { processKill, now, staleAfterMs })) {
+    return { acquired: false, holder: existing }
+  }
+  const holder = {
+    pid,
+    startedAt: startedAt instanceof Date ? startedAt.toISOString() : startedAt,
+    repoPath,
+  }
+  fs.writeFileSync(path, JSON.stringify(holder))
+  return { acquired: true, holder }
+}
+
+export function releaseLock(repoPath, options = {}) {
+  const { fsImpl, tmpDir = DEFAULT_TMP_DIR } = options
+  const fs = wrapFs(fsImpl)
+  const path = lockPathFor(repoPath, tmpDir)
+  if (fs.existsSync(path)) {
+    fs.unlinkSync(path)
+  }
+}
+
+export function peekLock(repoPath, options = {}) {
+  const {
+    fsImpl,
+    processKill = defaultProcessKill,
+    tmpDir = DEFAULT_TMP_DIR,
+  } = options
+  const fs = wrapFs(fsImpl)
+  const path = lockPathFor(repoPath, tmpDir)
+  const holder = readHolder(fs, path)
+  if (!holder) return null
+  return { holder, alive: isPidAlive(holder.pid, processKill) }
+}
+
+function readHolder(fs, path) {
+  if (!fs.existsSync(path)) return null
+  let raw
+  try {
+    raw = fs.readFileSync(path, 'utf8').toString()
+  } catch {
+    return null
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed.pid !== 'number') return null
+  return parsed
+}
+
+function isStale(holder, { processKill, now, staleAfterMs }) {
+  if (!isPidAlive(holder.pid, processKill)) return true
+  const startedMs = Date.parse(holder.startedAt)
+  if (Number.isNaN(startedMs)) return true
+  return now() - startedMs > staleAfterMs
+}
+
+function isPidAlive(pid, processKill) {
+  try {
+    processKill(pid, 0)
+    return true
+  } catch (err) {
+    // EPERM means the process exists but we can't signal it (still alive).
+    // ESRCH (and any other error) means treat as dead.
+    return err && err.code === 'EPERM'
+  }
+}
+
+function defaultProcessKill(pid, signal) {
+  return process.kill(pid, signal)
+}
+
+function wrapFs(fsImpl) {
+  if (!fsImpl) {
+    return {
+      existsSync: realExistsSync,
+      readFileSync: realReadFileSync,
+      writeFileSync: realWriteFileSync,
+      unlinkSync: realUnlinkSync,
+    }
+  }
+  return {
+    existsSync: fsImpl.existsSync.bind(fsImpl),
+    readFileSync: fsImpl.readFileSync.bind(fsImpl),
+    writeFileSync: fsImpl.writeFileSync.bind(fsImpl),
+    unlinkSync: fsImpl.unlinkSync.bind(fsImpl),
+  }
+}

--- a/packages/ralph/lib/lock.test.js
+++ b/packages/ralph/lib/lock.test.js
@@ -6,7 +6,9 @@ import { acquireLock, lockPathFor, peekLock, releaseLock } from './lock.js'
 const REPO = '/Users/me/repos/agenthub'
 
 function vol(initial = {}) {
-  return Volume.fromJSON(initial, '/')
+  const v = Volume.fromJSON(initial, '/')
+  v.mkdirSync('/tmp', { recursive: true })
+  return v
 }
 
 function expectedLockPath(repoPath, tmpDir = '/tmp') {

--- a/packages/ralph/lib/lock.test.js
+++ b/packages/ralph/lib/lock.test.js
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { createHash } from 'node:crypto'
+import { acquireLock, lockPathFor, peekLock, releaseLock } from './lock.js'
+
+const REPO = '/Users/me/repos/agenthub'
+
+function vol(initial = {}) {
+  return Volume.fromJSON(initial, '/')
+}
+
+function expectedLockPath(repoPath, tmpDir = '/tmp') {
+  const slug = createHash('sha256').update(repoPath).digest('hex').slice(0, 8)
+  return `${tmpDir}/ralph-cycle-${slug}.lock`
+}
+
+const aliveKill = () => () => {}
+const deadKill = () => () => {
+  const err = new Error('No such process')
+  err.code = 'ESRCH'
+  throw err
+}
+const permKill = () => () => {
+  const err = new Error('Operation not permitted')
+  err.code = 'EPERM'
+  throw err
+}
+
+describe('lockPathFor', () => {
+  it('returns /tmp/ralph-cycle-<sha8>.lock derived from the repo path', () => {
+    expect(lockPathFor(REPO)).toBe(expectedLockPath(REPO))
+  })
+
+  it('produces an 8-char hex slug', () => {
+    const path = lockPathFor(REPO)
+    const match = path.match(/ralph-cycle-([0-9a-f]+)\.lock$/)
+    expect(match).not.toBeNull()
+    expect(match[1]).toHaveLength(8)
+  })
+
+  it('is deterministic for the same repo path', () => {
+    expect(lockPathFor(REPO)).toBe(lockPathFor(REPO))
+  })
+
+  it('differs for different repo paths', () => {
+    expect(lockPathFor('/a')).not.toBe(lockPathFor('/b'))
+  })
+
+  it('honors a custom tmp directory', () => {
+    expect(lockPathFor(REPO, '/var/tmp')).toBe(expectedLockPath(REPO, '/var/tmp'))
+  })
+})
+
+describe('acquireLock', () => {
+  it('writes a fresh lockfile and returns acquired:true when no lock exists', () => {
+    const v = vol()
+    const startedAt = new Date('2026-04-29T00:00:00Z')
+    const result = acquireLock(REPO, {
+      pid: 4242,
+      startedAt,
+      fsImpl: v,
+      processKill: aliveKill(),
+      now: () => startedAt.getTime(),
+    })
+    expect(result).toEqual({
+      acquired: true,
+      holder: { pid: 4242, startedAt: startedAt.toISOString(), repoPath: REPO },
+    })
+    const written = JSON.parse(
+      v.readFileSync(expectedLockPath(REPO), 'utf8').toString(),
+    )
+    expect(written).toEqual({
+      pid: 4242,
+      startedAt: startedAt.toISOString(),
+      repoPath: REPO,
+    })
+  })
+
+  it('returns acquired:false with the existing holder when the lock is alive and fresh', () => {
+    const startedAt = '2026-04-29T00:00:00.000Z'
+    const existing = { pid: 1234, startedAt, repoPath: REPO }
+    const v = vol({
+      [expectedLockPath(REPO)]: JSON.stringify(existing),
+    })
+    const result = acquireLock(REPO, {
+      pid: 4242,
+      fsImpl: v,
+      processKill: aliveKill(),
+      now: () => Date.parse(startedAt) + 60_000,
+    })
+    expect(result).toEqual({ acquired: false, holder: existing })
+    const stillThere = JSON.parse(
+      v.readFileSync(expectedLockPath(REPO), 'utf8').toString(),
+    )
+    expect(stillThere).toEqual(existing)
+  })
+
+  it('overwrites the lockfile when the existing holder PID is dead (ESRCH)', () => {
+    const startedAt = '2026-04-29T00:00:00.000Z'
+    const v = vol({
+      [expectedLockPath(REPO)]: JSON.stringify({
+        pid: 1234,
+        startedAt,
+        repoPath: REPO,
+      }),
+    })
+    const newStartedAt = new Date('2026-04-29T01:00:00Z')
+    const result = acquireLock(REPO, {
+      pid: 4242,
+      startedAt: newStartedAt,
+      fsImpl: v,
+      processKill: deadKill(),
+      now: () => newStartedAt.getTime(),
+    })
+    expect(result.acquired).toBe(true)
+    expect(result.holder).toEqual({
+      pid: 4242,
+      startedAt: newStartedAt.toISOString(),
+      repoPath: REPO,
+    })
+    const written = JSON.parse(
+      v.readFileSync(expectedLockPath(REPO), 'utf8').toString(),
+    )
+    expect(written.pid).toBe(4242)
+  })
+
+  it('overwrites the lockfile when the existing lock is older than the default 6h threshold', () => {
+    const startedAt = '2026-04-29T00:00:00.000Z'
+    const v = vol({
+      [expectedLockPath(REPO)]: JSON.stringify({
+        pid: 1234,
+        startedAt,
+        repoPath: REPO,
+      }),
+    })
+    const sevenHoursLaterMs = Date.parse(startedAt) + 7 * 60 * 60 * 1000
+    const result = acquireLock(REPO, {
+      pid: 4242,
+      startedAt: new Date(sevenHoursLaterMs),
+      fsImpl: v,
+      processKill: aliveKill(),
+      now: () => sevenHoursLaterMs,
+    })
+    expect(result.acquired).toBe(true)
+    expect(result.holder.pid).toBe(4242)
+  })
+
+  it('honors a custom staleAfterMs threshold', () => {
+    const startedAt = '2026-04-29T00:00:00.000Z'
+    const v = vol({
+      [expectedLockPath(REPO)]: JSON.stringify({
+        pid: 1234,
+        startedAt,
+        repoPath: REPO,
+      }),
+    })
+    const twoMinutesLaterMs = Date.parse(startedAt) + 2 * 60 * 1000
+    const result = acquireLock(REPO, {
+      pid: 4242,
+      startedAt: new Date(twoMinutesLaterMs),
+      fsImpl: v,
+      processKill: aliveKill(),
+      now: () => twoMinutesLaterMs,
+      staleAfterMs: 60 * 1000,
+    })
+    expect(result.acquired).toBe(true)
+    expect(result.holder.pid).toBe(4242)
+  })
+
+  it('treats EPERM from process.kill as alive (process exists, signal denied)', () => {
+    const startedAt = '2026-04-29T00:00:00.000Z'
+    const existing = { pid: 1, startedAt, repoPath: REPO }
+    const v = vol({
+      [expectedLockPath(REPO)]: JSON.stringify(existing),
+    })
+    const result = acquireLock(REPO, {
+      pid: 4242,
+      fsImpl: v,
+      processKill: permKill(),
+      now: () => Date.parse(startedAt) + 60_000,
+    })
+    expect(result).toEqual({ acquired: false, holder: existing })
+  })
+
+  it('treats a corrupt lockfile as stale and acquires the lock', () => {
+    const v = vol({
+      [expectedLockPath(REPO)]: 'not json {{',
+    })
+    const startedAt = new Date('2026-04-29T00:00:00Z')
+    const result = acquireLock(REPO, {
+      pid: 4242,
+      startedAt,
+      fsImpl: v,
+      processKill: aliveKill(),
+      now: () => startedAt.getTime(),
+    })
+    expect(result.acquired).toBe(true)
+    expect(result.holder.pid).toBe(4242)
+  })
+})
+
+describe('releaseLock', () => {
+  it('removes the lockfile when present', () => {
+    const v = vol({
+      [expectedLockPath(REPO)]: JSON.stringify({ pid: 1234 }),
+    })
+    releaseLock(REPO, { fsImpl: v })
+    expect(v.existsSync(expectedLockPath(REPO))).toBe(false)
+  })
+
+  it('is a no-op when the lockfile is missing', () => {
+    const v = vol()
+    expect(() => releaseLock(REPO, { fsImpl: v })).not.toThrow()
+    expect(v.existsSync(expectedLockPath(REPO))).toBe(false)
+  })
+})
+
+describe('peekLock', () => {
+  it('returns null when the lockfile is missing', () => {
+    expect(peekLock(REPO, { fsImpl: vol() })).toBeNull()
+  })
+
+  it('returns { holder, alive: true } when the holder PID is alive', () => {
+    const startedAt = '2026-04-29T00:00:00.000Z'
+    const holder = { pid: 1234, startedAt, repoPath: REPO }
+    const v = vol({
+      [expectedLockPath(REPO)]: JSON.stringify(holder),
+    })
+    expect(peekLock(REPO, { fsImpl: v, processKill: aliveKill() })).toEqual({
+      holder,
+      alive: true,
+    })
+  })
+
+  it('returns { holder, alive: false } when the holder PID is dead', () => {
+    const startedAt = '2026-04-29T00:00:00.000Z'
+    const holder = { pid: 1234, startedAt, repoPath: REPO }
+    const v = vol({
+      [expectedLockPath(REPO)]: JSON.stringify(holder),
+    })
+    expect(peekLock(REPO, { fsImpl: v, processKill: deadKill() })).toEqual({
+      holder,
+      alive: false,
+    })
+  })
+
+  it('returns null when the lockfile is corrupt JSON', () => {
+    const v = vol({
+      [expectedLockPath(REPO)]: 'not json',
+    })
+    expect(peekLock(REPO, { fsImpl: v, processKill: aliveKill() })).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #216

## TDD
- Tests added: \`packages/ralph/lib/lock.test.js\`
- Before implementation (red): \`vitest\` failed to load \`./lock.js\` ("Does the file exist?") — module did not exist yet, so all 18 tests in \`lock.test.js\` were unloadable.
- After implementation (green): full ralph suite passes — 165/165 tests across 15 files (including the 18 new lock tests covering empty/alive+fresh/dead-PID/stale-by-time/EPERM-as-alive/corrupt-JSON/release/peek/custom-stale-threshold).

## Notes
- Lock path: \`/tmp/ralph-cycle-<sha8(repoPath)>.lock\` (sha8 = first 8 hex chars of sha256 over the repo path).
- Liveness: \`process.kill(pid, 0)\`. \`ESRCH\` ⇒ dead, \`EPERM\` ⇒ alive (process exists, signal denied).
- Default stale threshold: 6h (configurable via \`staleAfterMs\`). Corrupt or unparseable lockfiles are treated as stale and overwritten.
- All side effects (\`fs\`, \`process.kill\`, \`Date.now\`) are injectable for memfs-based unit tests; defaults preserve real-fs behavior in production.
- No integration with \`cycle\` / \`start\` yet — that lands in slice 4 per the parent PRD #215.