### PR TITLE
feat(ralph): start aborts when cycle lock is alive

### DIFF
--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -41,6 +41,8 @@ export async function startCommand({
   readSt = readState,
   writeSt = writeState,
   sendWa = sendWhatsappMessage,
+  peekLock = defaultPeekLock,
+  now = Date.now,
 } = {}) {
   const out = (msg) => stdout.write(msg + '\n')
   const err = (msg) => stderr.write(msg + '\n')
@@ -55,6 +57,17 @@ export async function startCommand({
       out(`   Matar:  tmux kill-session -t ${TMUX_SESSION}`)
       throw new StartAbort('tmux session already exists', 1)
     }
+  }
+
+  // 1.5. ralph cycle coexistence — abort if a live cycle holds the lock.
+  // Stale lock holders fall through silently so a crashed cycle doesn't block start.
+  const lockState = peekLock(cwd)
+  if (lockState && lockState.alive) {
+    const ageH = ageInHours(now(), lockState.holder?.startedAt)
+    err(
+      `⏸️ Cycle in progress (PID ${lockState.holder?.pid} for ${ageH}h) — wait or run \`ralph schedule pause\` first`,
+    )
+    throw new StartAbort('cycle lock held', 1)
   }
 
   // 2. Required commands (shared dep check)

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -12,6 +12,7 @@ import { detectPlatform } from '../platform.js'
 import { readState, writeState } from '../state.js'
 import { checkForUpdate } from '../update-check.js'
 import { sendWhatsappMessage } from '../utils/whatsapp.js'
+import { peekLock as defaultPeekLock } from '../lock.js'
 
 const TMUX_SESSION = 'ralph'
 const SEARCH_QUERY =

--- a/packages/ralph/lib/commands/start.js
+++ b/packages/ralph/lib/commands/start.js
@@ -269,4 +269,11 @@ export async function startCommand({
   return { exitCode: 0, started: true, count: Number(count) }
 }
 
+function ageInHours(nowMs, isoStartedAt) {
+  if (!isoStartedAt) return 0
+  const startMs = Date.parse(isoStartedAt)
+  if (!Number.isFinite(startMs)) return 0
+  return Math.max(0, Math.round((nowMs - startMs) / 3600000))
+}
+
 export { StartAbort }

--- a/packages/ralph/test/commands/start.test.js
+++ b/packages/ralph/test/commands/start.test.js
@@ -389,4 +389,133 @@ describe('startCommand', () => {
     expect(writes).toHaveLength(0)
   })
 
+  describe('cycle-lock coexistence', () => {
+    it('aborts when an alive cycle lock is held', async () => {
+      const deps = baseDeps()
+      const cwd = '/repo'
+      const peekCalls = []
+      deps.peekLock = (repoPath) => {
+        peekCalls.push(repoPath)
+        return {
+          holder: {
+            pid: 9999,
+            startedAt: '2026-04-29T00:00:00.000Z',
+            repoPath: cwd,
+          },
+          alive: true,
+        }
+      }
+      deps.now = () => Date.parse('2026-04-29T02:00:00.000Z')
+      deps.exec = makeExec({
+        'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      })
+      await expect(startCommand({ ...deps, cwd })).rejects.toBeInstanceOf(StartAbort)
+      expect(peekCalls).toHaveLength(1)
+      expect(peekCalls[0]).toBe(cwd)
+      const errOut = deps.stderr.output()
+      expect(errOut).toContain('⏸️ Cycle in progress')
+      expect(errOut).toContain('PID 9999')
+      expect(errOut).toContain('2h')
+      expect(errOut).toContain('ralph schedule pause')
+      expect(deps.exec.calls.some((c) => c.startsWith('gh auth status'))).toBe(false)
+      expect(deps.exec.calls.some((c) => c.startsWith('tmux new -d -s ralph'))).toBe(false)
+    })
+
+    it('proceeds when the cycle lock holder is stale (alive=false)', async () => {
+      const deps = baseDeps()
+      const cwd = '/repo'
+      deps.peekLock = () => ({
+        holder: {
+          pid: 4242,
+          startedAt: '2025-01-01T00:00:00.000Z',
+          repoPath: cwd,
+        },
+        alive: false,
+      })
+      deps.exec = makeExec({
+        'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+        'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+        'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+        },
+        'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length':
+          { exitCode: 0, stdout: '0', stderr: '' },
+      })
+      const result = await startCommand({ ...deps, cwd })
+      expect(result.exitCode).toBe(0)
+      expect(deps.stderr.output()).not.toContain('Cycle in progress')
+    })
+
+    it('proceeds normally when no cycle lock is held', async () => {
+      const deps = baseDeps()
+      const cwd = '/repo'
+      deps.peekLock = () => null
+      deps.exec = makeExec({
+        'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+        'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+        'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+        },
+        'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length':
+          { exitCode: 0, stdout: '0', stderr: '' },
+      })
+      const result = await startCommand({ ...deps, cwd })
+      expect(result.exitCode).toBe(0)
+      expect(deps.stderr.output()).not.toContain('Cycle in progress')
+    })
+
+    it('uses peekLock (read-only) and never acquires the lock', async () => {
+      const deps = baseDeps()
+      const cwd = '/repo'
+      let acquireCalled = false
+      deps.peekLock = () => null
+      deps.acquireLock = () => {
+        acquireCalled = true
+        return { acquired: true, holder: { pid: 1, startedAt: '', repoPath: cwd } }
+      }
+      deps.exec = makeExec({
+        'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+        'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
+        'gh issue list --state open --label claude-working --json number,title -q .[] | "  #\\(.number) \\(.title)"': {
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+        },
+        'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length':
+          { exitCode: 0, stdout: '0', stderr: '' },
+      })
+      await startCommand({ ...deps, cwd })
+      expect(acquireCalled).toBe(false)
+    })
+
+    it('does not send a WhatsApp notification on the alive-lock abort path', async () => {
+      const deps = baseDeps()
+      const cwd = '/repo'
+      let waCalled = false
+      deps.exists = (p) => p.endsWith('.env.local')
+      deps.loadEnv = () => ({ CALLMEBOT_KEY: 'k', WHATSAPP_PHONE: '+1' })
+      deps.sendWa = async () => {
+        waCalled = true
+        return { ok: true }
+      }
+      deps.peekLock = () => ({
+        holder: {
+          pid: 1234,
+          startedAt: '2026-04-29T00:00:00.000Z',
+          repoPath: cwd,
+        },
+        alive: true,
+      })
+      deps.now = () => Date.parse('2026-04-29T01:00:00.000Z')
+      deps.exec = makeExec({
+        'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      })
+      await expect(startCommand({ ...deps, cwd })).rejects.toBeInstanceOf(StartAbort)
+      expect(waCalled).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
Closes #222

## TDD
- Tests added/modified: `packages/ralph/test/commands/start.test.js`
- Before implementation (red): two new tests in the `cycle-lock coexistence` block failed because `startCommand` did not call `peekLock` — the alive-lock path resolved with `{ exitCode: 0, started: true }` instead of throwing `StartAbort`.
- After implementation (green): all 284 ralph tests pass via `cd packages/ralph && npm test` (5 new tests in `cycle-lock coexistence`, 279 pre-existing). Frontend: 186/186 pass via `npm test`. Lint: 0 errors (25 pre-existing fast-refresh warnings, untouched).

## Notes
- Wired `peekLock` from `lib/lock.js` into `startCommand` as an injected dep (defaults to the real implementation). The check runs immediately after the tmux session-uniqueness guard and before any other side effect (gh auth, label creation, queue check, tmux launch, WhatsApp notify).
- Alive lock → `stderr` carries `⏸️ Cycle in progress (PID X for Yh) — wait or run \`ralph schedule pause\` first` and the command throws `StartAbort('cycle lock held', 1)` (exit code 1). No WhatsApp notification on this path — start is interactive, the user reads stderr.
- Stale lock (`alive=false`) → ignored silently. A crashed cycle that left a lockfile behind must not block start.
- No lock at all → existing behavior unchanged.
- The check uses `peekLock` (read-only) and never `acquireLock` — start does not own the cycle lock, it only inspects it.
- Age in hours uses a small local helper (`ageInHours`) mirroring the `ageInMinutes` helper in `cycle.js` but rounded to hours to match the issue's message format.