### PR TITLE
feat(ralph): add lib/orphan-cleanup.js — detect + clear stuck claude-working issues

### DIFF
--- a/packages/ralph/lib/orphan-cleanup.js
+++ b/packages/ralph/lib/orphan-cleanup.js
@@ -1,0 +1,68 @@
+const ORPHAN_LABEL = 'claude-working'
+
+const LIST_ARGS = [
+  'issue',
+  'list',
+  '--state',
+  'open',
+  '--label',
+  ORPHAN_LABEL,
+  '--json',
+  'number,title,updatedAt',
+]
+
+export async function findOrphans({ exec, repoPath, log = console.error } = {}) {
+  if (typeof exec !== 'function') return []
+  let result
+  try {
+    result = await exec('gh', LIST_ARGS, { cwd: repoPath, reject: false })
+  } catch (err) {
+    log(`orphan-cleanup: failed to list orphans: ${err?.message ?? err}`)
+    return []
+  }
+  if (!result || result.exitCode !== 0) {
+    const stderr = (result?.stderr ?? '').trim()
+    log(`orphan-cleanup: gh list exited ${result?.exitCode}: ${stderr}`)
+    return []
+  }
+  const stdout = (result.stdout ?? '').trim() || '[]'
+  let parsed
+  try {
+    parsed = JSON.parse(stdout)
+  } catch (err) {
+    log(`orphan-cleanup: invalid JSON from gh: ${err?.message ?? err}`)
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  return parsed
+    .filter((item) => item && typeof item.number === 'number')
+    .map((item) => ({
+      number: item.number,
+      title: item.title,
+      updatedAt: item.updatedAt,
+    }))
+}
+
+export async function cleanupOrphans({ exec, orphans, log = console.error } = {}) {
+  if (typeof exec !== 'function') return []
+  if (!Array.isArray(orphans) || orphans.length === 0) return []
+  const cleared = []
+  for (const orphan of orphans) {
+    if (!orphan || typeof orphan.number !== 'number') continue
+    const args = ['issue', 'edit', String(orphan.number), '--remove-label', ORPHAN_LABEL]
+    let result
+    try {
+      result = await exec('gh', args, { reject: false })
+    } catch (err) {
+      log(`orphan-cleanup: failed to clear #${orphan.number}: ${err?.message ?? err}`)
+      continue
+    }
+    if (!result || result.exitCode !== 0) {
+      const stderr = (result?.stderr ?? '').trim()
+      log(`orphan-cleanup: gh edit #${orphan.number} exited ${result?.exitCode}: ${stderr}`)
+      continue
+    }
+    cleared.push(orphan.number)
+  }
+  return cleared
+}

--- a/packages/ralph/lib/orphan-cleanup.test.js
+++ b/packages/ralph/lib/orphan-cleanup.test.js
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import { cleanupOrphans, findOrphans } from './orphan-cleanup.js'
+
+const REPO = '/Users/me/repos/agenthub'
+
+function makeExec(handlers = {}) {
+  const calls = []
+  const exec = async (cmd, args, options = {}) => {
+    const key = `${cmd} ${args.join(' ')}`
+    calls.push({ key, cmd, args, options })
+    if (handlers[key]) {
+      const v = handlers[key]
+      return typeof v === 'function' ? v({ cmd, args, options }) : v
+    }
+    return { exitCode: 0, stdout: '', stderr: '' }
+  }
+  exec.calls = calls
+  return exec
+}
+
+function makeLog() {
+  const messages = []
+  const log = (...args) => {
+    messages.push(args.join(' '))
+  }
+  log.messages = messages
+  return log
+}
+
+describe('findOrphans', () => {
+  it('returns [] when gh returns an empty array', async () => {
+    const exec = makeExec({
+      'gh issue list --state open --label claude-working --json number,title,updatedAt': {
+        exitCode: 0,
+        stdout: '[]',
+        stderr: '',
+      },
+    })
+    const result = await findOrphans({ exec, repoPath: REPO })
+    expect(result).toEqual([])
+  })
+
+  it('returns the slim shape for each orphan when gh returns issues', async () => {
+    const stdout = JSON.stringify([
+      { number: 12, title: 'first', updatedAt: '2026-04-29T00:00:00Z' },
+      { number: 34, title: 'second', updatedAt: '2026-04-29T01:00:00Z' },
+    ])
+    const exec = makeExec({
+      'gh issue list --state open --label claude-working --json number,title,updatedAt': {
+        exitCode: 0,
+        stdout,
+        stderr: '',
+      },
+    })
+    const result = await findOrphans({ exec, repoPath: REPO })
+    expect(result).toEqual([
+      { number: 12, title: 'first', updatedAt: '2026-04-29T00:00:00Z' },
+      { number: 34, title: 'second', updatedAt: '2026-04-29T01:00:00Z' },
+    ])
+  })
+
+  it('runs gh in the supplied repoPath', async () => {
+    const exec = makeExec({
+      'gh issue list --state open --label claude-working --json number,title,updatedAt': {
+        exitCode: 0,
+        stdout: '[]',
+        stderr: '',
+      },
+    })
+    await findOrphans({ exec, repoPath: REPO })
+    const ghCall = exec.calls.find((c) => c.cmd === 'gh')
+    expect(ghCall).toBeDefined()
+    expect(ghCall.options.cwd).toBe(REPO)
+  })
+
+  it('returns [] when gh exits non-zero', async () => {
+    const log = makeLog()
+    const exec = makeExec({
+      'gh issue list --state open --label claude-working --json number,title,updatedAt': {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'gh: not authenticated',
+      },
+    })
+    const result = await findOrphans({ exec, repoPath: REPO, log })
+    expect(result).toEqual([])
+    expect(log.messages.join('\n')).toMatch(/not authenticated|gh|orphan/i)
+  })
+
+  it('returns [] when gh stdout is invalid JSON', async () => {
+    const log = makeLog()
+    const exec = makeExec({
+      'gh issue list --state open --label claude-working --json number,title,updatedAt': {
+        exitCode: 0,
+        stdout: 'not json {{',
+        stderr: '',
+      },
+    })
+    const result = await findOrphans({ exec, repoPath: REPO, log })
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when exec throws', async () => {
+    const log = makeLog()
+    const exec = async () => {
+      throw new Error('boom')
+    }
+    const result = await findOrphans({ exec, repoPath: REPO, log })
+    expect(result).toEqual([])
+    expect(log.messages.join('\n')).toMatch(/boom/)
+  })
+})
+
+describe('cleanupOrphans', () => {
+  it('is a no-op when orphans is empty (returns [])', async () => {
+    const exec = makeExec()
+    const result = await cleanupOrphans({ exec, orphans: [] })
+    expect(result).toEqual([])
+    expect(exec.calls).toEqual([])
+  })
+
+  it('is a no-op when orphans is missing/undefined', async () => {
+    const exec = makeExec()
+    const result = await cleanupOrphans({ exec })
+    expect(result).toEqual([])
+    expect(exec.calls).toEqual([])
+  })
+
+  it('removes the claude-working label from each orphan and returns the cleared numbers', async () => {
+    const exec = makeExec({
+      'gh issue edit 12 --remove-label claude-working': { exitCode: 0, stdout: '', stderr: '' },
+      'gh issue edit 34 --remove-label claude-working': { exitCode: 0, stdout: '', stderr: '' },
+    })
+    const result = await cleanupOrphans({
+      exec,
+      orphans: [
+        { number: 12, title: 'first' },
+        { number: 34, title: 'second' },
+      ],
+    })
+    expect(result).toEqual([12, 34])
+    expect(exec.calls.map((c) => c.key)).toEqual([
+      'gh issue edit 12 --remove-label claude-working',
+      'gh issue edit 34 --remove-label claude-working',
+    ])
+  })
+
+  it('swallows gh errors (non-zero exit) and continues with the remaining orphans', async () => {
+    const log = makeLog()
+    const exec = makeExec({
+      'gh issue edit 12 --remove-label claude-working': {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'label not found',
+      },
+      'gh issue edit 34 --remove-label claude-working': { exitCode: 0, stdout: '', stderr: '' },
+    })
+    const result = await cleanupOrphans({
+      exec,
+      orphans: [
+        { number: 12, title: 'first' },
+        { number: 34, title: 'second' },
+      ],
+      log,
+    })
+    expect(result).toEqual([34])
+    expect(log.messages.join('\n')).toMatch(/12/)
+  })
+
+  it('swallows thrown errors from exec and continues with the remaining orphans', async () => {
+    const log = makeLog()
+    let calls = 0
+    const exec = async (cmd, args) => {
+      calls++
+      if (args.includes('12')) throw new Error('exec blew up')
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    const result = await cleanupOrphans({
+      exec,
+      orphans: [
+        { number: 12, title: 'first' },
+        { number: 34, title: 'second' },
+      ],
+      log,
+    })
+    expect(result).toEqual([34])
+    expect(calls).toBe(2)
+    expect(log.messages.join('\n')).toMatch(/exec blew up/)
+  })
+
+  it('is idempotent — calling twice on already-cleared issues still returns the cleared numbers', async () => {
+    const exec = makeExec({
+      'gh issue edit 12 --remove-label claude-working': { exitCode: 0, stdout: '', stderr: '' },
+    })
+    const orphans = [{ number: 12, title: 'first' }]
+    const first = await cleanupOrphans({ exec, orphans })
+    const second = await cleanupOrphans({ exec, orphans })
+    expect(first).toEqual([12])
+    expect(second).toEqual([12])
+  })
+})


### PR DESCRIPTION
Closes #217

## TDD
- Tests added/modified: `packages/ralph/lib/orphan-cleanup.test.js`
- Before implementation (red): `lib/orphan-cleanup.test.js` failed with `Failed to load url ./orphan-cleanup.js` because the module did not exist yet.
- After implementation (green): all 177 tests pass via `cd packages/ralph && npm test` (12 new in orphan-cleanup, 165 pre-existing).

## Notes
- `findOrphans({ exec, repoPath, log? })` shells out to `gh issue list --state open --label claude-working --json number,title,updatedAt` with `cwd: repoPath` and returns the slim `{ number, title, updatedAt }[]` shape. gh failures, JSON errors, and thrown errors are caught and logged (best-effort).
- `cleanupOrphans({ exec, orphans, log? })` runs `gh issue edit <n> --remove-label claude-working` for each orphan, returning the array of cleared numbers. gh errors per orphan are swallowed and logging continues with the next item — matches the issue's "best-effort" requirement.
- Empty/missing `orphans` is a no-op that returns `[]` (covered by tests).
- Idempotency is covered: calling `cleanupOrphans` twice with the same input returns the same cleared numbers both times.
- Slice 4 (`ralph cycle`) will wire these into the cycle command — this PR only ships the unit-tested module per the parent plan.