### PR TITLE
feat(ralph): add ralph cycle — one-shot queue processor (lock + orphans + healthcheck)

### DIFF
--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -63,6 +63,23 @@ program
   })
 
 program
+  .command('cycle')
+  .description(
+    'Run one queue-processing cycle: preflight, lock, drain, notify. Designed for launchd / cron schedules.',
+  )
+  .action(async () => {
+    try {
+      const result = await cycleCommand()
+      process.exit(result.exitCode ?? 0)
+    } catch (e) {
+      if (e instanceof CycleAbort) {
+        process.exit(e.exitCode ?? 1)
+      }
+      throw e
+    }
+  })
+
+program
   .command('doctor')
   .description('Check required system deps and print install commands for missing ones')
   .action(async () => {

--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -7,6 +7,7 @@ import { startCommand, StartAbort } from '../lib/commands/start.js'
 import { stopCommand, StopAbort } from '../lib/commands/stop.js'
 import { initCommand, InitAbort } from '../lib/commands/init.js'
 import { doctorCommand, DoctorAbort } from '../lib/commands/doctor.js'
+import { cycleCommand, CycleAbort } from '../lib/commands/cycle.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'))

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -59,9 +59,9 @@ export async function cycleCommand({
   }
 
   const env = loadEnvIfExists(exists, loadEnv, resolve(root, '.env.local'))
-  const callmebotKey = env.CALLMEBOT_KEY ?? process.env.CALLMEBOT_KEY ?? ''
-  const whatsappPhone = env.WHATSAPP_PHONE ?? process.env.WHATSAPP_PHONE ?? ''
-  const healthcheckUrl = env.HEALTHCHECK_URL ?? process.env.HEALTHCHECK_URL ?? ''
+  const callmebotKey = env.CALLMEBOT_KEY ?? processEnv.CALLMEBOT_KEY ?? ''
+  const whatsappPhone = env.WHATSAPP_PHONE ?? processEnv.WHATSAPP_PHONE ?? ''
+  const healthcheckUrl = env.HEALTHCHECK_URL ?? processEnv.HEALTHCHECK_URL ?? ''
   const repoSlug = await resolveRepoSlug(exec, root)
 
   const notify = async (message) => {

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -1,0 +1,280 @@
+import { existsSync as realExistsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { execa } from 'execa'
+import { loadEnvFile } from '../utils/env.js'
+import { sendWhatsappMessage } from '../utils/whatsapp.js'
+import {
+  acquireLock as defaultAcquireLock,
+  releaseLock as defaultReleaseLock,
+} from '../lock.js'
+import {
+  findOrphans as defaultFindOrphans,
+  cleanupOrphans as defaultCleanupOrphans,
+} from '../orphan-cleanup.js'
+import {
+  pingSuccess as defaultPingSuccess,
+  pingFail as defaultPingFail,
+} from '../healthcheck.js'
+import { templatePath } from '../paths.js'
+
+const TMUX_SESSION = 'ralph'
+const SEARCH_QUERY =
+  'state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge'
+
+class CycleAbort extends Error {
+  constructor(message, exitCode = 1) {
+    super(message)
+    this.exitCode = exitCode
+  }
+}
+
+export async function cycleCommand({
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  exec = execa,
+  exists = realExistsSync,
+  loadEnv = loadEnvFile,
+  acquireLock = defaultAcquireLock,
+  releaseLock = defaultReleaseLock,
+  findOrphans = defaultFindOrphans,
+  cleanupOrphans = defaultCleanupOrphans,
+  sendWa = sendWhatsappMessage,
+  pingSuccess = defaultPingSuccess,
+  pingFail = defaultPingFail,
+  runQueueOnce = defaultRunQueueOnce,
+  now = Date.now,
+  claudeCredentialsPath = resolve(homedir(), '.claude', '.credentials.json'),
+} = {}) {
+  const out = (msg) => stdout.write(msg + '\n')
+  const err = (msg) => stderr.write(msg + '\n')
+
+  const root = await resolveRepoRoot(exec, cwd)
+
+  const tmux = await exec('tmux', ['has-session', '-t', TMUX_SESSION], { reject: false })
+  if (tmux.exitCode === 0) {
+    return { exitCode: 0, status: 'tmux-active', processed: 0, skipped: true }
+  }
+
+  const env = loadEnvIfExists(exists, loadEnv, resolve(root, '.env.local'))
+  const callmebotKey = env.CALLMEBOT_KEY ?? process.env.CALLMEBOT_KEY ?? ''
+  const whatsappPhone = env.WHATSAPP_PHONE ?? process.env.WHATSAPP_PHONE ?? ''
+  const healthcheckUrl = env.HEALTHCHECK_URL ?? process.env.HEALTHCHECK_URL ?? ''
+  const repoSlug = await resolveRepoSlug(exec, root)
+
+  const notify = async (message) => {
+    if (!callmebotKey || !whatsappPhone) return
+    try {
+      await sendWa({ phone: whatsappPhone, apiKey: callmebotKey, message })
+    } catch {
+      // best-effort: notification failures must never abort the cycle
+    }
+  }
+
+  const preflight = await runPreflight({
+    exec,
+    exists,
+    root,
+    claudeCredentialsPath,
+  })
+  if (!preflight.ok) {
+    err(`❌ ralph cycle: pré-checagem falhou (${preflight.reason}).`)
+    await notify(`🔴 ralph cycle abortado em ${repoSlug}: ${preflight.reason}`)
+    return {
+      exitCode: 1,
+      status: 'preflight-failed',
+      processed: 0,
+      skipped: false,
+      reason: preflight.reason,
+    }
+  }
+
+  const lockResult = acquireLock(root)
+  if (!lockResult.acquired) {
+    const ageMin = ageInMinutes(now(), lockResult.holder?.startedAt)
+    out(`ℹ️  ralph cycle: outra instância já está rodando (PID ${lockResult.holder?.pid}). Pulando.`)
+    await notify(
+      `⏭ ralph cycle skipped em ${repoSlug}: instância rodando há ${ageMin}min (PID ${lockResult.holder?.pid})`,
+    )
+    return {
+      exitCode: 0,
+      status: 'lock-held',
+      processed: 0,
+      skipped: true,
+      holder: lockResult.holder,
+    }
+  }
+
+  try {
+    const orphans = await safeFindOrphans(findOrphans, exec, root)
+    const cleared = await safeCleanupOrphans(cleanupOrphans, exec, orphans)
+    if (cleared.length > 0) {
+      const list = cleared.map((n) => `#${n}`).join(' ')
+      out(`🧹 ralph cycle: limpou ${cleared.length} orphan(s): ${list}`)
+      await notify(`🧹 ralph cycle: limpou ${cleared.length} orphans em ${repoSlug}: ${list}`)
+    }
+
+    const queueCount = await getQueueCount(exec, root)
+    if (queueCount === 0) {
+      out('ℹ️  ralph cycle: fila vazia, encerrando.')
+      return {
+        exitCode: 0,
+        status: 'queue-empty',
+        processed: 0,
+        skipped: true,
+      }
+    }
+
+    out(`🟢 ralph cycle: ${queueCount} issue(s) na fila em ${repoSlug}.`)
+    await notify(`🟢 cycle started — ${queueCount} issues, repo ${repoSlug}`)
+
+    const start = now()
+    const result = await runQueueOnce({ exec, root, stdout, stderr })
+    const successes = Array.isArray(result?.successes) ? result.successes : []
+    const failures = Array.isArray(result?.failures) ? result.failures : []
+    const durationMin = Math.max(0, Math.round((now() - start) / 60000))
+    const status = failures.length === 0 ? 'success' : successes.length > 0 ? 'partial' : 'failed'
+    const okList = successes.length > 0 ? successes.map((n) => `#${n}`).join(' ') : '-'
+    const failList = failures.length > 0 ? failures.map((n) => `#${n}`).join(' ') : '-'
+    const summary =
+      `Ralph finalizado: ${successes.length} ok, ${failures.length} falharam, ${durationMin}min. ` +
+      `OK: ${okList}| FAIL: ${failList}`
+    out(summary)
+    await notify(summary)
+
+    if (healthcheckUrl) {
+      try {
+        if (status === 'failed') {
+          await pingFail({ url: healthcheckUrl })
+        } else {
+          await pingSuccess({ url: healthcheckUrl })
+        }
+      } catch {
+        // best-effort: healthcheck failures must never abort the cycle
+      }
+    }
+
+    return {
+      exitCode: 0,
+      status,
+      processed: successes.length + failures.length,
+      skipped: false,
+      successes,
+      failures,
+      durationMin,
+    }
+  } finally {
+    try {
+      releaseLock(root)
+    } catch {
+      // best-effort: never let lock release crash the process
+    }
+  }
+}
+
+async function resolveRepoRoot(exec, cwd) {
+  const result = await exec('git', ['rev-parse', '--show-toplevel'], {
+    cwd,
+    reject: false,
+  })
+  if (!result || result.exitCode !== 0) {
+    throw new CycleAbort('not inside a git repository', 1)
+  }
+  return (result.stdout || '').trim() || cwd
+}
+
+async function resolveRepoSlug(exec, root) {
+  const result = await exec('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
+    cwd: root,
+    reject: false,
+  })
+  const slug = (result?.stdout || '').trim()
+  return slug || root
+}
+
+function loadEnvIfExists(exists, loadEnv, path) {
+  if (!exists(path)) return {}
+  try {
+    return loadEnv(path) || {}
+  } catch {
+    return {}
+  }
+}
+
+async function runPreflight({ exec, exists, root, claudeCredentialsPath }) {
+  const ghAuth = await exec('gh', ['auth', 'status'], { cwd: root, reject: false })
+  if (!ghAuth || ghAuth.exitCode !== 0) {
+    return { ok: false, reason: 'gh not authenticated' }
+  }
+  if (!exists(claudeCredentialsPath)) {
+    return { ok: false, reason: 'claude credentials missing' }
+  }
+  if (!exists(resolve(root, 'ralph.config.sh'))) {
+    return { ok: false, reason: 'ralph.config.sh missing' }
+  }
+  if (!exists(resolve(root, '.ralph', 'state.json'))) {
+    return { ok: false, reason: '.ralph/state.json missing' }
+  }
+  return { ok: true }
+}
+
+async function safeFindOrphans(findOrphans, exec, root) {
+  try {
+    const list = await findOrphans({ exec, repoPath: root })
+    return Array.isArray(list) ? list : []
+  } catch {
+    return []
+  }
+}
+
+async function safeCleanupOrphans(cleanupOrphans, exec, orphans) {
+  try {
+    const cleared = await cleanupOrphans({ exec, orphans })
+    return Array.isArray(cleared) ? cleared : []
+  } catch {
+    return []
+  }
+}
+
+async function getQueueCount(exec, root) {
+  const args = [
+    'issue',
+    'list',
+    '--search',
+    SEARCH_QUERY,
+    '--limit',
+    '100',
+    '--json',
+    'number',
+    '-q',
+    '. | length',
+  ]
+  const result = await exec('gh', args, { cwd: root, reject: false })
+  const raw = (result?.stdout || '').trim()
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) ? n : 0
+}
+
+function ageInMinutes(nowMs, isoStartedAt) {
+  if (!isoStartedAt) return 0
+  const startMs = Date.parse(isoStartedAt)
+  if (!Number.isFinite(startMs)) return 0
+  return Math.max(0, Math.round((nowMs - startMs) / 60000))
+}
+
+async function defaultRunQueueOnce({ exec, root, stdout, stderr }) {
+  const ralphTemplate = templatePath('ralph.sh')
+  const result = await exec('bash', [ralphTemplate, '--once'], {
+    cwd: root,
+    env: { ...process.env, RALPH_ONCE: '1' },
+    reject: false,
+    stdio: 'inherit',
+  })
+  if (!result || result.exitCode !== 0) {
+    return { successes: [], failures: [] }
+  }
+  return { successes: [], failures: [] }
+}
+
+export { CycleAbort }

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -46,6 +46,7 @@ export async function cycleCommand({
   runQueueOnce = defaultRunQueueOnce,
   now = Date.now,
   claudeCredentialsPath = resolve(homedir(), '.claude', '.credentials.json'),
+  processEnv = process.env,
 } = {}) {
   const out = (msg) => stdout.write(msg + '\n')
   const err = (msg) => stderr.write(msg + '\n')

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -384,6 +384,7 @@ describe('cycleCommand — best-effort failures never abort the cycle', () => {
     const deps = baseDeps({
       loadEnv: () => ({ CALLMEBOT_KEY: 'k', WHATSAPP_PHONE: '+1' }),
       runQueueOnce: async () => ({ successes: [101], failures: [] }),
+      processEnv: {},
     })
     deps.exec = makeExec({
       ...baseHandlers(),

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -404,6 +404,7 @@ describe('cycleCommand — best-effort failures never abort the cycle', () => {
     const deps = baseDeps({
       loadEnv: () => ({}),
       runQueueOnce: async () => ({ successes: [101], failures: [] }),
+      processEnv: {},
     })
     deps.exec = makeExec({
       ...baseHandlers(),

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -1,0 +1,420 @@
+import { describe, it, expect } from 'vitest'
+import { cycleCommand } from './cycle.js'
+
+const REPO = '/repo'
+const REPO_SLUG = 'lucasfe/agenthub'
+
+function makeStream() {
+  const chunks = []
+  return {
+    write: (s) => {
+      chunks.push(s)
+      return true
+    },
+    output: () => chunks.join(''),
+  }
+}
+
+function makeExec(handlers = {}) {
+  const calls = []
+  const exec = async (cmd, args, options = {}) => {
+    const key = `${cmd} ${args.join(' ')}`
+    calls.push({ key, cmd, args, options })
+    if (Object.prototype.hasOwnProperty.call(handlers, key)) {
+      const v = handlers[key]
+      return typeof v === 'function' ? v({ cmd, args, options }) : v
+    }
+    return { exitCode: 0, stdout: '', stderr: '' }
+  }
+  exec.calls = calls
+  return exec
+}
+
+function makeWa() {
+  const messages = []
+  const sendWa = async ({ message }) => {
+    messages.push(message)
+    return { ok: true }
+  }
+  sendWa.messages = messages
+  return sendWa
+}
+
+function makePing(name) {
+  const calls = []
+  const fn = async (opts) => {
+    calls.push(opts)
+    return { ok: true }
+  }
+  fn.calls = calls
+  fn.name = name
+  return fn
+}
+
+const baseHandlers = () => ({
+  'git rev-parse --show-toplevel': { exitCode: 0, stdout: `${REPO}\n`, stderr: '' },
+  'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+  'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+  'gh repo view --json nameWithOwner -q .nameWithOwner': {
+    exitCode: 0,
+    stdout: `${REPO_SLUG}\n`,
+    stderr: '',
+  },
+})
+
+const baseDeps = (overrides = {}) => {
+  const stdout = makeStream()
+  const stderr = makeStream()
+  const sendWa = makeWa()
+  const pingSuccess = makePing('pingSuccess')
+  const pingFail = makePing('pingFail')
+  return {
+    cwd: REPO,
+    stdout,
+    stderr,
+    exec: makeExec(baseHandlers()),
+    exists: () => true,
+    loadEnv: () => ({
+      CALLMEBOT_KEY: 'k',
+      WHATSAPP_PHONE: '+1',
+      HEALTHCHECK_URL: 'https://hc-ping.com/x',
+    }),
+    acquireLock: () => ({ acquired: true, holder: { pid: 1, startedAt: '2026-04-29T00:00:00.000Z', repoPath: REPO } }),
+    releaseLock: () => {},
+    findOrphans: async () => [],
+    cleanupOrphans: async () => [],
+    sendWa,
+    pingSuccess,
+    pingFail,
+    runQueueOnce: async () => ({ successes: [], failures: [] }),
+    now: () => Date.parse('2026-04-29T00:30:00.000Z'),
+    ...overrides,
+  }
+}
+
+describe('cycleCommand — tmux active', () => {
+  it('exits 0 silently when ralph tmux session is already running', async () => {
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'tmux has-session -t ralph': { exitCode: 0, stdout: '', stderr: '' },
+    })
+    const result = await cycleCommand(deps)
+    expect(result).toEqual({
+      exitCode: 0,
+      status: 'tmux-active',
+      processed: 0,
+      skipped: true,
+    })
+    expect(deps.sendWa.messages).toEqual([])
+    expect(deps.exec.calls.some((c) => c.key.startsWith('gh auth status'))).toBe(false)
+  })
+})
+
+describe('cycleCommand — preflight failure', () => {
+  it('returns preflight-failed and notifies WhatsApp when gh auth is broken', async () => {
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh auth status': { exitCode: 1, stdout: '', stderr: 'not authenticated' },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(1)
+    expect(result.status).toBe('preflight-failed')
+    expect(deps.sendWa.messages.length).toBeGreaterThan(0)
+    expect(deps.sendWa.messages[0]).toMatch(/abort/i)
+  })
+
+  it('returns preflight-failed when ralph.config.sh is missing', async () => {
+    const deps = baseDeps()
+    deps.exists = (path) => !path.endsWith('ralph.config.sh')
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(1)
+    expect(result.status).toBe('preflight-failed')
+    expect(result.reason).toMatch(/ralph\.config\.sh/)
+  })
+
+  it('returns preflight-failed when .ralph/state.json is missing', async () => {
+    const deps = baseDeps()
+    deps.exists = (path) => !path.endsWith('state.json')
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(1)
+    expect(result.status).toBe('preflight-failed')
+    expect(result.reason).toMatch(/state\.json/)
+  })
+
+  it('returns preflight-failed when claude credentials file is missing', async () => {
+    const deps = baseDeps()
+    deps.exists = (path) => !path.includes('.claude')
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(1)
+    expect(result.status).toBe('preflight-failed')
+    expect(result.reason).toMatch(/claude/i)
+  })
+})
+
+describe('cycleCommand — lock held', () => {
+  it('returns lock-held and notifies skipped when another instance holds the lock', async () => {
+    const deps = baseDeps({
+      acquireLock: () => ({
+        acquired: false,
+        holder: {
+          pid: 9999,
+          startedAt: '2026-04-29T00:00:00.000Z',
+          repoPath: REPO,
+        },
+      }),
+    })
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.status).toBe('lock-held')
+    expect(result.skipped).toBe(true)
+    expect(deps.sendWa.messages.length).toBe(1)
+    expect(deps.sendWa.messages[0]).toMatch(/skip/i)
+  })
+
+  it('does not call runQueueOnce when lock is held', async () => {
+    let queueCalled = false
+    const deps = baseDeps({
+      acquireLock: () => ({
+        acquired: false,
+        holder: { pid: 9999, startedAt: '2026-04-29T00:00:00.000Z', repoPath: REPO },
+      }),
+      runQueueOnce: async () => {
+        queueCalled = true
+        return { successes: [], failures: [] }
+      },
+    })
+    await cycleCommand(deps)
+    expect(queueCalled).toBe(false)
+  })
+})
+
+describe('cycleCommand — orphans cleared', () => {
+  it('runs cleanupOrphans and notifies aggregated when orphans existed', async () => {
+    const deps = baseDeps({
+      findOrphans: async () => [
+        { number: 12, title: 'a', updatedAt: '2026-04-28T00:00:00Z' },
+        { number: 34, title: 'b', updatedAt: '2026-04-28T01:00:00Z' },
+      ],
+      cleanupOrphans: async () => [12, 34],
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    const orphanMsg = deps.sendWa.messages.find((m) => /orphan|limpou|cleared/i.test(m))
+    expect(orphanMsg).toBeDefined()
+    expect(orphanMsg).toMatch(/12/)
+    expect(orphanMsg).toMatch(/34/)
+  })
+
+  it('does not notify orphan summary when no orphans were cleared', async () => {
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    expect(deps.sendWa.messages.find((m) => /orphan|limpou|cleared/i.test(m))).toBeUndefined()
+  })
+})
+
+describe('cycleCommand — queue empty', () => {
+  it('exits 0 silently and releases the lock when queue has 0 issues', async () => {
+    let released = false
+    const deps = baseDeps({ releaseLock: () => { released = true } })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result).toMatchObject({
+      exitCode: 0,
+      status: 'queue-empty',
+      processed: 0,
+      skipped: true,
+    })
+    expect(deps.sendWa.messages).toEqual([])
+    expect(released).toBe(true)
+  })
+})
+
+describe('cycleCommand — success path', () => {
+  it('sends start + end WhatsApp, runs queue, pings success, releases lock', async () => {
+    let released = false
+    const deps = baseDeps({
+      releaseLock: () => { released = true },
+      runQueueOnce: async () => ({ successes: [101, 102], failures: [] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '2',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.status).toBe('success')
+    expect(result.processed).toBe(2)
+    expect(deps.sendWa.messages.length).toBe(2)
+    expect(deps.sendWa.messages[0]).toMatch(/cycle started/i)
+    expect(deps.sendWa.messages[0]).toMatch(/2 issues/)
+    expect(deps.sendWa.messages[0]).toMatch(REPO_SLUG)
+    expect(deps.sendWa.messages[1]).toMatch(/finalizado|finished|done/i)
+    expect(deps.sendWa.messages[1]).toMatch(/2 ok/i)
+    expect(deps.pingSuccess.calls.length).toBe(1)
+    expect(deps.pingFail.calls.length).toBe(0)
+    expect(released).toBe(true)
+  })
+
+  it('reports partial status when some issues failed', async () => {
+    const deps = baseDeps({
+      runQueueOnce: async () => ({ successes: [101], failures: [102] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '2',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('partial')
+    expect(deps.pingSuccess.calls.length).toBe(1)
+    expect(deps.pingFail.calls.length).toBe(0)
+  })
+
+  it('reports failed status and pings fail when every issue failed', async () => {
+    const deps = baseDeps({
+      runQueueOnce: async () => ({ successes: [], failures: [101] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '1',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('failed')
+    expect(deps.pingSuccess.calls.length).toBe(0)
+    expect(deps.pingFail.calls.length).toBe(1)
+  })
+})
+
+describe('cycleCommand — best-effort failures never abort the cycle', () => {
+  it('still returns success when WhatsApp send throws', async () => {
+    const deps = baseDeps({
+      sendWa: async () => {
+        throw new Error('callmebot down')
+      },
+      runQueueOnce: async () => ({ successes: [101], failures: [] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '1',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.status).toBe('success')
+  })
+
+  it('still returns success when pingSuccess throws', async () => {
+    const deps = baseDeps({
+      pingSuccess: async () => {
+        throw new Error('hc down')
+      },
+      runQueueOnce: async () => ({ successes: [101], failures: [] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '1',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.status).toBe('success')
+  })
+
+  it('still releases the lock when runQueueOnce throws', async () => {
+    let released = false
+    const deps = baseDeps({
+      releaseLock: () => { released = true },
+      runQueueOnce: async () => {
+        throw new Error('queue blew up')
+      },
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '1',
+        stderr: '',
+      },
+    })
+    await expect(cycleCommand(deps)).rejects.toThrow(/queue blew up/)
+    expect(released).toBe(true)
+  })
+
+  it('skips healthcheck silently when HEALTHCHECK_URL is missing', async () => {
+    const deps = baseDeps({
+      loadEnv: () => ({ CALLMEBOT_KEY: 'k', WHATSAPP_PHONE: '+1' }),
+      runQueueOnce: async () => ({ successes: [101], failures: [] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '1',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('success')
+    expect(deps.pingSuccess.calls.length).toBe(0)
+    expect(deps.pingFail.calls.length).toBe(0)
+  })
+
+  it('skips WhatsApp silently when CALLMEBOT_KEY/WHATSAPP_PHONE are missing', async () => {
+    const deps = baseDeps({
+      loadEnv: () => ({}),
+      runQueueOnce: async () => ({ successes: [101], failures: [] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '1',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('success')
+    expect(deps.sendWa.messages).toEqual([])
+  })
+})

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -65,8 +65,8 @@ const baseDeps = (overrides = {}) => {
   const stdout = makeStream()
   const stderr = makeStream()
   const sendWa = makeWa()
-  const pingSuccess = makePing('pingSuccess')
-  const pingFail = makePing('pingFail')
+  const pingSuccess = makePing()
+  const pingFail = makePing()
   return {
     cwd: REPO,
     stdout,

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -40,14 +40,13 @@ function makeWa() {
   return sendWa
 }
 
-function makePing(name) {
+function makePing() {
   const calls = []
   const fn = async (opts) => {
     calls.push(opts)
     return { ok: true }
   }
   fn.calls = calls
-  fn.name = name
   return fn
 }
 

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -176,6 +176,12 @@ fi
 # Stdout always — visible to anyone running `tmux attach`.
 echo "$msg"
 
+# In --once mode (called from `ralph cycle`), the parent owns notifications +
+# lifetime. Skip end-of-run notify and tmux teardown.
+if [ -n "$RALPH_ONCE_MODE" ]; then
+  exit 0
+fi
+
 # Re-source .env.local so credentials added mid-run are picked up.
 if [ -f ./.env.local ]; then
   set -a

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -4,6 +4,15 @@
 
 set -u
 
+# `--once` mode: callable from `ralph cycle`, which owns its own start/end
+# notifications, lock, and process lifetime. In once mode we drain the queue a
+# single time and exit cleanly without sending end-of-run notifications or
+# killing the tmux session (cycle is not running inside one).
+RALPH_ONCE_MODE="${RALPH_ONCE:-}"
+if [ "${1:-}" = "--once" ]; then
+  RALPH_ONCE_MODE=1
+fi
+
 # Path safety: anchor the loop to the git project root and refuse to run
 # outside a git repo or in $HOME / root. PROJECT_ROOT is exported so child
 # tools (Claude, gh, npm) inherit the same anchor.


### PR DESCRIPTION
Closes #219

Slice 4 of the Ralph package plan. Wires together the deep modules from slices 1-3 (`lib/lock.js`, `lib/orphan-cleanup.js`, `lib/healthcheck.js`) into a single user-facing command.

## What

`ralph cycle` is the one-shot queue processor that the launchd schedule (slice 5) will call. End-to-end, it:

1. Resolves repo root via `git rev-parse --show-toplevel`.
2. Bails silently when a `tmux` ralph session is active (avoid stomping a manual `ralph start`).
3. Pre-flight: gh auth, claude credentials file, `ralph.config.sh`, `.ralph/state.json` — abort + WhatsApp on any miss.
4. `acquireLock` from slice 1 — if held, send "skipped" notify and exit 0.
5. `findOrphans` + `cleanupOrphans` from slice 2 — aggregated WhatsApp when any cleared.
6. Counts queue with the same `SEARCH_QUERY` as `ralph start` — empty → release lock + exit 0 silently.
7. WhatsApp "🟢 cycle started — N issues, repo {slug}".
8. Drains the queue once (default impl invokes `bash ralph.sh --once`, which is a new mode added to the existing template that skips end-of-run notify + tmux teardown — cycle owns those).
9. WhatsApp end-of-run summary in the same format as the existing `ralph.sh` finalizer.
10. `pingSuccess` / `pingFail` from slice 3 against `HEALTHCHECK_URL`.
11. Always releases the lock (`finally`).

WhatsApp + healthcheck failures are swallowed: best-effort notifications must never abort the cycle.

## TDD
- Tests added: `packages/ralph/lib/commands/cycle.test.js` (18 tests covering tmux active, 4 preflight failure modes, lock-held, orphans cleared, queue empty, success/partial/failed paths, and the "best-effort never aborts" invariants).
- Before implementation (red): module-not-found — `Failed to load url ./cycle.js` (cycle.js did not exist yet).
- After implementation (green): all 18 cycle tests pass; full ralph suite green at 210/210; root frontend suite green at 186/186; `npm run lint` clean (0 errors, only pre-existing warnings).

## Notes
- The cycle command takes every external collaborator as a constructor-injected dep (lock, orphans, healthcheck, whatsapp, runQueueOnce, processEnv, claudeCredentialsPath). Tests stub them; production wiring uses the defaults from slices 1-3.
- `ralph.sh --once` is wired via env var (`RALPH_ONCE=1`) too, since the default `runQueueOnce` spawns it. The flag short-circuits end-of-run WhatsApp + `tmux kill-session` while keeping the validation block (it's idempotent via the `config_hash` check).
- This slice does not touch the launchd schedule or `ralph start`/`cycle` coexistence — those are slices 5 and 7.