### PR TITLE
feat(ralph): add lib/healthcheck.js — best-effort Healthchecks.io ping

### DIFF
--- a/packages/ralph/lib/healthcheck.js
+++ b/packages/ralph/lib/healthcheck.js
@@ -13,7 +13,6 @@ export async function pingSuccess({
 export async function pingFail({
   url,
   failUrl,
-  message: _message,
   fetch: fetchImpl = typeof globalThis.fetch === 'function' ? globalThis.fetch : null,
   timeoutMs = DEFAULT_TIMEOUT_MS,
 } = {}) {

--- a/packages/ralph/lib/healthcheck.js
+++ b/packages/ralph/lib/healthcheck.js
@@ -1,0 +1,44 @@
+const DEFAULT_TIMEOUT_MS = 5000
+
+export async function pingSuccess({
+  url,
+  fetch: fetchImpl = typeof globalThis.fetch === 'function' ? globalThis.fetch : null,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  if (!url) return { ok: false, reason: 'no-url' }
+  if (typeof fetchImpl !== 'function') return { ok: false, reason: 'no-fetch' }
+  return doPing(url, fetchImpl, timeoutMs)
+}
+
+export async function pingFail({
+  url,
+  failUrl,
+  message: _message,
+  fetch: fetchImpl = typeof globalThis.fetch === 'function' ? globalThis.fetch : null,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  const target = failUrl || (url ? `${url}/fail` : '')
+  if (!target) return { ok: false, reason: 'no-url' }
+  if (typeof fetchImpl !== 'function') return { ok: false, reason: 'no-fetch' }
+  return doPing(target, fetchImpl, timeoutMs)
+}
+
+async function doPing(url, fetchImpl, timeoutMs) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetchImpl(url, { method: 'GET', signal: controller.signal })
+    if (!res || !res.ok) {
+      const status = res?.status ?? 'unknown'
+      return { ok: false, reason: `http-${status}` }
+    }
+    return { ok: true }
+  } catch (err) {
+    const reason = err && err.name === 'AbortError' ? 'timeout' : 'network-error'
+    return { ok: false, reason }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export { DEFAULT_TIMEOUT_MS }

--- a/packages/ralph/lib/healthcheck.test.js
+++ b/packages/ralph/lib/healthcheck.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { pingSuccess, pingFail } from './healthcheck.js'
+
+function makeFetch(handler) {
+  const calls = []
+  const fn = async (url, opts) => {
+    calls.push({ url, opts })
+    return handler(url, opts)
+  }
+  fn.calls = calls
+  return fn
+}
+
+const URL = 'https://hc-ping.com/abc123'
+
+describe('pingSuccess', () => {
+  it('returns { ok: false, reason: "no-url" } when url is missing and does not call fetch', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: true, status: 200 }))
+    expect(await pingSuccess({ url: '', fetch: fetchImpl })).toEqual({
+      ok: false,
+      reason: 'no-url',
+    })
+    expect(await pingSuccess({ fetch: fetchImpl })).toEqual({
+      ok: false,
+      reason: 'no-url',
+    })
+    expect(fetchImpl.calls).toHaveLength(0)
+  })
+
+  it('returns { ok: false, reason: "no-fetch" } when no fetch implementation is available', async () => {
+    expect(await pingSuccess({ url: URL, fetch: null })).toEqual({
+      ok: false,
+      reason: 'no-fetch',
+    })
+  })
+
+  it('issues a GET to the url and returns { ok: true } on 2xx', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: true, status: 200 }))
+    const res = await pingSuccess({ url: URL, fetch: fetchImpl })
+    expect(res).toEqual({ ok: true })
+    expect(fetchImpl.calls).toHaveLength(1)
+    expect(fetchImpl.calls[0].url).toBe(URL)
+    expect(fetchImpl.calls[0].opts.method).toBe('GET')
+  })
+
+  it('returns { ok: false, reason: "http-<status>" } when the upstream responds non-ok', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: false, status: 500 }))
+    const res = await pingSuccess({ url: URL, fetch: fetchImpl })
+    expect(res).toEqual({ ok: false, reason: 'http-500' })
+  })
+
+  it('returns { ok: false, reason: "network-error" } when fetch rejects', async () => {
+    const fetchImpl = makeFetch(() => {
+      throw new Error('boom')
+    })
+    const res = await pingSuccess({ url: URL, fetch: fetchImpl })
+    expect(res).toEqual({ ok: false, reason: 'network-error' })
+  })
+
+  it('returns { ok: false, reason: "timeout" } when the fetch is aborted by the timeout signal', async () => {
+    const fetchImpl = (_url, opts) =>
+      new Promise((_resolve, reject) => {
+        opts.signal.addEventListener('abort', () => {
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+        })
+      })
+    const res = await pingSuccess({ url: URL, fetch: fetchImpl, timeoutMs: 5 })
+    expect(res).toEqual({ ok: false, reason: 'timeout' })
+  })
+
+  it('never throws even when fetch synchronously throws a non-Error value', async () => {
+    const fetchImpl = () => {
+      throw 'string-error'
+    }
+    const res = await pingSuccess({ url: URL, fetch: fetchImpl })
+    expect(res.ok).toBe(false)
+  })
+})
+
+describe('pingFail', () => {
+  it('returns { ok: false, reason: "no-url" } when url and failUrl are both missing', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: true, status: 200 }))
+    expect(await pingFail({ url: '', fetch: fetchImpl })).toEqual({
+      ok: false,
+      reason: 'no-url',
+    })
+    expect(await pingFail({ fetch: fetchImpl })).toEqual({
+      ok: false,
+      reason: 'no-url',
+    })
+    expect(fetchImpl.calls).toHaveLength(0)
+  })
+
+  it('derives the failure URL by appending /fail to the base url by default', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: true, status: 200 }))
+    const res = await pingFail({ url: URL, fetch: fetchImpl })
+    expect(res).toEqual({ ok: true })
+    expect(fetchImpl.calls).toHaveLength(1)
+    expect(fetchImpl.calls[0].url).toBe(`${URL}/fail`)
+    expect(fetchImpl.calls[0].opts.method).toBe('GET')
+  })
+
+  it('uses a custom failUrl when provided, ignoring the base url', async () => {
+    const customFailUrl = 'https://hc-ping.com/custom-fail-uuid'
+    const fetchImpl = makeFetch(() => ({ ok: true, status: 200 }))
+    const res = await pingFail({ url: URL, failUrl: customFailUrl, fetch: fetchImpl })
+    expect(res).toEqual({ ok: true })
+    expect(fetchImpl.calls[0].url).toBe(customFailUrl)
+  })
+
+  it('uses failUrl even when base url is empty', async () => {
+    const customFailUrl = 'https://hc-ping.com/custom-fail-uuid'
+    const fetchImpl = makeFetch(() => ({ ok: true, status: 200 }))
+    const res = await pingFail({ failUrl: customFailUrl, fetch: fetchImpl })
+    expect(res).toEqual({ ok: true })
+    expect(fetchImpl.calls[0].url).toBe(customFailUrl)
+  })
+
+  it('accepts a message argument without throwing (message handling is best-effort)', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: true, status: 200 }))
+    const res = await pingFail({ url: URL, message: 'something failed', fetch: fetchImpl })
+    expect(res).toEqual({ ok: true })
+    expect(fetchImpl.calls).toHaveLength(1)
+  })
+
+  it('returns { ok: false, reason: "network-error" } when fetch rejects', async () => {
+    const fetchImpl = makeFetch(() => {
+      throw new Error('boom')
+    })
+    const res = await pingFail({ url: URL, fetch: fetchImpl })
+    expect(res).toEqual({ ok: false, reason: 'network-error' })
+  })
+
+  it('returns { ok: false, reason: "timeout" } when aborted by the timeout signal', async () => {
+    const fetchImpl = (_url, opts) =>
+      new Promise((_resolve, reject) => {
+        opts.signal.addEventListener('abort', () => {
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+        })
+      })
+    const res = await pingFail({ url: URL, fetch: fetchImpl, timeoutMs: 5 })
+    expect(res).toEqual({ ok: false, reason: 'timeout' })
+  })
+
+  it('returns { ok: false, reason: "http-<status>" } when the upstream responds non-ok', async () => {
+    const fetchImpl = makeFetch(() => ({ ok: false, status: 502 }))
+    const res = await pingFail({ url: URL, fetch: fetchImpl })
+    expect(res).toEqual({ ok: false, reason: 'http-502' })
+  })
+})


### PR DESCRIPTION
Closes #218

## TDD
- Tests added: `packages/ralph/lib/healthcheck.test.js`
- Before implementation (red): `vitest` failed to load `./healthcheck.js` ("Does the file exist?") — module did not exist yet, so all 15 tests in `healthcheck.test.js` were unloadable.
- After implementation (green): full ralph suite passes — 192/192 tests across 17 files (including 15 new healthcheck tests covering success, missing URL, missing fetch, network error, timeout, http-<status>, fail-url derivation, custom failUrl, and message acceptance).

## Notes
- Both `pingSuccess` and `pingFail` are best-effort: they never throw and always resolve to `{ ok, reason? }`.
- Default timeout: 5s via `AbortController`. Aborted requests resolve to `{ ok: false, reason: 'timeout' }`.
- `pingFail` derives the failure URL by appending `/fail` to `url`, OR uses a caller-provided `failUrl` when set (which works even if `url` is empty).
- Empty/missing URL short-circuits with `{ ok: false, reason: 'no-url' }` and never invokes fetch.
- Missing fetch implementation (Node <18 without polyfill) returns `{ ok: false, reason: 'no-fetch' }` — the module defaults to `globalThis.fetch` when available so callers in modern runtimes don't need to inject one.
- `message` parameter is accepted on `pingFail` for forward compatibility with v2 (Healthchecks.io body delivery), but per the slice 3 spec the v1 implementation issues a strict GET; sending the body is left to a future slice that switches to POST.
- No integration with `cycle` yet — that lands in slice 4 per the parent PRD #215.