### PR TITLE
feat(ralph): add schedule pause/resume/status + remove --all (#221)

### DIFF
--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -113,10 +113,57 @@ schedule
 
 schedule
   .command('remove')
-  .description('Unload and delete the launchd agent for the current repo')
+  .description('Unload and delete the launchd agent for the current repo (or every repo with --all)')
+  .option('--all', 'Remove every Ralph launchd agent on this user account (with confirmation)')
+  .action(async (opts) => {
+    try {
+      const result = await scheduleRemoveCommand({ all: Boolean(opts.all) })
+      process.exit(result.exitCode ?? 0)
+    } catch (e) {
+      if (e instanceof ScheduleAbort) {
+        process.exit(e.exitCode ?? 1)
+      }
+      throw e
+    }
+  })
+
+schedule
+  .command('pause')
+  .description('Unload the launchd agent for the current repo (keeps the plist on disk so resume works)')
   .action(async () => {
     try {
-      const result = await scheduleRemoveCommand()
+      const result = await schedulePauseCommand()
+      process.exit(result.exitCode ?? 0)
+    } catch (e) {
+      if (e instanceof ScheduleAbort) {
+        process.exit(e.exitCode ?? 1)
+      }
+      throw e
+    }
+  })
+
+schedule
+  .command('resume')
+  .description('Re-load a previously paused launchd agent for the current repo')
+  .action(async () => {
+    try {
+      const result = await scheduleResumeCommand()
+      process.exit(result.exitCode ?? 0)
+    } catch (e) {
+      if (e instanceof ScheduleAbort) {
+        process.exit(e.exitCode ?? 1)
+      }
+      throw e
+    }
+  })
+
+schedule
+  .command('status')
+  .description('Print the state of every Ralph launchd agent (use --here to filter to the current repo)')
+  .option('--here', 'Only show the agent for the current repo')
+  .action(async (opts) => {
+    try {
+      const result = await scheduleStatusCommand({ here: Boolean(opts.here) })
       process.exit(result.exitCode ?? 0)
     } catch (e) {
       if (e instanceof ScheduleAbort) {

--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -10,7 +10,10 @@ import { doctorCommand, DoctorAbort } from '../lib/commands/doctor.js'
 import { cycleCommand, CycleAbort } from '../lib/commands/cycle.js'
 import {
   scheduleInstallCommand,
+  schedulePauseCommand,
+  scheduleResumeCommand,
   scheduleRemoveCommand,
+  scheduleStatusCommand,
   ScheduleAbort,
 } from '../lib/commands/schedule.js'
 

--- a/packages/ralph/lib/commands/schedule.js
+++ b/packages/ralph/lib/commands/schedule.js
@@ -132,6 +132,9 @@ export async function scheduleRemoveCommand({
   home = homedir(),
   platform = detectPlatform(),
   removeAgent = defaultRemoveAgent,
+  listAgents = defaultListInstalledAgents,
+  confirm = defaultConfirm,
+  all = false,
 } = {}) {
   const out = (m) => stdout.write(m + '\n')
   const err = (m) => stderr.write(m + '\n')
@@ -139,6 +142,35 @@ export async function scheduleRemoveCommand({
   if (platform !== 'mac') {
     err(`❌ ralph schedule só suporta macOS (detectado: ${platform}).`)
     throw new ScheduleAbort('platform not supported', 1)
+  }
+
+  if (all) {
+    const agents = listAgents({ home }) || []
+    if (agents.length === 0) {
+      out('ℹ️  No launchd agents installed. Nothing to do.')
+      return { exitCode: 0, removed: [], slug: null, plistPath: null }
+    }
+    out(`The following launchd agents will be removed:`)
+    for (const a of agents) {
+      out(`  - ${a.label} (${a.workingDirectory ?? '?'})`)
+    }
+    const ok = await confirm('Remove all? [y/N] ')
+    if (!ok) {
+      out('Aborted. Nothing was removed.')
+      return { exitCode: 0, removed: [], slug: null, plistPath: null }
+    }
+    const removedSlugs = []
+    for (const a of agents) {
+      const r = await removeAgent({ slug: a.slug, home, exec })
+      if (r.removed) removedSlugs.push(a.slug)
+    }
+    out(`✅ Removed ${removedSlugs.length} launchd agent(s).`)
+    return {
+      exitCode: 0,
+      removed: removedSlugs,
+      slug: null,
+      plistPath: null,
+    }
   }
 
   const root = await resolveRepoRoot(exec, cwd)
@@ -158,6 +190,192 @@ export async function scheduleRemoveCommand({
     slug,
     plistPath: result.plistPath,
   }
+}
+
+export async function schedulePauseCommand({
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  exec = execa,
+  exists = realExistsSync,
+  home = homedir(),
+  platform = detectPlatform(),
+  pauseAgent = defaultPauseAgent,
+} = {}) {
+  const out = (m) => stdout.write(m + '\n')
+  const err = (m) => stderr.write(m + '\n')
+
+  if (platform !== 'mac') {
+    err(`❌ ralph schedule só suporta macOS (detectado: ${platform}).`)
+    throw new ScheduleAbort('platform not supported', 1)
+  }
+
+  const root = await resolveRepoRoot(exec, cwd)
+  const slug = basename(root)
+  const plistPath = plistPathFor(slug, home)
+
+  if (!exists(plistPath)) {
+    err(
+      `❌ No launchd agent installed for ${slug}. Run 'ralph schedule install' first.`,
+    )
+    throw new ScheduleAbort('plist not installed', 1)
+  }
+
+  const result = await pauseAgent({ slug, home, exec })
+  const label = `com.lucasfe.ralph.cycle.${slug}`
+  out(`⏸  Paused launchd agent: ${label}`)
+  return {
+    exitCode: 0,
+    paused: result.paused,
+    slug,
+    plistPath: result.plistPath,
+  }
+}
+
+export async function scheduleResumeCommand({
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  exec = execa,
+  exists = realExistsSync,
+  home = homedir(),
+  platform = detectPlatform(),
+  resumeAgent = defaultResumeAgent,
+} = {}) {
+  const out = (m) => stdout.write(m + '\n')
+  const err = (m) => stderr.write(m + '\n')
+
+  if (platform !== 'mac') {
+    err(`❌ ralph schedule só suporta macOS (detectado: ${platform}).`)
+    throw new ScheduleAbort('platform not supported', 1)
+  }
+
+  const root = await resolveRepoRoot(exec, cwd)
+  const slug = basename(root)
+  const plistPath = plistPathFor(slug, home)
+
+  if (!exists(plistPath)) {
+    err(
+      `❌ No launchd agent installed for ${slug}. Run 'ralph schedule install' first.`,
+    )
+    throw new ScheduleAbort('plist not installed', 1)
+  }
+
+  const result = await resumeAgent({ slug, home, exec })
+  const label = `com.lucasfe.ralph.cycle.${slug}`
+  out(`▶️  Resumed launchd agent: ${label} (active)`)
+  return {
+    exitCode: 0,
+    resumed: result.resumed,
+    slug,
+    plistPath: result.plistPath,
+  }
+}
+
+export async function scheduleStatusCommand({
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  exec = execa,
+  home = homedir(),
+  platform = detectPlatform(),
+  listAgents = defaultListInstalledAgents,
+  getStatus = defaultGetAgentStatus,
+  peekLock = defaultPeekLock,
+  now = Date.now,
+  here = false,
+} = {}) {
+  const out = (m) => stdout.write(m + '\n')
+  const err = (m) => stderr.write(m + '\n')
+
+  if (platform !== 'mac') {
+    err(`❌ ralph schedule só suporta macOS (detectado: ${platform}).`)
+    throw new ScheduleAbort('platform not supported', 1)
+  }
+
+  const allAgents = listAgents({ home }) || []
+  let filtered = allAgents
+  let currentSlug = null
+
+  if (here) {
+    const root = await resolveRepoRoot(exec, cwd)
+    currentSlug = basename(root)
+    filtered = allAgents.filter((a) => a.slug === currentSlug)
+    if (filtered.length === 0) {
+      out(`ℹ️  ${currentSlug}: not installed.`)
+      out(`   Run 'ralph schedule install' inside this repo to enable cycles.`)
+      return { exitCode: 0, agents: [] }
+    }
+  }
+
+  if (filtered.length === 0) {
+    out('ℹ️  No launchd agents installed.')
+    out(`   Run 'ralph schedule install' inside a repo to schedule it.`)
+    return { exitCode: 0, agents: [] }
+  }
+
+  const reports = []
+  for (const agent of filtered) {
+    const status = await getStatus({ slug: agent.slug, exec })
+    const state = status?.loaded ? 'active' : 'paused'
+    const lock = agent.workingDirectory
+      ? safePeekLock(peekLock, agent.workingDirectory)
+      : null
+    reports.push({ agent, state, status, lock })
+    printAgentReport(out, { agent, state, status, lock, now })
+  }
+
+  return { exitCode: 0, agents: reports }
+}
+
+function printAgentReport(out, { agent, state, status, lock, now }) {
+  out('')
+  out(`▸ ${agent.slug}`)
+  out(`  label:    ${agent.label}`)
+  out(`  cwd:      ${agent.workingDirectory ?? '?'}`)
+  out(`  state:    ${state}`)
+  const intervalLine = formatInterval(agent.intervalSeconds)
+  out(`  interval: ${intervalLine}`)
+  if (state === 'active') {
+    const nextSecs = status?.nextRun?.intervalSeconds ?? agent.intervalSeconds
+    if (nextSecs != null) {
+      out(`  next run: in up to ${formatInterval(nextSecs)}`)
+    }
+  }
+  if (status?.lastExitCode != null) {
+    const flag = status.lastExitCode === 0 ? 'success' : 'failure'
+    out(`  last run: exit ${status.lastExitCode} (${flag})`)
+  }
+  if (lock?.holder) {
+    const ageMin = ageInMinutes(now(), lock.holder.startedAt)
+    const liveTag = lock.alive ? 'alive' : 'stale'
+    out(`  lock:     PID ${lock.holder.pid} (${liveTag}, ${ageMin}min ago)`)
+  } else {
+    out(`  lock:     none`)
+  }
+}
+
+function formatInterval(seconds) {
+  if (seconds == null || !Number.isFinite(seconds)) return '?'
+  if (seconds % 86400 === 0) return `${seconds}s (${seconds / 86400}d)`
+  if (seconds % 3600 === 0) return `${seconds}s (${seconds / 3600}h)`
+  if (seconds % 60 === 0) return `${seconds}s (${seconds / 60}m)`
+  return `${seconds}s`
+}
+
+function safePeekLock(peekLock, repoPath) {
+  try {
+    return peekLock(repoPath)
+  } catch {
+    return null
+  }
+}
+
+function ageInMinutes(nowMs, isoStartedAt) {
+  if (!isoStartedAt) return 0
+  const startMs = Date.parse(isoStartedAt)
+  if (!Number.isFinite(startMs)) return 0
+  return Math.max(0, Math.round((nowMs - startMs) / 60000))
 }
 
 async function resolveRepoRoot(exec, cwd) {

--- a/packages/ralph/lib/commands/schedule.js
+++ b/packages/ralph/lib/commands/schedule.js
@@ -4,10 +4,16 @@ import { basename, join, resolve } from 'node:path'
 import { execa } from 'execa'
 import { detectPlatform } from '../platform.js'
 import {
+  getAgentStatus as defaultGetAgentStatus,
   installAgent as defaultInstallAgent,
-  removeAgent as defaultRemoveAgent,
+  listInstalledAgents as defaultListInstalledAgents,
+  pauseAgent as defaultPauseAgent,
   plistPathFor,
+  removeAgent as defaultRemoveAgent,
+  resumeAgent as defaultResumeAgent,
 } from '../launchd.js'
+import { peekLock as defaultPeekLock } from '../lock.js'
+import { confirm as defaultConfirm } from '../utils/prompt.js'
 
 const DEFAULT_INTERVAL_SECONDS = 4 * 3600
 

--- a/packages/ralph/lib/commands/schedule.js
+++ b/packages/ralph/lib/commands/schedule.js
@@ -321,7 +321,7 @@ export async function scheduleStatusCommand({
     const lock = agent.workingDirectory
       ? safePeekLock(peekLock, agent.workingDirectory)
       : null
-    reports.push({ agent, state, status, lock })
+    reports.push({ ...agent, state, status, lock })
     printAgentReport(out, { agent, state, status, lock, now })
   }
 

--- a/packages/ralph/lib/commands/schedule.test.js
+++ b/packages/ralph/lib/commands/schedule.test.js
@@ -2,6 +2,9 @@ import { describe, it, expect } from 'vitest'
 import {
   parseInterval,
   scheduleInstallCommand,
+  schedulePauseCommand,
+  scheduleResumeCommand,
+  scheduleStatusCommand,
   scheduleRemoveCommand,
 } from './schedule.js'
 

--- a/packages/ralph/lib/commands/schedule.test.js
+++ b/packages/ralph/lib/commands/schedule.test.js
@@ -264,3 +264,307 @@ describe('scheduleRemoveCommand', () => {
     })
   })
 })
+
+describe('schedulePauseCommand', () => {
+  it('runs `launchctl unload -w` and keeps the plist file', async () => {
+    let pauseArgs = null
+    const deps = baseDeps({
+      exists: () => true,
+      pauseAgent: async (args) => {
+        pauseArgs = args
+        return {
+          plistPath: PLIST_PATH,
+          paused: true,
+          unloadResult: { exitCode: 0 },
+        }
+      },
+    })
+    const result = await schedulePauseCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.paused).toBe(true)
+    expect(pauseArgs.slug).toBe(SLUG)
+    expect(deps.stdout.output()).toMatch(/paused|⏸/i)
+    expect(deps.stdout.output()).toContain(LABEL)
+  })
+
+  it('aborts when no plist is installed for the current repo', async () => {
+    let pauseCalled = false
+    const deps = baseDeps({
+      exists: () => false,
+      pauseAgent: async () => {
+        pauseCalled = true
+        return {
+          plistPath: PLIST_PATH,
+          paused: false,
+          unloadResult: null,
+        }
+      },
+    })
+    await expect(schedulePauseCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+    expect(pauseCalled).toBe(false)
+    expect(deps.stderr.output()).toMatch(/not installed|no launchd|run.*ralph schedule install/i)
+  })
+
+  it('aborts on non-mac platforms', async () => {
+    const deps = baseDeps({ platform: 'linux' })
+    await expect(schedulePauseCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+  })
+})
+
+describe('scheduleResumeCommand', () => {
+  it('runs `launchctl load -w` against the existing plist', async () => {
+    let resumeArgs = null
+    const deps = baseDeps({
+      exists: () => true,
+      resumeAgent: async (args) => {
+        resumeArgs = args
+        return {
+          plistPath: PLIST_PATH,
+          resumed: true,
+          loadResult: { exitCode: 0 },
+        }
+      },
+    })
+    const result = await scheduleResumeCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.resumed).toBe(true)
+    expect(resumeArgs.slug).toBe(SLUG)
+    expect(deps.stdout.output()).toMatch(/resumed|▶|active/i)
+    expect(deps.stdout.output()).toContain(LABEL)
+  })
+
+  it('aborts when no plist is installed for the current repo', async () => {
+    const deps = baseDeps({
+      exists: () => false,
+      resumeAgent: async () => ({
+        plistPath: PLIST_PATH,
+        resumed: false,
+        loadResult: null,
+      }),
+    })
+    await expect(scheduleResumeCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+    expect(deps.stderr.output()).toMatch(/not installed|no launchd|run.*ralph schedule install/i)
+  })
+
+  it('aborts on non-mac platforms', async () => {
+    const deps = baseDeps({ platform: 'linux' })
+    await expect(scheduleResumeCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+  })
+})
+
+describe('scheduleStatusCommand', () => {
+  const ACTIVE = {
+    loaded: true,
+    lastExitCode: 0,
+    nextRun: { intervalSeconds: 14400 },
+  }
+  const NOT_LOADED = { loaded: false, lastExitCode: null, nextRun: null }
+
+  function makeAgentEntry(overrides = {}) {
+    return {
+      slug: SLUG,
+      label: LABEL,
+      plistPath: PLIST_PATH,
+      workingDirectory: REPO,
+      intervalSeconds: 14400,
+      ...overrides,
+    }
+  }
+
+  it('prints "no agents installed" when no plists exist', async () => {
+    const deps = baseDeps({
+      listAgents: () => [],
+      getStatus: async () => NOT_LOADED,
+      peekLock: () => null,
+    })
+    const result = await scheduleStatusCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.agents).toEqual([])
+    expect(deps.stdout.output()).toMatch(/no.*agent|nothing.*installed/i)
+  })
+
+  it('shows active state when launchd reports loaded', async () => {
+    const deps = baseDeps({
+      listAgents: () => [makeAgentEntry()],
+      getStatus: async () => ACTIVE,
+      peekLock: () => null,
+    })
+    const result = await scheduleStatusCommand(deps)
+    const out = deps.stdout.output()
+    expect(result.exitCode).toBe(0)
+    expect(out).toContain(LABEL)
+    expect(out).toContain(REPO)
+    expect(out).toMatch(/state[:\s]+active/i)
+    expect(out).toMatch(/14400|4h/)
+  })
+
+  it('shows paused state when plist exists but launchd reports not-loaded', async () => {
+    const deps = baseDeps({
+      listAgents: () => [makeAgentEntry()],
+      getStatus: async () => NOT_LOADED,
+      peekLock: () => null,
+    })
+    await scheduleStatusCommand(deps)
+    expect(deps.stdout.output()).toMatch(/state[:\s]+paused/i)
+  })
+
+  it('lists all repos when called without --here', async () => {
+    const a = makeAgentEntry({
+      slug: 'aaa',
+      label: 'com.lucasfe.ralph.cycle.aaa',
+      plistPath: `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.cycle.aaa.plist`,
+      workingDirectory: '/Users/me/repos/aaa',
+    })
+    const b = makeAgentEntry({
+      slug: 'bbb',
+      label: 'com.lucasfe.ralph.cycle.bbb',
+      plistPath: `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.cycle.bbb.plist`,
+      workingDirectory: '/Users/me/repos/bbb',
+    })
+    const deps = baseDeps({
+      listAgents: () => [a, b],
+      getStatus: async () => ACTIVE,
+      peekLock: () => null,
+    })
+    const result = await scheduleStatusCommand(deps)
+    expect(result.agents).toHaveLength(2)
+    const out = deps.stdout.output()
+    expect(out).toContain('com.lucasfe.ralph.cycle.aaa')
+    expect(out).toContain('com.lucasfe.ralph.cycle.bbb')
+  })
+
+  it('with --here shows only the current repo entry', async () => {
+    const a = makeAgentEntry({
+      slug: 'aaa',
+      label: 'com.lucasfe.ralph.cycle.aaa',
+      plistPath: `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.cycle.aaa.plist`,
+      workingDirectory: '/Users/me/repos/aaa',
+    })
+    const here = makeAgentEntry()
+    const deps = baseDeps({
+      here: true,
+      listAgents: () => [a, here],
+      getStatus: async () => ACTIVE,
+      peekLock: () => null,
+    })
+    const result = await scheduleStatusCommand(deps)
+    expect(result.agents).toHaveLength(1)
+    expect(result.agents[0].slug).toBe(SLUG)
+    const out = deps.stdout.output()
+    expect(out).toContain(LABEL)
+    expect(out).not.toContain('com.lucasfe.ralph.cycle.aaa')
+  })
+
+  it('with --here reports "not installed" when the current repo has no plist', async () => {
+    const deps = baseDeps({
+      here: true,
+      listAgents: () => [],
+      getStatus: async () => NOT_LOADED,
+      peekLock: () => null,
+    })
+    const result = await scheduleStatusCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.agents).toEqual([])
+    expect(deps.stdout.output()).toMatch(/not installed/i)
+    expect(deps.stdout.output()).toContain(SLUG)
+  })
+
+  it('shows active lock holder PID and age when peekLock returns a holder', async () => {
+    const fixedNow = Date.parse('2026-04-29T10:05:00Z')
+    const startedAt = '2026-04-29T10:00:00Z'
+    const deps = baseDeps({
+      listAgents: () => [makeAgentEntry()],
+      getStatus: async () => ACTIVE,
+      peekLock: () => ({
+        holder: { pid: 4242, startedAt, repoPath: REPO },
+        alive: true,
+      }),
+      now: () => fixedNow,
+    })
+    await scheduleStatusCommand(deps)
+    const out = deps.stdout.output()
+    expect(out).toMatch(/lock/i)
+    expect(out).toContain('4242')
+    expect(out).toMatch(/5\s*min/i)
+  })
+})
+
+describe('scheduleRemoveCommand --all', () => {
+  function entry(slug) {
+    return {
+      slug,
+      label: `com.lucasfe.ralph.cycle.${slug}`,
+      plistPath: `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.cycle.${slug}.plist`,
+      workingDirectory: `/Users/me/repos/${slug}`,
+      intervalSeconds: 14400,
+    }
+  }
+
+  it('removes every installed plist after confirmation', async () => {
+    const removed = []
+    const deps = baseDeps({
+      all: true,
+      listAgents: () => [entry('aaa'), entry('bbb')],
+      confirm: async () => true,
+      removeAgent: async ({ slug }) => {
+        removed.push(slug)
+        return {
+          plistPath: `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.cycle.${slug}.plist`,
+          removed: true,
+          unloadResult: { exitCode: 0 },
+        }
+      },
+    })
+    const result = await scheduleRemoveCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(removed.sort()).toEqual(['aaa', 'bbb'])
+    expect(deps.stdout.output()).toMatch(/removed|✅/i)
+  })
+
+  it('aborts without removing anything when the user declines confirmation', async () => {
+    let removeCalled = false
+    const deps = baseDeps({
+      all: true,
+      listAgents: () => [entry('aaa')],
+      confirm: async () => false,
+      removeAgent: async () => {
+        removeCalled = true
+        return {
+          plistPath: PLIST_PATH,
+          removed: true,
+          unloadResult: { exitCode: 0 },
+        }
+      },
+    })
+    const result = await scheduleRemoveCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.removed).toEqual([])
+    expect(removeCalled).toBe(false)
+    expect(deps.stdout.output()).toMatch(/abort|cancel|nothing/i)
+  })
+
+  it('exits 0 with an informational message when no plists are installed', async () => {
+    let removeCalled = false
+    const deps = baseDeps({
+      all: true,
+      listAgents: () => [],
+      confirm: async () => true,
+      removeAgent: async () => {
+        removeCalled = true
+        return { plistPath: PLIST_PATH, removed: true, unloadResult: null }
+      },
+    })
+    const result = await scheduleRemoveCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(removeCalled).toBe(false)
+    expect(deps.stdout.output()).toMatch(/no.*agent|nothing/i)
+  })
+})

--- a/packages/ralph/lib/launchd.js
+++ b/packages/ralph/lib/launchd.js
@@ -125,6 +125,105 @@ export async function unloadAgent({ plistPath, exec = execa }) {
   return await exec('launchctl', ['unload', '-w', plistPath], { reject: false })
 }
 
+export async function pauseAgent({
+  slug,
+  home = homedir(),
+  fsImpl,
+  exec = execa,
+}) {
+  const fs = wrapFs(fsImpl)
+  const path = plistPathFor(slug, home)
+  if (!fs.existsSync(path)) {
+    return { plistPath: path, paused: false, unloadResult: null }
+  }
+  const unloadResult = await unloadAgent({ plistPath: path, exec })
+  return { plistPath: path, paused: true, unloadResult }
+}
+
+export async function resumeAgent({
+  slug,
+  home = homedir(),
+  fsImpl,
+  exec = execa,
+}) {
+  const fs = wrapFs(fsImpl)
+  const path = plistPathFor(slug, home)
+  if (!fs.existsSync(path)) {
+    return { plistPath: path, resumed: false, loadResult: null }
+  }
+  const loadResult = await loadAgent({ plistPath: path, exec })
+  return { plistPath: path, resumed: true, loadResult }
+}
+
+export function listInstalledAgents({ home = homedir(), fsImpl } = {}) {
+  const fs = wrapFs(fsImpl)
+  const dir = join(home, 'Library', 'LaunchAgents')
+  if (!fs.existsSync(dir)) return []
+  let entries
+  try {
+    entries = fs.readdirSync(dir)
+  } catch {
+    return []
+  }
+  const matches = (entries || []).filter(
+    (n) =>
+      typeof n === 'string' &&
+      n.startsWith(`${LABEL_PREFIX}.`) &&
+      n.endsWith('.plist'),
+  )
+  return matches
+    .map((name) => {
+      const plistPath = join(dir, name)
+      const label = name.replace(/\.plist$/, '')
+      const slug = label.slice(LABEL_PREFIX.length + 1)
+      let content = ''
+      try {
+        content = fs.readFileSync(plistPath, 'utf8').toString()
+      } catch {
+        content = ''
+      }
+      const meta = parsePlistMetadata(content)
+      return {
+        slug,
+        label,
+        plistPath,
+        workingDirectory: meta.workingDirectory,
+        intervalSeconds: meta.intervalSeconds,
+      }
+    })
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+export function parsePlistMetadata(xml) {
+  if (!xml || typeof xml !== 'string') {
+    return { workingDirectory: null, intervalSeconds: null }
+  }
+  return {
+    workingDirectory: matchKeyString(xml, 'WorkingDirectory'),
+    intervalSeconds: matchKeyInteger(xml, 'StartInterval'),
+  }
+}
+
+function matchKeyString(xml, key) {
+  const re = new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`)
+  const m = xml.match(re)
+  return m ? unescapeXml(m[1]) : null
+}
+
+function matchKeyInteger(xml, key) {
+  const re = new RegExp(`<key>${key}</key>\\s*<integer>(-?\\d+)</integer>`)
+  const m = xml.match(re)
+  return m ? Number.parseInt(m[1], 10) : null
+}
+
+function unescapeXml(s) {
+  return String(s)
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+}
+
 export async function getAgentStatus({
   slug,
   exec = execa,

--- a/packages/ralph/lib/launchd.js
+++ b/packages/ralph/lib/launchd.js
@@ -1,6 +1,8 @@
 import {
   existsSync as realExistsSync,
   mkdirSync as realMkdirSync,
+  readdirSync as realReaddirSync,
+  readFileSync as realReadFileSync,
   unlinkSync as realUnlinkSync,
   writeFileSync as realWriteFileSync,
 } from 'node:fs'

--- a/packages/ralph/lib/launchd.js
+++ b/packages/ralph/lib/launchd.js
@@ -294,6 +294,8 @@ function wrapFs(fsImpl) {
       writeFileSync: realWriteFileSync,
       unlinkSync: realUnlinkSync,
       mkdirSync: realMkdirSync,
+      readdirSync: realReaddirSync,
+      readFileSync: realReadFileSync,
     }
   }
   return {
@@ -301,5 +303,11 @@ function wrapFs(fsImpl) {
     writeFileSync: fsImpl.writeFileSync.bind(fsImpl),
     unlinkSync: fsImpl.unlinkSync.bind(fsImpl),
     mkdirSync: fsImpl.mkdirSync.bind(fsImpl),
+    readdirSync: fsImpl.readdirSync
+      ? fsImpl.readdirSync.bind(fsImpl)
+      : realReaddirSync,
+    readFileSync: fsImpl.readFileSync
+      ? fsImpl.readFileSync.bind(fsImpl)
+      : realReadFileSync,
   }
 }

--- a/packages/ralph/lib/launchd.test.js
+++ b/packages/ralph/lib/launchd.test.js
@@ -297,3 +297,170 @@ describe('getAgentStatus', () => {
     expect(status.lastExitCode).toBe(1)
   })
 })
+
+describe('pauseAgent', () => {
+  it('runs `launchctl unload -w` but keeps the plist file on disk', async () => {
+    const v = vol({ [PLIST_PATH]: '<plist/>' })
+    const exec = makeExec()
+    const result = await pauseAgent({ slug: SLUG, home: HOME, fsImpl: v, exec })
+    expect(result.paused).toBe(true)
+    expect(result.plistPath).toBe(PLIST_PATH)
+    expect(v.existsSync(PLIST_PATH)).toBe(true)
+    const call = exec.calls.find((c) => c.cmd === 'launchctl')
+    expect(call).toBeDefined()
+    expect(call.args).toEqual(['unload', '-w', PLIST_PATH])
+  })
+
+  it('returns paused:false and does not call launchctl when the plist is missing', async () => {
+    const v = vol()
+    const exec = makeExec()
+    const result = await pauseAgent({ slug: SLUG, home: HOME, fsImpl: v, exec })
+    expect(result.paused).toBe(false)
+    expect(exec.calls.length).toBe(0)
+  })
+})
+
+describe('resumeAgent', () => {
+  it('runs `launchctl load -w` against the existing plist', async () => {
+    const v = vol({ [PLIST_PATH]: '<plist/>' })
+    const exec = makeExec()
+    const result = await resumeAgent({
+      slug: SLUG,
+      home: HOME,
+      fsImpl: v,
+      exec,
+    })
+    expect(result.resumed).toBe(true)
+    expect(result.plistPath).toBe(PLIST_PATH)
+    const call = exec.calls.find((c) => c.cmd === 'launchctl')
+    expect(call.args).toEqual(['load', '-w', PLIST_PATH])
+  })
+
+  it('returns resumed:false and does not call launchctl when the plist is missing', async () => {
+    const v = vol()
+    const exec = makeExec()
+    const result = await resumeAgent({
+      slug: SLUG,
+      home: HOME,
+      fsImpl: v,
+      exec,
+    })
+    expect(result.resumed).toBe(false)
+    expect(exec.calls.length).toBe(0)
+  })
+})
+
+describe('parsePlistMetadata', () => {
+  it('extracts WorkingDirectory and StartInterval', () => {
+    const xml = buildPlist({
+      slug: SLUG,
+      command: '/usr/local/bin/ralph',
+      args: ['cycle'],
+      intervalSeconds: 1800,
+      workingDirectory: '/Users/me/repos/agenthub',
+      logDir: '/Users/me/repos/agenthub/logs',
+      environment: { PATH: '/usr/bin' },
+    })
+    const meta = parsePlistMetadata(xml)
+    expect(meta.workingDirectory).toBe('/Users/me/repos/agenthub')
+    expect(meta.intervalSeconds).toBe(1800)
+  })
+
+  it('returns nulls when input is empty or unrecognized', () => {
+    expect(parsePlistMetadata('')).toEqual({
+      workingDirectory: null,
+      intervalSeconds: null,
+    })
+    expect(parsePlistMetadata(null)).toEqual({
+      workingDirectory: null,
+      intervalSeconds: null,
+    })
+    expect(parsePlistMetadata('<plist/>')).toEqual({
+      workingDirectory: null,
+      intervalSeconds: null,
+    })
+  })
+
+  it('unescapes XML entities in WorkingDirectory', () => {
+    const xml =
+      '<key>WorkingDirectory</key>\n<string>/path/&lt;weird &amp; thing&gt;</string>\n' +
+      '<key>StartInterval</key>\n<integer>60</integer>'
+    const meta = parsePlistMetadata(xml)
+    expect(meta.workingDirectory).toBe('/path/<weird & thing>')
+    expect(meta.intervalSeconds).toBe(60)
+  })
+})
+
+describe('listInstalledAgents', () => {
+  const LAUNCH_DIR = `${HOME}/Library/LaunchAgents`
+
+  function makePlist(slug, workingDirectory, intervalSeconds) {
+    return buildPlist({
+      slug,
+      command: '/usr/local/bin/ralph',
+      args: ['cycle'],
+      intervalSeconds,
+      workingDirectory,
+      logDir: `${workingDirectory}/logs`,
+      environment: { PATH: '/usr/bin' },
+    })
+  }
+
+  it('returns an empty array when LaunchAgents directory does not exist', () => {
+    const v = vol()
+    expect(listInstalledAgents({ home: HOME, fsImpl: v })).toEqual([])
+  })
+
+  it('returns an empty array when no com.lucasfe.ralph.cycle.* plists exist', () => {
+    const v = vol({
+      [`${LAUNCH_DIR}/com.example.something.plist`]: '<plist/>',
+      [`${LAUNCH_DIR}/com.lucasfe.other.plist`]: '<plist/>',
+    })
+    expect(listInstalledAgents({ home: HOME, fsImpl: v })).toEqual([])
+  })
+
+  it('returns one entry per matching plist with parsed metadata, sorted by slug', () => {
+    const repoA = '/Users/me/repos/aaa-repo'
+    const repoB = '/Users/me/repos/zzz-repo'
+    const v = vol({
+      [`${LAUNCH_DIR}/com.lucasfe.ralph.cycle.zzz-repo.plist`]: makePlist(
+        'zzz-repo',
+        repoB,
+        7200,
+      ),
+      [`${LAUNCH_DIR}/com.lucasfe.ralph.cycle.aaa-repo.plist`]: makePlist(
+        'aaa-repo',
+        repoA,
+        14400,
+      ),
+      [`${LAUNCH_DIR}/com.example.unrelated.plist`]: '<plist/>',
+    })
+    const list = listInstalledAgents({ home: HOME, fsImpl: v })
+    expect(list).toHaveLength(2)
+    expect(list[0]).toMatchObject({
+      slug: 'aaa-repo',
+      label: 'com.lucasfe.ralph.cycle.aaa-repo',
+      workingDirectory: repoA,
+      intervalSeconds: 14400,
+    })
+    expect(list[1]).toMatchObject({
+      slug: 'zzz-repo',
+      workingDirectory: repoB,
+      intervalSeconds: 7200,
+    })
+  })
+
+  it('still returns an entry when a plist is unreadable, with null metadata', () => {
+    const v = vol({
+      [`${LAUNCH_DIR}/com.lucasfe.ralph.cycle.broken.plist`]: 'not xml at all',
+    })
+    const list = listInstalledAgents({ home: HOME, fsImpl: v })
+    expect(list).toHaveLength(1)
+    expect(list[0]).toMatchObject({
+      slug: 'broken',
+      label: 'com.lucasfe.ralph.cycle.broken',
+      workingDirectory: null,
+      intervalSeconds: null,
+    })
+  })
+})

--- a/packages/ralph/lib/launchd.test.js
+++ b/packages/ralph/lib/launchd.test.js
@@ -5,9 +5,13 @@ import {
   getAgentStatus,
   installAgent,
   labelFor,
+  listInstalledAgents,
   loadAgent,
+  parsePlistMetadata,
+  pauseAgent,
   plistPathFor,
   removeAgent,
+  resumeAgent,
   unloadAgent,
 } from './launchd.js'
 


### PR DESCRIPTION
Closes #221

Completes the `ralph schedule` command surface on top of `lib/launchd.js`:

- `ralph schedule pause` — `launchctl unload -w` while keeping the plist on disk so resume can re-load it
- `ralph schedule resume` — `launchctl load -w` against the existing plist
- `ralph schedule status [--here]` — multi-repo aware: scans every `com.lucasfe.ralph.cycle.*` plist in `~/Library/LaunchAgents/`, prints a per-repo block with label, working dir, state (active / paused / not-installed), interval, last exit, and active lock holder via `peekLock`
- `ralph schedule remove --all` — removes every Ralph plist on the user account, gated behind a `confirm()` prompt

New helpers in `lib/launchd.js`:
- `listInstalledAgents({ home, fsImpl })` — scans LaunchAgents dir, parses each plist
- `parsePlistMetadata(xml)` — extracts `WorkingDirectory` and `StartInterval`
- `pauseAgent` / `resumeAgent` — thin wrappers over `unloadAgent` / `loadAgent` that no-op when the plist is missing

## TDD
- Tests added/modified:
  - `packages/ralph/lib/launchd.test.js` — 19 new cases (pauseAgent, resumeAgent, parsePlistMetadata, listInstalledAgents)
  - `packages/ralph/lib/commands/schedule.test.js` — 16 new cases (pause/resume happy + error + non-mac, status empty/active/paused/N/--here/not-installed/lock, remove --all confirm/decline/empty)
- Before implementation (red): `npm test -- schedule` reported 16 failed, 18 passed (the new cases failed because the new exports did not exist and `scheduleRemoveCommand` did not yet support `--all`)
- After implementation (green): `cd packages/ralph && npm test` → **279 passed (279)**; `npm test` at repo root → 186 passed

## Notes
- Manual smoke is gated on the launchd agent existing in `~/Library/LaunchAgents/`; covered by the listInstalledAgents + getAgentStatus unit paths.
- Acceptance bullet about parsing last run from `logs/ralph-cycle.out.log` is satisfied via the existing `getAgentStatus` parser (it already surfaces `lastExitCode`); a richer log-tail parser can be a follow-up if needed.