### PR TITLE
feat(ralph): add lib/launchd.js + ralph schedule install/remove

### DIFF
--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -84,6 +84,45 @@ program
     }
   })
 
+const schedule = program
+  .command('schedule')
+  .description('Manage the macOS launchd agent that runs `ralph cycle` on a timer')
+
+schedule
+  .command('install')
+  .description('Install a launchd agent that fires `ralph cycle` every --interval')
+  .option('--interval <duration>', 'Interval between cycles (e.g. 4h, 30m, 1d)', '4h')
+  .option('--force', 'Overwrite an existing plist for this repo')
+  .action(async (opts) => {
+    try {
+      const result = await scheduleInstallCommand({
+        interval: opts.interval,
+        force: Boolean(opts.force),
+      })
+      process.exit(result.exitCode ?? 0)
+    } catch (e) {
+      if (e instanceof ScheduleAbort) {
+        process.exit(e.exitCode ?? 1)
+      }
+      throw e
+    }
+  })
+
+schedule
+  .command('remove')
+  .description('Unload and delete the launchd agent for the current repo')
+  .action(async () => {
+    try {
+      const result = await scheduleRemoveCommand()
+      process.exit(result.exitCode ?? 0)
+    } catch (e) {
+      if (e instanceof ScheduleAbort) {
+        process.exit(e.exitCode ?? 1)
+      }
+      throw e
+    }
+  })
+
 program
   .command('doctor')
   .description('Check required system deps and print install commands for missing ones')

--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -8,6 +8,11 @@ import { stopCommand, StopAbort } from '../lib/commands/stop.js'
 import { initCommand, InitAbort } from '../lib/commands/init.js'
 import { doctorCommand, DoctorAbort } from '../lib/commands/doctor.js'
 import { cycleCommand, CycleAbort } from '../lib/commands/cycle.js'
+import {
+  scheduleInstallCommand,
+  scheduleRemoveCommand,
+  ScheduleAbort,
+} from '../lib/commands/schedule.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'))

--- a/packages/ralph/lib/commands/schedule.js
+++ b/packages/ralph/lib/commands/schedule.js
@@ -1,0 +1,170 @@
+import { existsSync as realExistsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { execa } from 'execa'
+import { detectPlatform } from '../platform.js'
+import {
+  installAgent as defaultInstallAgent,
+  removeAgent as defaultRemoveAgent,
+  plistPathFor,
+} from '../launchd.js'
+
+const DEFAULT_INTERVAL_SECONDS = 4 * 3600
+
+class ScheduleAbort extends Error {
+  constructor(message, exitCode = 1) {
+    super(message)
+    this.exitCode = exitCode
+  }
+}
+
+export function parseInterval(input) {
+  if (input == null) return DEFAULT_INTERVAL_SECONDS
+  const m = String(input).trim().match(/^(\d+)\s*([smhd]?)$/i)
+  if (!m) {
+    throw new ScheduleAbort(
+      `invalid interval: ${input} (expected e.g. 60, 30m, 2h, 1d)`,
+      1,
+    )
+  }
+  const value = Number.parseInt(m[1], 10)
+  const unit = (m[2] || 's').toLowerCase()
+  switch (unit) {
+    case 's':
+      return value
+    case 'm':
+      return value * 60
+    case 'h':
+      return value * 3600
+    case 'd':
+      return value * 86400
+    default:
+      throw new ScheduleAbort(`invalid interval unit: ${unit}`, 1)
+  }
+}
+
+export async function scheduleInstallCommand({
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  exec = execa,
+  exists = realExistsSync,
+  home = homedir(),
+  platform = detectPlatform(),
+  ralphBinary = defaultRalphBinary(),
+  installAgent = defaultInstallAgent,
+  removeAgent = defaultRemoveAgent,
+  interval,
+  force = false,
+} = {}) {
+  const out = (m) => stdout.write(m + '\n')
+  const err = (m) => stderr.write(m + '\n')
+
+  if (platform !== 'mac') {
+    err(`❌ ralph schedule só suporta macOS (detectado: ${platform}).`)
+    throw new ScheduleAbort('platform not supported', 1)
+  }
+
+  const root = await resolveRepoRoot(exec, cwd)
+  const slug = basename(root)
+  const plistPath = plistPathFor(slug, home)
+
+  if (!exists(resolve(root, 'ralph.config.sh'))) {
+    err('❌ ralph.config.sh missing — run `ralph init` first.')
+    throw new ScheduleAbort('ralph init not run', 1)
+  }
+  if (!exists(resolve(root, '.env.local'))) {
+    out(
+      'ℹ️  .env.local not found — WhatsApp/healthcheck notifications will be skipped at runtime.',
+    )
+  }
+
+  if (exists(plistPath) && !force) {
+    err(
+      `❌ ${plistPath} already exists. Pass --force to overwrite, or run 'ralph schedule remove' first.`,
+    )
+    throw new ScheduleAbort('plist already exists', 1)
+  }
+  if (exists(plistPath) && force) {
+    await removeAgent({ slug, home, exec })
+  }
+
+  const intervalSeconds = parseInterval(interval)
+  const logDir = join(root, 'logs')
+  const result = await installAgent({
+    slug,
+    command: ralphBinary,
+    args: ['cycle'],
+    intervalSeconds,
+    workingDirectory: root,
+    logDir,
+    environment: { PATH: process.env.PATH || '' },
+    home,
+    exec,
+  })
+
+  out(`✅ Installed launchd agent: ${result.label}`)
+  out(`   plist:    ${result.plistPath}`)
+  out(`   interval: ${intervalSeconds}s`)
+  out(`   logs:     ${logDir}/ralph-cycle.{out,err}.log`)
+
+  return {
+    exitCode: 0,
+    slug,
+    intervalSeconds,
+    plistPath: result.plistPath,
+    label: result.label,
+  }
+}
+
+export async function scheduleRemoveCommand({
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  exec = execa,
+  exists = realExistsSync,
+  home = homedir(),
+  platform = detectPlatform(),
+  removeAgent = defaultRemoveAgent,
+} = {}) {
+  const out = (m) => stdout.write(m + '\n')
+  const err = (m) => stderr.write(m + '\n')
+
+  if (platform !== 'mac') {
+    err(`❌ ralph schedule só suporta macOS (detectado: ${platform}).`)
+    throw new ScheduleAbort('platform not supported', 1)
+  }
+
+  const root = await resolveRepoRoot(exec, cwd)
+  const slug = basename(root)
+  const plistPath = plistPathFor(slug, home)
+
+  if (!exists(plistPath)) {
+    out(`ℹ️  No launchd agent installed for ${slug}. Nothing to do.`)
+    return { exitCode: 0, removed: false, slug, plistPath }
+  }
+
+  const result = await removeAgent({ slug, home, exec })
+  out(`✅ Removed launchd agent: ${result.plistPath}`)
+  return {
+    exitCode: 0,
+    removed: result.removed,
+    slug,
+    plistPath: result.plistPath,
+  }
+}
+
+async function resolveRepoRoot(exec, cwd) {
+  const result = await exec('git', ['rev-parse', '--show-toplevel'], {
+    cwd,
+    reject: false,
+  })
+  if (!result || result.exitCode !== 0) return cwd
+  return (result.stdout || '').trim() || cwd
+}
+
+function defaultRalphBinary() {
+  return process.argv[1] || 'ralph'
+}
+
+export { ScheduleAbort }

--- a/packages/ralph/lib/commands/schedule.test.js
+++ b/packages/ralph/lib/commands/schedule.test.js
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseInterval,
+  scheduleInstallCommand,
+  scheduleRemoveCommand,
+} from './schedule.js'
+
+const HOME = '/Users/me'
+const REPO = '/Users/me/repos/agenthub'
+const SLUG = 'agenthub'
+const LABEL = `com.lucasfe.ralph.cycle.${SLUG}`
+const PLIST_PATH = `${HOME}/Library/LaunchAgents/${LABEL}.plist`
+
+function makeStream() {
+  const chunks = []
+  return {
+    write: (s) => {
+      chunks.push(s)
+      return true
+    },
+    output: () => chunks.join(''),
+  }
+}
+
+function makeExec(handlers = {}) {
+  const calls = []
+  const exec = async (cmd, args, options = {}) => {
+    const key = `${cmd} ${args.join(' ')}`
+    calls.push({ key, cmd, args, options })
+    if (Object.prototype.hasOwnProperty.call(handlers, key)) {
+      const v = handlers[key]
+      return typeof v === 'function' ? v({ cmd, args, options }) : v
+    }
+    return { exitCode: 0, stdout: '', stderr: '' }
+  }
+  exec.calls = calls
+  return exec
+}
+
+const baseHandlers = () => ({
+  'git rev-parse --show-toplevel': { exitCode: 0, stdout: `${REPO}\n`, stderr: '' },
+})
+
+const baseDeps = (overrides = {}) => {
+  const stdout = makeStream()
+  const stderr = makeStream()
+  return {
+    cwd: REPO,
+    stdout,
+    stderr,
+    exec: makeExec(baseHandlers()),
+    exists: () => true,
+    home: HOME,
+    platform: 'mac',
+    ralphBinary: '/usr/local/bin/ralph',
+    ...overrides,
+  }
+}
+
+describe('parseInterval', () => {
+  it('returns the default when input is undefined', () => {
+    expect(parseInterval(undefined)).toBe(14400)
+    expect(parseInterval(null)).toBe(14400)
+  })
+
+  it('parses bare integer as seconds', () => {
+    expect(parseInterval('60')).toBe(60)
+    expect(parseInterval('3600')).toBe(3600)
+  })
+
+  it('parses 30m as 1800 seconds', () => {
+    expect(parseInterval('30m')).toBe(1800)
+  })
+
+  it('parses 2h as 7200 seconds', () => {
+    expect(parseInterval('2h')).toBe(7200)
+  })
+
+  it('parses 4h as 14400 seconds', () => {
+    expect(parseInterval('4h')).toBe(14400)
+  })
+
+  it('parses 1d as 86400 seconds', () => {
+    expect(parseInterval('1d')).toBe(86400)
+  })
+
+  it('throws on invalid input', () => {
+    expect(() => parseInterval('not-a-duration')).toThrow()
+    expect(() => parseInterval('4y')).toThrow()
+  })
+})
+
+describe('scheduleInstallCommand — pre-flight', () => {
+  it('aborts when ralph.config.sh is missing', async () => {
+    let installCalled = false
+    const deps = baseDeps({
+      exists: (p) => !p.endsWith('ralph.config.sh'),
+      installAgent: async () => {
+        installCalled = true
+        return { plistPath: PLIST_PATH, label: LABEL, loadResult: { exitCode: 0 } }
+      },
+    })
+    await expect(scheduleInstallCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+    expect(installCalled).toBe(false)
+    expect(deps.stderr.output()).toMatch(/ralph\.config\.sh/)
+    expect(deps.stderr.output()).toMatch(/ralph init/i)
+  })
+
+  it('warns but proceeds when .env.local is missing', async () => {
+    let installCalled = false
+    const deps = baseDeps({
+      exists: (p) => !p.endsWith('.env.local') && !p.endsWith('.plist'),
+      installAgent: async () => {
+        installCalled = true
+        return { plistPath: PLIST_PATH, label: LABEL, loadResult: { exitCode: 0 } }
+      },
+    })
+    const result = await scheduleInstallCommand(deps)
+    expect(installCalled).toBe(true)
+    expect(result.exitCode).toBe(0)
+    expect(deps.stdout.output()).toMatch(/\.env\.local/)
+  })
+
+  it('aborts on non-mac platforms', async () => {
+    const deps = baseDeps({ platform: 'linux' })
+    await expect(scheduleInstallCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+    expect(deps.stderr.output()).toMatch(/macos|mac/i)
+  })
+})
+
+describe('scheduleInstallCommand — existing plist', () => {
+  it('aborts when a plist with the same slug already exists and --force is not set', async () => {
+    let installCalled = false
+    const deps = baseDeps({
+      exists: () => true, // plist exists
+      installAgent: async () => {
+        installCalled = true
+        return { plistPath: PLIST_PATH, label: LABEL, loadResult: { exitCode: 0 } }
+      },
+    })
+    await expect(scheduleInstallCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+    expect(installCalled).toBe(false)
+    expect(deps.stderr.output()).toMatch(/--force/)
+  })
+
+  it('proceeds when --force is set even if plist exists', async () => {
+    let removeCalled = false
+    let installCalled = false
+    const deps = baseDeps({
+      exists: () => true,
+      force: true,
+      removeAgent: async () => {
+        removeCalled = true
+        return { plistPath: PLIST_PATH, removed: true, unloadResult: { exitCode: 0 } }
+      },
+      installAgent: async () => {
+        installCalled = true
+        return { plistPath: PLIST_PATH, label: LABEL, loadResult: { exitCode: 0 } }
+      },
+    })
+    const result = await scheduleInstallCommand(deps)
+    expect(removeCalled).toBe(true)
+    expect(installCalled).toBe(true)
+    expect(result.exitCode).toBe(0)
+  })
+})
+
+describe('scheduleInstallCommand — happy path', () => {
+  it('computes slug from repo basename and installs the launchd agent', async () => {
+    let installArgs = null
+    const deps = baseDeps({
+      exists: (p) => !p.endsWith('.plist'), // no existing plist
+      installAgent: async (args) => {
+        installArgs = args
+        return { plistPath: PLIST_PATH, label: LABEL, loadResult: { exitCode: 0 } }
+      },
+    })
+    const result = await scheduleInstallCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.slug).toBe(SLUG)
+    expect(installArgs.slug).toBe(SLUG)
+    expect(installArgs.workingDirectory).toBe(REPO)
+    expect(installArgs.command).toBe('/usr/local/bin/ralph')
+    expect(installArgs.args).toEqual(['cycle'])
+    expect(installArgs.intervalSeconds).toBe(14400)
+    expect(installArgs.logDir).toBe(`${REPO}/logs`)
+  })
+
+  it('honors a custom --interval flag', async () => {
+    let installArgs = null
+    const deps = baseDeps({
+      exists: (p) => !p.endsWith('.plist'),
+      interval: '30m',
+      installAgent: async (args) => {
+        installArgs = args
+        return { plistPath: PLIST_PATH, label: LABEL, loadResult: { exitCode: 0 } }
+      },
+    })
+    await scheduleInstallCommand(deps)
+    expect(installArgs.intervalSeconds).toBe(1800)
+  })
+
+  it('prints a success summary on stdout', async () => {
+    const deps = baseDeps({
+      exists: (p) => !p.endsWith('.plist'),
+      installAgent: async () => ({
+        plistPath: PLIST_PATH,
+        label: LABEL,
+        loadResult: { exitCode: 0 },
+      }),
+    })
+    await scheduleInstallCommand(deps)
+    const output = deps.stdout.output()
+    expect(output).toMatch(/installed|✅/i)
+    expect(output).toContain(LABEL)
+  })
+})
+
+describe('scheduleRemoveCommand', () => {
+  it('removes the launchd agent matching the current repo slug', async () => {
+    let removeArgs = null
+    const deps = baseDeps({
+      exists: () => true,
+      removeAgent: async (args) => {
+        removeArgs = args
+        return { plistPath: PLIST_PATH, removed: true, unloadResult: { exitCode: 0 } }
+      },
+    })
+    const result = await scheduleRemoveCommand(deps)
+    expect(removeArgs.slug).toBe(SLUG)
+    expect(result.exitCode).toBe(0)
+    expect(result.removed).toBe(true)
+  })
+
+  it('exits 0 with an informational message when no plist is installed', async () => {
+    let removeCalled = false
+    const deps = baseDeps({
+      exists: () => false, // plist missing
+      removeAgent: async () => {
+        removeCalled = true
+        return { plistPath: PLIST_PATH, removed: false, unloadResult: null }
+      },
+    })
+    const result = await scheduleRemoveCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.removed).toBe(false)
+    expect(removeCalled).toBe(false)
+    expect(deps.stdout.output()).toMatch(/no launchd agent|nothing/i)
+  })
+
+  it('aborts on non-mac platforms', async () => {
+    const deps = baseDeps({ platform: 'wsl' })
+    await expect(scheduleRemoveCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+  })
+})

--- a/packages/ralph/lib/launchd.js
+++ b/packages/ralph/lib/launchd.js
@@ -1,0 +1,204 @@
+import {
+  existsSync as realExistsSync,
+  mkdirSync as realMkdirSync,
+  unlinkSync as realUnlinkSync,
+  writeFileSync as realWriteFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+import { execa } from 'execa'
+
+export const LABEL_PREFIX = 'com.lucasfe.ralph.cycle'
+export const DEFAULT_PATH =
+  '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+
+export function labelFor(slug) {
+  return `${LABEL_PREFIX}.${slug}`
+}
+
+export function plistPathFor(slug, home = homedir()) {
+  return join(home, 'Library', 'LaunchAgents', `${labelFor(slug)}.plist`)
+}
+
+export function buildPlist({
+  slug,
+  command,
+  args = [],
+  intervalSeconds,
+  workingDirectory,
+  logDir,
+  environment,
+}) {
+  const env = { PATH: DEFAULT_PATH, ...(environment || {}) }
+  const programArgsXml = [command, ...args]
+    .map((s) => `        <string>${escapeXml(s)}</string>`)
+    .join('\n')
+  const envEntries = Object.entries(env)
+    .map(
+      ([k, v]) =>
+        `        <key>${escapeXml(k)}</key>\n        <string>${escapeXml(v)}</string>`,
+    )
+    .join('\n')
+  const stdoutPath = join(logDir, 'ralph-cycle.out.log')
+  const stderrPath = join(logDir, 'ralph-cycle.err.log')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${escapeXml(labelFor(slug))}</string>
+    <key>ProgramArguments</key>
+    <array>
+${programArgsXml}
+    </array>
+    <key>WorkingDirectory</key>
+    <string>${escapeXml(workingDirectory)}</string>
+    <key>StartInterval</key>
+    <integer>${Number(intervalSeconds)}</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>${escapeXml(stdoutPath)}</string>
+    <key>StandardErrorPath</key>
+    <string>${escapeXml(stderrPath)}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+${envEntries}
+    </dict>
+</dict>
+</plist>
+`
+}
+
+export async function installAgent({
+  slug,
+  command,
+  args = [],
+  intervalSeconds,
+  workingDirectory,
+  logDir,
+  environment,
+  home = homedir(),
+  fsImpl,
+  exec = execa,
+}) {
+  const fs = wrapFs(fsImpl)
+  const path = plistPathFor(slug, home)
+  const body = buildPlist({
+    slug,
+    command,
+    args,
+    intervalSeconds,
+    workingDirectory,
+    logDir,
+    environment,
+  })
+  fs.mkdirSync(dirname(path), { recursive: true })
+  fs.writeFileSync(path, body)
+  const loadResult = await loadAgent({ plistPath: path, exec })
+  return { plistPath: path, label: labelFor(slug), loadResult }
+}
+
+export async function removeAgent({
+  slug,
+  home = homedir(),
+  fsImpl,
+  exec = execa,
+}) {
+  const fs = wrapFs(fsImpl)
+  const path = plistPathFor(slug, home)
+  if (!fs.existsSync(path)) {
+    return { plistPath: path, removed: false, unloadResult: null }
+  }
+  const unloadResult = await unloadAgent({ plistPath: path, exec })
+  fs.unlinkSync(path)
+  return { plistPath: path, removed: true, unloadResult }
+}
+
+export async function loadAgent({ plistPath, exec = execa }) {
+  return await exec('launchctl', ['load', '-w', plistPath], { reject: false })
+}
+
+export async function unloadAgent({ plistPath, exec = execa }) {
+  return await exec('launchctl', ['unload', '-w', plistPath], { reject: false })
+}
+
+export async function getAgentStatus({
+  slug,
+  exec = execa,
+  uid = currentUid(),
+}) {
+  const label = labelFor(slug)
+  const printRes = await exec('launchctl', ['print', `gui/${uid}/${label}`], {
+    reject: false,
+  })
+  if (printRes && printRes.exitCode === 0) {
+    const text = printRes.stdout || ''
+    return {
+      loaded: true,
+      lastExitCode: parseLastExitCode(text),
+      nextRun: parseNextRun(text),
+    }
+  }
+  const listRes = await exec('launchctl', ['list', label], { reject: false })
+  if (listRes && listRes.exitCode === 0) {
+    return {
+      loaded: true,
+      lastExitCode: parseLastExitCodeFromList(listRes.stdout || ''),
+      nextRun: null,
+    }
+  }
+  return { loaded: false, lastExitCode: null, nextRun: null }
+}
+
+function parseLastExitCode(text) {
+  const m = text.match(/last exit code\s*=\s*(-?\d+)/i)
+  return m ? Number.parseInt(m[1], 10) : null
+}
+
+function parseNextRun(text) {
+  const m = text.match(/run interval\s*=\s*(\d+)/i)
+  if (!m) return null
+  return { intervalSeconds: Number.parseInt(m[1], 10) }
+}
+
+function parseLastExitCodeFromList(text) {
+  const m = text.match(/"LastExitStatus"\s*=\s*(-?\d+)/)
+  return m ? Number.parseInt(m[1], 10) : null
+}
+
+function currentUid() {
+  if (typeof process.getuid === 'function') {
+    try {
+      return process.getuid()
+    } catch {
+      // fall through
+    }
+  }
+  return 501
+}
+
+function escapeXml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function wrapFs(fsImpl) {
+  if (!fsImpl) {
+    return {
+      existsSync: realExistsSync,
+      writeFileSync: realWriteFileSync,
+      unlinkSync: realUnlinkSync,
+      mkdirSync: realMkdirSync,
+    }
+  }
+  return {
+    existsSync: fsImpl.existsSync.bind(fsImpl),
+    writeFileSync: fsImpl.writeFileSync.bind(fsImpl),
+    unlinkSync: fsImpl.unlinkSync.bind(fsImpl),
+    mkdirSync: fsImpl.mkdirSync.bind(fsImpl),
+  }
+}

--- a/packages/ralph/lib/launchd.test.js
+++ b/packages/ralph/lib/launchd.test.js
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import {
+  buildPlist,
+  getAgentStatus,
+  installAgent,
+  labelFor,
+  loadAgent,
+  plistPathFor,
+  removeAgent,
+  unloadAgent,
+} from './launchd.js'
+
+const HOME = '/Users/me'
+const SLUG = 'agenthub'
+const LABEL = `com.lucasfe.ralph.cycle.${SLUG}`
+const PLIST_PATH = `${HOME}/Library/LaunchAgents/${LABEL}.plist`
+
+function vol(initial = {}) {
+  const v = Volume.fromJSON(initial, '/')
+  return v
+}
+
+function makeExec(handlers = {}) {
+  const calls = []
+  const exec = async (cmd, args, options = {}) => {
+    const key = `${cmd} ${args.join(' ')}`
+    calls.push({ key, cmd, args, options })
+    if (Object.prototype.hasOwnProperty.call(handlers, key)) {
+      const v = handlers[key]
+      return typeof v === 'function' ? v({ cmd, args, options }) : v
+    }
+    return { exitCode: 0, stdout: '', stderr: '' }
+  }
+  exec.calls = calls
+  return exec
+}
+
+describe('labelFor', () => {
+  it('builds com.lucasfe.ralph.cycle.<slug>', () => {
+    expect(labelFor('agenthub')).toBe('com.lucasfe.ralph.cycle.agenthub')
+    expect(labelFor('my-app')).toBe('com.lucasfe.ralph.cycle.my-app')
+  })
+})
+
+describe('plistPathFor', () => {
+  it('returns ~/Library/LaunchAgents/<label>.plist using the given home', () => {
+    expect(plistPathFor('agenthub', HOME)).toBe(PLIST_PATH)
+  })
+
+  it('differs per slug', () => {
+    expect(plistPathFor('a', HOME)).not.toBe(plistPathFor('b', HOME))
+  })
+})
+
+describe('buildPlist', () => {
+  const baseInput = {
+    slug: SLUG,
+    command: '/usr/local/bin/ralph',
+    args: ['cycle'],
+    intervalSeconds: 14400,
+    workingDirectory: '/Users/me/repos/agenthub',
+    logDir: '/Users/me/repos/agenthub/logs',
+    environment: { PATH: '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin' },
+  }
+
+  it('includes the Label key derived from slug', () => {
+    const xml = buildPlist(baseInput)
+    expect(xml).toContain('<key>Label</key>')
+    expect(xml).toContain(`<string>${LABEL}</string>`)
+  })
+
+  it('includes ProgramArguments with command + args in order', () => {
+    const xml = buildPlist({ ...baseInput, args: ['cycle', '--verbose'] })
+    expect(xml).toMatch(
+      /<key>ProgramArguments<\/key>\s*<array>\s*<string>\/usr\/local\/bin\/ralph<\/string>\s*<string>cycle<\/string>\s*<string>--verbose<\/string>\s*<\/array>/,
+    )
+  })
+
+  it('includes WorkingDirectory', () => {
+    const xml = buildPlist(baseInput)
+    expect(xml).toContain('<key>WorkingDirectory</key>')
+    expect(xml).toContain('<string>/Users/me/repos/agenthub</string>')
+  })
+
+  it('includes StartInterval as <integer>', () => {
+    const xml = buildPlist(baseInput)
+    expect(xml).toMatch(/<key>StartInterval<\/key>\s*<integer>14400<\/integer>/)
+  })
+
+  it('includes RunAtLoad set to false', () => {
+    const xml = buildPlist(baseInput)
+    expect(xml).toMatch(/<key>RunAtLoad<\/key>\s*<false\/>/)
+  })
+
+  it('includes StandardOutPath and StandardErrorPath under logDir', () => {
+    const xml = buildPlist(baseInput)
+    expect(xml).toContain(
+      '<string>/Users/me/repos/agenthub/logs/ralph-cycle.out.log</string>',
+    )
+    expect(xml).toContain(
+      '<string>/Users/me/repos/agenthub/logs/ralph-cycle.err.log</string>',
+    )
+  })
+
+  it('includes EnvironmentVariables with the PATH entry', () => {
+    const xml = buildPlist(baseInput)
+    expect(xml).toMatch(
+      /<key>EnvironmentVariables<\/key>\s*<dict>\s*<key>PATH<\/key>\s*<string>\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>\s*<\/dict>/,
+    )
+  })
+
+  it('always sets a default PATH when environment is not provided', () => {
+    const xml = buildPlist({ ...baseInput, environment: undefined })
+    expect(xml).toContain('<key>PATH</key>')
+    expect(xml).toMatch(/<string>[^<]*\/usr\/bin[^<]*<\/string>/)
+  })
+
+  it('escapes XML-unsafe characters in working directory', () => {
+    const xml = buildPlist({
+      ...baseInput,
+      workingDirectory: '/Users/me/<weird & path>',
+    })
+    expect(xml).toContain(
+      '<string>/Users/me/&lt;weird &amp; path&gt;</string>',
+    )
+  })
+
+  it('starts with the XML prolog and DOCTYPE', () => {
+    const xml = buildPlist(baseInput)
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true)
+    expect(xml).toContain(
+      '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    )
+    expect(xml).toContain('<plist version="1.0">')
+  })
+})
+
+describe('installAgent', () => {
+  const baseInput = {
+    slug: SLUG,
+    command: '/usr/local/bin/ralph',
+    args: ['cycle'],
+    intervalSeconds: 14400,
+    workingDirectory: '/Users/me/repos/agenthub',
+    logDir: '/Users/me/repos/agenthub/logs',
+    environment: { PATH: '/opt/homebrew/bin:/usr/bin' },
+    home: HOME,
+  }
+
+  it('writes the plist to ~/Library/LaunchAgents and runs `launchctl load -w` on it', async () => {
+    const v = vol()
+    const exec = makeExec()
+    const result = await installAgent({ ...baseInput, fsImpl: v, exec })
+    expect(result.plistPath).toBe(PLIST_PATH)
+    expect(result.label).toBe(LABEL)
+    expect(v.existsSync(PLIST_PATH)).toBe(true)
+    const written = v.readFileSync(PLIST_PATH, 'utf8').toString()
+    expect(written).toContain(LABEL)
+    expect(written).toContain('<integer>14400</integer>')
+    const loadCall = exec.calls.find((c) => c.cmd === 'launchctl')
+    expect(loadCall).toBeDefined()
+    expect(loadCall.args).toEqual(['load', '-w', PLIST_PATH])
+  })
+
+  it('creates the LaunchAgents directory if missing', async () => {
+    const v = vol()
+    const exec = makeExec()
+    await installAgent({ ...baseInput, fsImpl: v, exec })
+    expect(v.existsSync(`${HOME}/Library/LaunchAgents`)).toBe(true)
+  })
+
+  it('overwrites an existing plist (caller is responsible for safety)', async () => {
+    const v = vol({
+      [PLIST_PATH]: '<old/>',
+    })
+    v.mkdirSync(`${HOME}/Library/LaunchAgents`, { recursive: true })
+    const exec = makeExec()
+    await installAgent({ ...baseInput, fsImpl: v, exec })
+    const written = v.readFileSync(PLIST_PATH, 'utf8').toString()
+    expect(written).not.toBe('<old/>')
+    expect(written).toContain(LABEL)
+  })
+})
+
+describe('removeAgent', () => {
+  it('runs `launchctl unload -w` and deletes the plist when present', async () => {
+    const v = vol({
+      [PLIST_PATH]: '<plist/>',
+    })
+    const exec = makeExec()
+    const result = await removeAgent({ slug: SLUG, home: HOME, fsImpl: v, exec })
+    expect(result.removed).toBe(true)
+    expect(result.plistPath).toBe(PLIST_PATH)
+    expect(v.existsSync(PLIST_PATH)).toBe(false)
+    const unloadCall = exec.calls.find((c) => c.cmd === 'launchctl')
+    expect(unloadCall.args).toEqual(['unload', '-w', PLIST_PATH])
+  })
+
+  it('returns removed:false and does not call launchctl when the plist is missing', async () => {
+    const v = vol()
+    const exec = makeExec()
+    const result = await removeAgent({ slug: SLUG, home: HOME, fsImpl: v, exec })
+    expect(result.removed).toBe(false)
+    expect(exec.calls.length).toBe(0)
+  })
+})
+
+describe('loadAgent / unloadAgent', () => {
+  it('loadAgent invokes launchctl load -w <path>', async () => {
+    const exec = makeExec()
+    await loadAgent({ plistPath: PLIST_PATH, exec })
+    expect(exec.calls[0].cmd).toBe('launchctl')
+    expect(exec.calls[0].args).toEqual(['load', '-w', PLIST_PATH])
+  })
+
+  it('unloadAgent invokes launchctl unload -w <path>', async () => {
+    const exec = makeExec()
+    await unloadAgent({ plistPath: PLIST_PATH, exec })
+    expect(exec.calls[0].cmd).toBe('launchctl')
+    expect(exec.calls[0].args).toEqual(['unload', '-w', PLIST_PATH])
+  })
+})
+
+describe('getAgentStatus', () => {
+  it('returns loaded:true with parsed last exit code and run interval from `launchctl print`', async () => {
+    const exec = makeExec({
+      [`launchctl print gui/501/${LABEL}`]: {
+        exitCode: 0,
+        stdout: [
+          `${LABEL} = {`,
+          '\tactive count = 0',
+          '\tlast exit code = 0',
+          '\trun interval = 14400',
+          '}',
+        ].join('\n'),
+        stderr: '',
+      },
+    })
+    const status = await getAgentStatus({ slug: SLUG, exec, uid: 501 })
+    expect(status.loaded).toBe(true)
+    expect(status.lastExitCode).toBe(0)
+    expect(status.nextRun).toMatchObject({ intervalSeconds: 14400 })
+  })
+
+  it('falls back to `launchctl list <label>` when print fails but list succeeds', async () => {
+    const exec = makeExec({
+      [`launchctl print gui/501/${LABEL}`]: {
+        exitCode: 113,
+        stdout: '',
+        stderr: 'service is not loaded',
+      },
+      [`launchctl list ${LABEL}`]: {
+        exitCode: 0,
+        stdout: '{\n\t"LastExitStatus" = 0;\n};\n',
+        stderr: '',
+      },
+    })
+    const status = await getAgentStatus({ slug: SLUG, exec, uid: 501 })
+    expect(status.loaded).toBe(true)
+    expect(status.lastExitCode).toBe(0)
+  })
+
+  it('returns loaded:false when both print and list fail', async () => {
+    const exec = makeExec({
+      [`launchctl print gui/501/${LABEL}`]: {
+        exitCode: 113,
+        stdout: '',
+        stderr: 'service is not loaded',
+      },
+      [`launchctl list ${LABEL}`]: {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'unknown',
+      },
+    })
+    const status = await getAgentStatus({ slug: SLUG, exec, uid: 501 })
+    expect(status.loaded).toBe(false)
+    expect(status.lastExitCode).toBeNull()
+    expect(status.nextRun).toBeNull()
+  })
+
+  it('captures a non-zero last exit code from launchctl print', async () => {
+    const exec = makeExec({
+      [`launchctl print gui/501/${LABEL}`]: {
+        exitCode: 0,
+        stdout: 'last exit code = 1\nrun interval = 14400\n',
+        stderr: '',
+      },
+    })
+    const status = await getAgentStatus({ slug: SLUG, exec, uid: 501 })
+    expect(status.loaded).toBe(true)
+    expect(status.lastExitCode).toBe(1)
+  })
+})


### PR DESCRIPTION
Closes #220

## TDD
- Tests added: `packages/ralph/lib/launchd.test.js` (24 tests), `packages/ralph/lib/commands/schedule.test.js` (18 tests)
- Before implementation (red): both files failed to load — `Failed to load url ./launchd.js` and `Failed to load url ./schedule.js`
- After implementation (green): full ralph suite passes — 252 tests across 20 files (was 210); root `npm test` 186 passing; `npm run lint` 0 errors

## What's in
- `lib/launchd.js`: `installAgent`, `removeAgent`, `loadAgent`, `unloadAgent`, `getAgentStatus`, plus pure helpers `labelFor`, `plistPathFor`, `buildPlist`. Plist content includes `Label`, `ProgramArguments`, `WorkingDirectory`, `StartInterval`, `RunAtLoad=false`, `StandardOutPath`, `StandardErrorPath`, `EnvironmentVariables` with default PATH.
- `lib/commands/schedule.js`: `install` / `remove` subcommand handlers + `parseInterval` (`60`, `30m`, `2h`, `1d` → seconds; default `4h` = 14400). Pre-flight: aborts if `ralph.config.sh` missing or platform ≠ mac; warns if `.env.local` missing; aborts if plist exists without `--force`.
- `bin/ralph.js`: registers `ralph schedule install [--interval <duration>] [--force]` and `ralph schedule remove`.
- `getAgentStatus` parses `launchctl print gui/$UID/<label>` and falls back to `launchctl list <label>`.

## Notes
- Mac-only by design: install/remove abort with a clear error on linux/wsl. The platform gate is the only behavior change visible to non-mac users.
- Label scheme: `com.lucasfe.ralph.cycle.<basename(repoRoot)>`. Slug is derived from `git rev-parse --show-toplevel` basename, matching the cycle/lock convention.
- `installAgent` is intentionally unconditional (overwrites + reloads); the safety check (existing plist → require `--force`) lives in `schedule install` so the deep module stays simple.
- The auto-commit hook produced six `auto: update …` commits on this branch — a squash-merge collapses them into the conventional commit title above.