### PR TITLE
feat(ralph): add lib/heartbeat.js + ralph schedule heartbeat — daily 24h summary

### DIFF
--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -94,13 +94,20 @@ const schedule = program
 
 schedule
   .command('install')
-  .description('Install a launchd agent that fires `ralph cycle` every --interval')
+  .description(
+    'Install both launchd agents: cycle (every --interval) + heartbeat (daily summary at RALPH_DAILY_SUMMARY_TIME or 09:00)',
+  )
   .option('--interval <duration>', 'Interval between cycles (e.g. 4h, 30m, 1d)', '4h')
-  .option('--force', 'Overwrite an existing plist for this repo')
+  .option(
+    '--heartbeat-time <hh:mm>',
+    'Time for the daily heartbeat summary (defaults to RALPH_DAILY_SUMMARY_TIME or 09:00)',
+  )
+  .option('--force', 'Overwrite existing plists for this repo')
   .action(async (opts) => {
     try {
       const result = await scheduleInstallCommand({
         interval: opts.interval,
+        heartbeatTime: opts.heartbeatTime,
         force: Boolean(opts.force),
       })
       process.exit(result.exitCode ?? 0)

--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -181,6 +181,23 @@ schedule
     }
   })
 
+schedule
+  .command('heartbeat')
+  .description(
+    'Internal: aggregate the last 24h of cycle logs and send the daily summary via WhatsApp',
+  )
+  .action(async () => {
+    try {
+      const result = await scheduleHeartbeatCommand()
+      process.exit(result.exitCode ?? 0)
+    } catch (e) {
+      if (e instanceof ScheduleAbort) {
+        process.exit(e.exitCode ?? 1)
+      }
+      throw e
+    }
+  })
+
 program
   .command('doctor')
   .description('Check required system deps and print install commands for missing ones')

--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -9,6 +9,7 @@ import { initCommand, InitAbort } from '../lib/commands/init.js'
 import { doctorCommand, DoctorAbort } from '../lib/commands/doctor.js'
 import { cycleCommand, CycleAbort } from '../lib/commands/cycle.js'
 import {
+  scheduleHeartbeatCommand,
   scheduleInstallCommand,
   schedulePauseCommand,
   scheduleResumeCommand,

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -142,6 +142,13 @@ export async function cycleCommand({
     const queueCount = await getQueueCount(exec, root)
     if (queueCount === 0) {
       out('ℹ️  ralph cycle: fila vazia, encerrando.')
+      emitEvent({
+        status: 'queue-empty',
+        ok: 0,
+        failed: 0,
+        durationMin: 0,
+        processed: 0,
+      })
       return {
         exitCode: 0,
         status: 'queue-empty',

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -113,6 +113,14 @@ export async function cycleCommand({
     await notify(
       `⏭ ralph cycle skipped em ${repoSlug}: instância rodando há ${ageMin}min (PID ${lockResult.holder?.pid})`,
     )
+    emitEvent({
+      status: 'lock-held',
+      ok: 0,
+      failed: 0,
+      durationMin: 0,
+      processed: 0,
+      holderPid: lockResult.holder?.pid ?? null,
+    })
     return {
       exitCode: 0,
       status: 'lock-held',

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -89,6 +89,14 @@ export async function cycleCommand({
   if (!preflight.ok) {
     err(`❌ ralph cycle: pré-checagem falhou (${preflight.reason}).`)
     await notify(`🔴 ralph cycle abortado em ${repoSlug}: ${preflight.reason}`)
+    emitEvent({
+      status: 'preflight-failed',
+      ok: 0,
+      failed: 0,
+      durationMin: 0,
+      processed: 0,
+      reason: preflight.reason,
+    })
     return {
       exitCode: 1,
       status: 'preflight-failed',

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -186,6 +186,14 @@ export async function cycleCommand({
       }
     }
 
+    emitEvent({
+      status,
+      ok: successes.length,
+      failed: failures.length,
+      durationMin,
+      processed: successes.length + failures.length,
+    })
+
     return {
       exitCode: 0,
       status,

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -21,6 +21,7 @@ import { templatePath } from '../paths.js'
 const TMUX_SESSION = 'ralph'
 const SEARCH_QUERY =
   'state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge'
+const CYCLE_EVENT_TAG = 'RALPH_CYCLE_EVENT'
 
 class CycleAbort extends Error {
   constructor(message, exitCode = 1) {

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -54,8 +54,14 @@ export async function cycleCommand({
 
   const root = await resolveRepoRoot(exec, cwd)
 
+  const emitEvent = (event) => {
+    const payload = { ts: new Date(now()).toISOString(), ...event }
+    out(`${CYCLE_EVENT_TAG} ${JSON.stringify(payload)}`)
+  }
+
   const tmux = await exec('tmux', ['has-session', '-t', TMUX_SESSION], { reject: false })
   if (tmux.exitCode === 0) {
+    emitEvent({ status: 'tmux-active', ok: 0, failed: 0, durationMin: 0, processed: 0 })
     return { exitCode: 0, status: 'tmux-active', processed: 0, skipped: true }
   }
 

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -419,3 +419,112 @@ describe('cycleCommand — best-effort failures never abort the cycle', () => {
     expect(deps.sendWa.messages).toEqual([])
   })
 })
+
+describe('cycleCommand — RALPH_CYCLE_EVENT log line', () => {
+  function readEvent(stdout) {
+    const text = stdout.output()
+    const idx = text.indexOf('RALPH_CYCLE_EVENT ')
+    if (idx === -1) return null
+    const lineEnd = text.indexOf('\n', idx)
+    const line = text.slice(idx, lineEnd === -1 ? text.length : lineEnd)
+    const jsonPart = line.slice('RALPH_CYCLE_EVENT '.length).trim()
+    return JSON.parse(jsonPart)
+  }
+
+  it('emits status=success with ts/ok/failed/durationMin/processed on the success path', async () => {
+    const deps = baseDeps({
+      runQueueOnce: async () => ({ successes: [101, 102], failures: [] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '2',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    expect(event).not.toBeNull()
+    expect(event.status).toBe('success')
+    expect(event.ok).toBe(2)
+    expect(event.failed).toBe(0)
+    expect(event.processed).toBe(2)
+    expect(typeof event.ts).toBe('string')
+    expect(event.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('emits status=tmux-active when tmux session is already running', async () => {
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'tmux has-session -t ralph': { exitCode: 0, stdout: '', stderr: '' },
+    })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    expect(event).not.toBeNull()
+    expect(event.status).toBe('tmux-active')
+  })
+
+  it('emits status=lock-held when another instance holds the lock', async () => {
+    const deps = baseDeps({
+      acquireLock: () => ({
+        acquired: false,
+        holder: { pid: 9999, startedAt: '2026-04-29T00:00:00.000Z', repoPath: REPO },
+      }),
+    })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    expect(event).not.toBeNull()
+    expect(event.status).toBe('lock-held')
+    expect(event.holderPid).toBe(9999)
+  })
+
+  it('emits status=preflight-failed when preflight rejects', async () => {
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh auth status': { exitCode: 1, stdout: '', stderr: 'not authenticated' },
+    })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    expect(event).not.toBeNull()
+    expect(event.status).toBe('preflight-failed')
+  })
+
+  it('emits status=queue-empty when no issues are queued', async () => {
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    expect(event).not.toBeNull()
+    expect(event.status).toBe('queue-empty')
+  })
+
+  it('emits status=failed when every issue failed', async () => {
+    const deps = baseDeps({
+      runQueueOnce: async () => ({ successes: [], failures: [101] }),
+    })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '1',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    expect(event).not.toBeNull()
+    expect(event.status).toBe('failed')
+    expect(event.ok).toBe(0)
+    expect(event.failed).toBe(1)
+  })
+})

--- a/packages/ralph/lib/commands/schedule.js
+++ b/packages/ralph/lib/commands/schedule.js
@@ -14,8 +14,15 @@ import {
 } from '../launchd.js'
 import { peekLock as defaultPeekLock } from '../lock.js'
 import { confirm as defaultConfirm } from '../utils/prompt.js'
+import { loadEnvFile as defaultLoadEnv } from '../utils/env.js'
+import {
+  formatSummary as defaultFormatSummary,
+  summarizeLast24h as defaultSummarizeLast24h,
+} from '../heartbeat.js'
+import { sendWhatsappMessage as defaultSendWhatsapp } from '../utils/whatsapp.js'
 
 const DEFAULT_INTERVAL_SECONDS = 4 * 3600
+const DEFAULT_HEARTBEAT_TIME = '09:00'
 
 class ScheduleAbort extends Error {
   constructor(message, exitCode = 1) {
@@ -49,6 +56,32 @@ export function parseInterval(input) {
   }
 }
 
+export function parseHeartbeatTime(input) {
+  const raw = (input ?? DEFAULT_HEARTBEAT_TIME).trim()
+  const m = raw.match(/^(\d{1,2}):(\d{2})$/)
+  if (!m) {
+    throw new ScheduleAbort(
+      `invalid heartbeat time: ${input} (expected HH:MM, e.g. 09:00)`,
+      1,
+    )
+  }
+  const hour = Number.parseInt(m[1], 10)
+  const minute = Number.parseInt(m[2], 10)
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    throw new ScheduleAbort(
+      `invalid heartbeat time: ${input} (hour 0-23, minute 0-59)`,
+      1,
+    )
+  }
+  return { hour, minute }
+}
+
+function formatHeartbeatTime({ hour, minute }) {
+  const hh = String(hour).padStart(2, '0')
+  const mm = String(minute).padStart(2, '0')
+  return `${hh}:${mm}`
+}
+
 export async function scheduleInstallCommand({
   cwd = process.cwd(),
   stdout = process.stdout,
@@ -61,6 +94,8 @@ export async function scheduleInstallCommand({
   installAgent = defaultInstallAgent,
   removeAgent = defaultRemoveAgent,
   interval,
+  heartbeatTime,
+  processEnv = process.env,
   force = false,
 } = {}) {
   const out = (m) => stdout.write(m + '\n')
@@ -73,7 +108,8 @@ export async function scheduleInstallCommand({
 
   const root = await resolveRepoRoot(exec, cwd)
   const slug = basename(root)
-  const plistPath = plistPathFor(slug, home)
+  const cyclePlistPath = plistPathFor(slug, home, 'cycle')
+  const heartbeatPlistPath = plistPathFor(slug, home, 'heartbeat')
 
   if (!exists(resolve(root, 'ralph.config.sh'))) {
     err('❌ ralph.config.sh missing — run `ralph init` first.')
@@ -85,41 +121,85 @@ export async function scheduleInstallCommand({
     )
   }
 
-  if (exists(plistPath) && !force) {
+  const cycleExists = exists(cyclePlistPath)
+  const heartbeatExists = exists(heartbeatPlistPath)
+  if ((cycleExists || heartbeatExists) && !force) {
+    const which = [
+      cycleExists ? cyclePlistPath : null,
+      heartbeatExists ? heartbeatPlistPath : null,
+    ]
+      .filter(Boolean)
+      .join(', ')
     err(
-      `❌ ${plistPath} already exists. Pass --force to overwrite, or run 'ralph schedule remove' first.`,
+      `❌ ${which} already exists. Pass --force to overwrite, or run 'ralph schedule remove' first.`,
     )
     throw new ScheduleAbort('plist already exists', 1)
   }
-  if (exists(plistPath) && force) {
-    await removeAgent({ slug, home, exec })
+  if (cycleExists && force) {
+    await removeAgent({ slug, kind: 'cycle', home, exec })
+  }
+  if (heartbeatExists && force) {
+    await removeAgent({ slug, kind: 'heartbeat', home, exec })
   }
 
   const intervalSeconds = parseInterval(interval)
+  const heartbeatAt = parseHeartbeatTime(
+    heartbeatTime ?? processEnv.RALPH_DAILY_SUMMARY_TIME,
+  )
   const logDir = join(root, 'logs')
-  const result = await installAgent({
+  const baseEnv = { PATH: processEnv.PATH || '' }
+
+  const cycleResult = await installAgent({
     slug,
+    kind: 'cycle',
     command: ralphBinary,
     args: ['cycle'],
     intervalSeconds,
     workingDirectory: root,
     logDir,
-    environment: { PATH: process.env.PATH || '' },
+    environment: baseEnv,
     home,
     exec,
   })
 
-  out(`✅ Installed launchd agent: ${result.label}`)
-  out(`   plist:    ${result.plistPath}`)
-  out(`   interval: ${intervalSeconds}s`)
-  out(`   logs:     ${logDir}/ralph-cycle.{out,err}.log`)
+  const heartbeatResult = await installAgent({
+    slug,
+    kind: 'heartbeat',
+    command: ralphBinary,
+    args: ['schedule', 'heartbeat'],
+    startCalendarInterval: heartbeatAt,
+    workingDirectory: root,
+    logDir,
+    environment: baseEnv,
+    home,
+    exec,
+  })
+
+  out(`✅ Installed launchd agents for ${slug}:`)
+  out(`   cycle:     ${cycleResult.label}`)
+  out(`     plist:    ${cycleResult.plistPath}`)
+  out(`     interval: ${intervalSeconds}s`)
+  out(`     logs:     ${logDir}/ralph-cycle.{out,err}.log`)
+  out(`   heartbeat: ${heartbeatResult.label}`)
+  out(`     plist:    ${heartbeatResult.plistPath}`)
+  out(`     time:     daily at ${formatHeartbeatTime(heartbeatAt)}`)
+  out(`     logs:     ${logDir}/ralph-heartbeat.{out,err}.log`)
 
   return {
     exitCode: 0,
     slug,
     intervalSeconds,
-    plistPath: result.plistPath,
-    label: result.label,
+    heartbeatTime: formatHeartbeatTime(heartbeatAt),
+    cycle: {
+      plistPath: cycleResult.plistPath,
+      label: cycleResult.label,
+    },
+    heartbeat: {
+      plistPath: heartbeatResult.plistPath,
+      label: heartbeatResult.label,
+    },
+    plistPath: cycleResult.plistPath,
+    label: cycleResult.label,
   }
 }
 
@@ -161,7 +241,12 @@ export async function scheduleRemoveCommand({
     }
     const removedSlugs = []
     for (const a of agents) {
-      const r = await removeAgent({ slug: a.slug, home, exec })
+      const r = await removeAgent({
+        slug: a.slug,
+        kind: a.kind ?? 'cycle',
+        home,
+        exec,
+      })
       if (r.removed) removedSlugs.push(a.slug)
     }
     out(`✅ Removed ${removedSlugs.length} launchd agent(s).`)
@@ -175,20 +260,48 @@ export async function scheduleRemoveCommand({
 
   const root = await resolveRepoRoot(exec, cwd)
   const slug = basename(root)
-  const plistPath = plistPathFor(slug, home)
+  const cyclePlistPath = plistPathFor(slug, home, 'cycle')
+  const heartbeatPlistPath = plistPathFor(slug, home, 'heartbeat')
 
-  if (!exists(plistPath)) {
+  const cycleExists = exists(cyclePlistPath)
+  const heartbeatExists = exists(heartbeatPlistPath)
+
+  if (!cycleExists && !heartbeatExists) {
     out(`ℹ️  No launchd agent installed for ${slug}. Nothing to do.`)
-    return { exitCode: 0, removed: false, slug, plistPath }
+    return {
+      exitCode: 0,
+      removed: false,
+      slug,
+      plistPath: cyclePlistPath,
+      cycle: { removed: false, plistPath: cyclePlistPath },
+      heartbeat: { removed: false, plistPath: heartbeatPlistPath },
+    }
   }
 
-  const result = await removeAgent({ slug, home, exec })
-  out(`✅ Removed launchd agent: ${result.plistPath}`)
+  let cycleResult = { removed: false, plistPath: cyclePlistPath }
+  if (cycleExists) {
+    cycleResult = await removeAgent({ slug, kind: 'cycle', home, exec })
+    out(`✅ Removed launchd agent: ${cycleResult.plistPath}`)
+  }
+
+  let heartbeatResult = { removed: false, plistPath: heartbeatPlistPath }
+  if (heartbeatExists) {
+    heartbeatResult = await removeAgent({
+      slug,
+      kind: 'heartbeat',
+      home,
+      exec,
+    })
+    out(`✅ Removed launchd agent: ${heartbeatResult.plistPath}`)
+  }
+
   return {
     exitCode: 0,
-    removed: result.removed,
+    removed: cycleResult.removed || heartbeatResult.removed,
     slug,
-    plistPath: result.plistPath,
+    plistPath: cycleResult.plistPath,
+    cycle: cycleResult,
+    heartbeat: heartbeatResult,
   }
 }
 
@@ -212,23 +325,40 @@ export async function schedulePauseCommand({
 
   const root = await resolveRepoRoot(exec, cwd)
   const slug = basename(root)
-  const plistPath = plistPathFor(slug, home)
+  const cyclePlistPath = plistPathFor(slug, home, 'cycle')
+  const heartbeatPlistPath = plistPathFor(slug, home, 'heartbeat')
 
-  if (!exists(plistPath)) {
+  const cycleExists = exists(cyclePlistPath)
+  const heartbeatExists = exists(heartbeatPlistPath)
+
+  if (!cycleExists && !heartbeatExists) {
     err(
       `❌ No launchd agent installed for ${slug}. Run 'ralph schedule install' first.`,
     )
     throw new ScheduleAbort('plist not installed', 1)
   }
 
-  const result = await pauseAgent({ slug, home, exec })
-  const label = `com.lucasfe.ralph.cycle.${slug}`
-  out(`⏸  Paused launchd agent: ${label}`)
+  const cycleResult = cycleExists
+    ? await pauseAgent({ slug, kind: 'cycle', home, exec })
+    : { paused: false, plistPath: cyclePlistPath }
+  const heartbeatResult = heartbeatExists
+    ? await pauseAgent({ slug, kind: 'heartbeat', home, exec })
+    : { paused: false, plistPath: heartbeatPlistPath }
+
+  if (cycleExists) {
+    out(`⏸  Paused launchd agent: com.lucasfe.ralph.cycle.${slug}`)
+  }
+  if (heartbeatExists) {
+    out(`⏸  Paused launchd agent: com.lucasfe.ralph.heartbeat.${slug}`)
+  }
+
   return {
     exitCode: 0,
-    paused: result.paused,
+    paused: cycleResult.paused || heartbeatResult.paused,
     slug,
-    plistPath: result.plistPath,
+    plistPath: cycleResult.plistPath,
+    cycle: cycleResult,
+    heartbeat: heartbeatResult,
   }
 }
 
@@ -252,23 +382,42 @@ export async function scheduleResumeCommand({
 
   const root = await resolveRepoRoot(exec, cwd)
   const slug = basename(root)
-  const plistPath = plistPathFor(slug, home)
+  const cyclePlistPath = plistPathFor(slug, home, 'cycle')
+  const heartbeatPlistPath = plistPathFor(slug, home, 'heartbeat')
 
-  if (!exists(plistPath)) {
+  const cycleExists = exists(cyclePlistPath)
+  const heartbeatExists = exists(heartbeatPlistPath)
+
+  if (!cycleExists && !heartbeatExists) {
     err(
       `❌ No launchd agent installed for ${slug}. Run 'ralph schedule install' first.`,
     )
     throw new ScheduleAbort('plist not installed', 1)
   }
 
-  const result = await resumeAgent({ slug, home, exec })
-  const label = `com.lucasfe.ralph.cycle.${slug}`
-  out(`▶️  Resumed launchd agent: ${label} (active)`)
+  const cycleResult = cycleExists
+    ? await resumeAgent({ slug, kind: 'cycle', home, exec })
+    : { resumed: false, plistPath: cyclePlistPath }
+  const heartbeatResult = heartbeatExists
+    ? await resumeAgent({ slug, kind: 'heartbeat', home, exec })
+    : { resumed: false, plistPath: heartbeatPlistPath }
+
+  if (cycleExists) {
+    out(`▶️  Resumed launchd agent: com.lucasfe.ralph.cycle.${slug} (active)`)
+  }
+  if (heartbeatExists) {
+    out(
+      `▶️  Resumed launchd agent: com.lucasfe.ralph.heartbeat.${slug} (active)`,
+    )
+  }
+
   return {
     exitCode: 0,
-    resumed: result.resumed,
+    resumed: cycleResult.resumed || heartbeatResult.resumed,
     slug,
-    plistPath: result.plistPath,
+    plistPath: cycleResult.plistPath,
+    cycle: cycleResult,
+    heartbeat: heartbeatResult,
   }
 }
 
@@ -316,42 +465,161 @@ export async function scheduleStatusCommand({
 
   const reports = []
   for (const agent of filtered) {
-    const status = await getStatus({ slug: agent.slug, exec })
+    const kind = agent.kind ?? 'cycle'
+    const status = await getStatus({ slug: agent.slug, kind, exec })
     const state = status?.loaded ? 'active' : 'paused'
-    const lock = agent.workingDirectory
-      ? safePeekLock(peekLock, agent.workingDirectory)
-      : null
-    reports.push({ ...agent, state, status, lock })
-    printAgentReport(out, { agent, state, status, lock, now })
+    const lock =
+      kind === 'cycle' && agent.workingDirectory
+        ? safePeekLock(peekLock, agent.workingDirectory)
+        : null
+    reports.push({ ...agent, kind, state, status, lock })
+    printAgentReport(out, { agent: { ...agent, kind }, state, status, lock, now })
   }
 
   return { exitCode: 0, agents: reports }
 }
 
+export async function scheduleHeartbeatCommand({
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  exec = execa,
+  exists = realExistsSync,
+  home = homedir(),
+  platform = detectPlatform(),
+  loadEnv = defaultLoadEnv,
+  summarize = defaultSummarizeLast24h,
+  format = defaultFormatSummary,
+  sendWa = defaultSendWhatsapp,
+  listAgents = defaultListInstalledAgents,
+  clock = Date.now,
+  processEnv = process.env,
+} = {}) {
+  const out = (m) => stdout.write(m + '\n')
+  const err = (m) => stderr.write(m + '\n')
+
+  if (platform !== 'mac') {
+    err(`❌ ralph schedule só suporta macOS (detectado: ${platform}).`)
+    throw new ScheduleAbort('platform not supported', 1)
+  }
+
+  const root = await resolveRepoRoot(exec, cwd)
+  const slug = basename(root)
+  const logDir = join(root, 'logs')
+  const repoSlug = await resolveRepoSlug(exec, root, slug)
+  const env = loadEnvIfExists(exists, loadEnv, resolve(root, '.env.local'))
+  const callmebotKey = env.CALLMEBOT_KEY ?? processEnv.CALLMEBOT_KEY ?? ''
+  const whatsappPhone = env.WHATSAPP_PHONE ?? processEnv.WHATSAPP_PHONE ?? ''
+  const heartbeatTimeStr =
+    env.RALPH_DAILY_SUMMARY_TIME ??
+    processEnv.RALPH_DAILY_SUMMARY_TIME ??
+    DEFAULT_HEARTBEAT_TIME
+  const nextTick = safeFormatNextTick(heartbeatTimeStr, listAgents, slug, home)
+
+  let message
+  try {
+    const summary = summarize({ logDir, clock })
+    message = format(summary, { repoSlug, nextTick })
+  } catch (e) {
+    const reason = e?.message || String(e)
+    message = `❌ Ralph 24h summary failed: ${reason}`
+    err(message)
+  }
+
+  out(message)
+
+  if (callmebotKey && whatsappPhone) {
+    try {
+      await sendWa({
+        phone: whatsappPhone,
+        apiKey: callmebotKey,
+        message,
+      })
+    } catch (e) {
+      err(`heartbeat: WhatsApp send failed: ${e?.message ?? e}`)
+    }
+  }
+
+  return { exitCode: 0, slug, repoSlug, message, nextTick }
+}
+
+function safeFormatNextTick(envTime, listAgents, slug, home) {
+  try {
+    const parsed = parseHeartbeatTime(envTime)
+    return formatHeartbeatTime(parsed)
+  } catch {
+    // fall through and try to read from installed plist
+  }
+  try {
+    const agents = listAgents({ home }) || []
+    const heartbeat = agents.find(
+      (a) => a.slug === slug && a.kind === 'heartbeat',
+    )
+    if (heartbeat?.startCalendarInterval) {
+      return formatHeartbeatTime(heartbeat.startCalendarInterval)
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_HEARTBEAT_TIME
+}
+
+function loadEnvIfExists(exists, loadEnv, path) {
+  if (!exists(path)) return {}
+  try {
+    return loadEnv(path) || {}
+  } catch {
+    return {}
+  }
+}
+
+async function resolveRepoSlug(exec, root, fallback) {
+  try {
+    const result = await exec(
+      'gh',
+      ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
+      { cwd: root, reject: false },
+    )
+    const slug = (result?.stdout || '').trim()
+    return slug || fallback
+  } catch {
+    return fallback
+  }
+}
+
 function printAgentReport(out, { agent, state, status, lock, now }) {
+  const kind = agent.kind ?? 'cycle'
   out('')
-  out(`▸ ${agent.slug}`)
+  out(`▸ ${agent.slug} (${kind})`)
   out(`  label:    ${agent.label}`)
   out(`  cwd:      ${agent.workingDirectory ?? '?'}`)
   out(`  state:    ${state}`)
-  const intervalLine = formatInterval(agent.intervalSeconds)
-  out(`  interval: ${intervalLine}`)
-  if (state === 'active') {
-    const nextSecs = status?.nextRun?.intervalSeconds ?? agent.intervalSeconds
-    if (nextSecs != null) {
-      out(`  next run: in up to ${formatInterval(nextSecs)}`)
+  if (kind === 'heartbeat' && agent.startCalendarInterval) {
+    out(
+      `  schedule: daily at ${formatHeartbeatTime(agent.startCalendarInterval)}`,
+    )
+  } else {
+    const intervalLine = formatInterval(agent.intervalSeconds)
+    out(`  interval: ${intervalLine}`)
+    if (state === 'active') {
+      const nextSecs = status?.nextRun?.intervalSeconds ?? agent.intervalSeconds
+      if (nextSecs != null) {
+        out(`  next run: in up to ${formatInterval(nextSecs)}`)
+      }
     }
   }
   if (status?.lastExitCode != null) {
     const flag = status.lastExitCode === 0 ? 'success' : 'failure'
     out(`  last run: exit ${status.lastExitCode} (${flag})`)
   }
-  if (lock?.holder) {
-    const ageMin = ageInMinutes(now(), lock.holder.startedAt)
-    const liveTag = lock.alive ? 'alive' : 'stale'
-    out(`  lock:     PID ${lock.holder.pid} (${liveTag}, ${ageMin}min ago)`)
-  } else {
-    out(`  lock:     none`)
+  if (kind === 'cycle') {
+    if (lock?.holder) {
+      const ageMin = ageInMinutes(now(), lock.holder.startedAt)
+      const liveTag = lock.alive ? 'alive' : 'stale'
+      out(`  lock:     PID ${lock.holder.pid} (${liveTag}, ${ageMin}min ago)`)
+    } else {
+      out(`  lock:     none`)
+    }
   }
 }
 

--- a/packages/ralph/lib/commands/schedule.test.js
+++ b/packages/ralph/lib/commands/schedule.test.js
@@ -175,53 +175,82 @@ describe('scheduleInstallCommand — existing plist', () => {
 })
 
 describe('scheduleInstallCommand — happy path', () => {
-  it('computes slug from repo basename and installs the launchd agent', async () => {
-    let installArgs = null
+  function trackInstalls() {
+    const calls = []
+    const installAgent = async (args) => {
+      calls.push(args)
+      const kind = args.kind ?? 'cycle'
+      const label =
+        kind === 'cycle'
+          ? `com.lucasfe.ralph.cycle.${args.slug}`
+          : `com.lucasfe.ralph.heartbeat.${args.slug}`
+      const plistPath = `${HOME}/Library/LaunchAgents/${label}.plist`
+      return { plistPath, label, kind, loadResult: { exitCode: 0 } }
+    }
+    installAgent.calls = calls
+    return installAgent
+  }
+
+  it('computes slug from repo basename and installs both cycle and heartbeat agents', async () => {
+    const installAgent = trackInstalls()
     const deps = baseDeps({
       exists: (p) => !p.endsWith('.plist'), // no existing plist
-      installAgent: async (args) => {
-        installArgs = args
-        return { plistPath: PLIST_PATH, label: LABEL, loadResult: { exitCode: 0 } }
-      },
+      installAgent,
     })
     const result = await scheduleInstallCommand(deps)
     expect(result.exitCode).toBe(0)
     expect(result.slug).toBe(SLUG)
-    expect(installArgs.slug).toBe(SLUG)
-    expect(installArgs.workingDirectory).toBe(REPO)
-    expect(installArgs.command).toBe('/usr/local/bin/ralph')
-    expect(installArgs.args).toEqual(['cycle'])
-    expect(installArgs.intervalSeconds).toBe(14400)
-    expect(installArgs.logDir).toBe(`${REPO}/logs`)
+    expect(installAgent.calls).toHaveLength(2)
+    const cycleCall = installAgent.calls.find((c) => c.kind === 'cycle')
+    const heartbeatCall = installAgent.calls.find((c) => c.kind === 'heartbeat')
+    expect(cycleCall).toBeDefined()
+    expect(cycleCall.slug).toBe(SLUG)
+    expect(cycleCall.workingDirectory).toBe(REPO)
+    expect(cycleCall.command).toBe('/usr/local/bin/ralph')
+    expect(cycleCall.args).toEqual(['cycle'])
+    expect(cycleCall.intervalSeconds).toBe(14400)
+    expect(cycleCall.logDir).toBe(`${REPO}/logs`)
+    expect(heartbeatCall).toBeDefined()
+    expect(heartbeatCall.args).toEqual(['schedule', 'heartbeat'])
+    expect(heartbeatCall.startCalendarInterval).toEqual({ hour: 9, minute: 0 })
+    expect(result.heartbeat.label).toBe(`com.lucasfe.ralph.heartbeat.${SLUG}`)
   })
 
-  it('honors a custom --interval flag', async () => {
-    let installArgs = null
+  it('honors a custom --interval flag for the cycle plist', async () => {
+    const installAgent = trackInstalls()
     const deps = baseDeps({
       exists: (p) => !p.endsWith('.plist'),
       interval: '30m',
-      installAgent: async (args) => {
-        installArgs = args
-        return { plistPath: PLIST_PATH, label: LABEL, loadResult: { exitCode: 0 } }
-      },
+      installAgent,
     })
     await scheduleInstallCommand(deps)
-    expect(installArgs.intervalSeconds).toBe(1800)
+    const cycleCall = installAgent.calls.find((c) => c.kind === 'cycle')
+    expect(cycleCall.intervalSeconds).toBe(1800)
   })
 
-  it('prints a success summary on stdout', async () => {
+  it('honors RALPH_DAILY_SUMMARY_TIME for the heartbeat plist', async () => {
+    const installAgent = trackInstalls()
     const deps = baseDeps({
       exists: (p) => !p.endsWith('.plist'),
-      installAgent: async () => ({
-        plistPath: PLIST_PATH,
-        label: LABEL,
-        loadResult: { exitCode: 0 },
-      }),
+      processEnv: { RALPH_DAILY_SUMMARY_TIME: '07:30' },
+      installAgent,
+    })
+    await scheduleInstallCommand(deps)
+    const heartbeatCall = installAgent.calls.find((c) => c.kind === 'heartbeat')
+    expect(heartbeatCall.startCalendarInterval).toEqual({ hour: 7, minute: 30 })
+  })
+
+  it('prints a success summary on stdout listing both plists', async () => {
+    const deps = baseDeps({
+      exists: (p) => !p.endsWith('.plist'),
+      installAgent: trackInstalls(),
     })
     await scheduleInstallCommand(deps)
     const output = deps.stdout.output()
     expect(output).toMatch(/installed|✅/i)
-    expect(output).toContain(LABEL)
+    expect(output).toContain(`com.lucasfe.ralph.cycle.${SLUG}`)
+    expect(output).toContain(`com.lucasfe.ralph.heartbeat.${SLUG}`)
+    expect(output).toMatch(/daily at 09:00/i)
   })
 })
 

--- a/packages/ralph/lib/commands/schedule.test.js
+++ b/packages/ralph/lib/commands/schedule.test.js
@@ -599,3 +599,291 @@ describe('scheduleRemoveCommand --all', () => {
     expect(deps.stdout.output()).toMatch(/no.*agent|nothing/i)
   })
 })
+
+describe('parseHeartbeatTime', () => {
+  it('parses HH:MM into {hour, minute}', () => {
+    expect(parseHeartbeatTime('09:00')).toEqual({ hour: 9, minute: 0 })
+    expect(parseHeartbeatTime('23:59')).toEqual({ hour: 23, minute: 59 })
+    expect(parseHeartbeatTime('7:30')).toEqual({ hour: 7, minute: 30 })
+  })
+
+  it('uses 09:00 as default when input is null/undefined', () => {
+    expect(parseHeartbeatTime(undefined)).toEqual({ hour: 9, minute: 0 })
+    expect(parseHeartbeatTime(null)).toEqual({ hour: 9, minute: 0 })
+  })
+
+  it('rejects invalid formats and out-of-range values', () => {
+    expect(() => parseHeartbeatTime('foo')).toThrow()
+    expect(() => parseHeartbeatTime('25:00')).toThrow()
+    expect(() => parseHeartbeatTime('12:60')).toThrow()
+    expect(() => parseHeartbeatTime('12')).toThrow()
+  })
+})
+
+describe('scheduleInstallCommand — dual plist', () => {
+  it('passes --force through to remove BOTH existing plists before install', async () => {
+    const removeCalls = []
+    const deps = baseDeps({
+      exists: () => true,
+      force: true,
+      removeAgent: async (args) => {
+        removeCalls.push(args.kind ?? 'cycle')
+        return {
+          plistPath: PLIST_PATH,
+          kind: args.kind ?? 'cycle',
+          removed: true,
+          unloadResult: { exitCode: 0 },
+        }
+      },
+      installAgent: async (args) => ({
+        plistPath: `${HOME}/Library/LaunchAgents/x.plist`,
+        label: 'x',
+        kind: args.kind ?? 'cycle',
+        loadResult: { exitCode: 0 },
+      }),
+    })
+    await scheduleInstallCommand(deps)
+    expect(removeCalls.sort()).toEqual(['cycle', 'heartbeat'])
+  })
+})
+
+describe('scheduleRemoveCommand — dual plist', () => {
+  it('removes both cycle and heartbeat plists when both exist', async () => {
+    const removed = []
+    const deps = baseDeps({
+      exists: () => true,
+      removeAgent: async (args) => {
+        removed.push(args.kind ?? 'cycle')
+        return {
+          plistPath: PLIST_PATH,
+          kind: args.kind ?? 'cycle',
+          removed: true,
+          unloadResult: { exitCode: 0 },
+        }
+      },
+    })
+    const result = await scheduleRemoveCommand(deps)
+    expect(removed.sort()).toEqual(['cycle', 'heartbeat'])
+    expect(result.exitCode).toBe(0)
+    expect(result.cycle.removed).toBe(true)
+    expect(result.heartbeat.removed).toBe(true)
+  })
+
+  it('removes only the heartbeat plist when the cycle plist is missing', async () => {
+    const removed = []
+    const heartbeatPath = `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.heartbeat.${SLUG}.plist`
+    const deps = baseDeps({
+      exists: (p) => p === heartbeatPath,
+      removeAgent: async (args) => {
+        removed.push(args.kind ?? 'cycle')
+        return {
+          plistPath: heartbeatPath,
+          kind: 'heartbeat',
+          removed: true,
+          unloadResult: { exitCode: 0 },
+        }
+      },
+    })
+    const result = await scheduleRemoveCommand(deps)
+    expect(removed).toEqual(['heartbeat'])
+    expect(result.cycle.removed).toBe(false)
+    expect(result.heartbeat.removed).toBe(true)
+  })
+})
+
+describe('schedulePauseCommand — dual plist', () => {
+  it('pauses both cycle and heartbeat agents when both plists exist', async () => {
+    const paused = []
+    const deps = baseDeps({
+      exists: () => true,
+      pauseAgent: async (args) => {
+        paused.push(args.kind ?? 'cycle')
+        return {
+          plistPath: PLIST_PATH,
+          kind: args.kind ?? 'cycle',
+          paused: true,
+          unloadResult: { exitCode: 0 },
+        }
+      },
+    })
+    const result = await schedulePauseCommand(deps)
+    expect(paused.sort()).toEqual(['cycle', 'heartbeat'])
+    expect(result.cycle.paused).toBe(true)
+    expect(result.heartbeat.paused).toBe(true)
+  })
+})
+
+describe('scheduleResumeCommand — dual plist', () => {
+  it('resumes both cycle and heartbeat agents when both plists exist', async () => {
+    const resumed = []
+    const deps = baseDeps({
+      exists: () => true,
+      resumeAgent: async (args) => {
+        resumed.push(args.kind ?? 'cycle')
+        return {
+          plistPath: PLIST_PATH,
+          kind: args.kind ?? 'cycle',
+          resumed: true,
+          loadResult: { exitCode: 0 },
+        }
+      },
+    })
+    const result = await scheduleResumeCommand(deps)
+    expect(resumed.sort()).toEqual(['cycle', 'heartbeat'])
+    expect(result.cycle.resumed).toBe(true)
+    expect(result.heartbeat.resumed).toBe(true)
+  })
+})
+
+describe('scheduleStatusCommand — dual plist', () => {
+  it('renders both cycle and heartbeat agent blocks', async () => {
+    const cycleEntry = {
+      slug: SLUG,
+      label: `com.lucasfe.ralph.cycle.${SLUG}`,
+      plistPath: PLIST_PATH,
+      kind: 'cycle',
+      workingDirectory: REPO,
+      intervalSeconds: 14400,
+    }
+    const heartbeatEntry = {
+      slug: SLUG,
+      label: `com.lucasfe.ralph.heartbeat.${SLUG}`,
+      plistPath: `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.heartbeat.${SLUG}.plist`,
+      kind: 'heartbeat',
+      workingDirectory: REPO,
+      intervalSeconds: null,
+      startCalendarInterval: { hour: 9, minute: 0 },
+    }
+    const deps = baseDeps({
+      listAgents: () => [cycleEntry, heartbeatEntry],
+      getStatus: async () => ({
+        loaded: true,
+        lastExitCode: 0,
+        nextRun: null,
+      }),
+      peekLock: () => null,
+    })
+    const result = await scheduleStatusCommand(deps)
+    expect(result.agents).toHaveLength(2)
+    const out = deps.stdout.output()
+    expect(out).toContain(`com.lucasfe.ralph.cycle.${SLUG}`)
+    expect(out).toContain(`com.lucasfe.ralph.heartbeat.${SLUG}`)
+    expect(out).toMatch(/daily at 09:00/)
+  })
+})
+
+describe('scheduleHeartbeatCommand', () => {
+  function makeFs(files = {}) {
+    const dirs = new Set()
+    for (const path of Object.keys(files)) {
+      let parent = path
+      while (parent.includes('/')) {
+        parent = parent.slice(0, parent.lastIndexOf('/'))
+        dirs.add(parent)
+      }
+    }
+    return {
+      existsSync: (p) =>
+        Object.prototype.hasOwnProperty.call(files, p) || dirs.has(p),
+      readFileSync: (p) => {
+        if (!Object.prototype.hasOwnProperty.call(files, p)) {
+          const err = new Error(`ENOENT: ${p}`)
+          err.code = 'ENOENT'
+          throw err
+        }
+        return files[p]
+      },
+      readdirSync: (p) => {
+        const prefix = p.endsWith('/') ? p : `${p}/`
+        const entries = new Set()
+        for (const k of Object.keys(files)) {
+          if (k.startsWith(prefix)) {
+            entries.add(k.slice(prefix.length).split('/')[0])
+          }
+        }
+        return Array.from(entries).sort()
+      },
+    }
+  }
+
+  function heartbeatBaseDeps(overrides = {}) {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const sendWaCalls = []
+    const sendWa = async (args) => {
+      sendWaCalls.push(args)
+      return { ok: true }
+    }
+    sendWa.calls = sendWaCalls
+    return {
+      cwd: REPO,
+      stdout,
+      stderr,
+      home: HOME,
+      platform: 'mac',
+      processEnv: {
+        CALLMEBOT_KEY: 'k',
+        WHATSAPP_PHONE: '+1',
+        RALPH_DAILY_SUMMARY_TIME: '09:00',
+      },
+      loadEnv: () => ({}),
+      exists: () => true,
+      exec: makeExec(baseHandlers()),
+      sendWa,
+      summarize: () => ({
+        cycles: 6,
+        totalIssues: 12,
+        ok: 10,
+        failed: 2,
+        abortedCycles: 0,
+        durations: [],
+        lastCycle: null,
+      }),
+      format: (summary, { repoSlug, nextTick }) =>
+        `📊 Ralph 24h | ${summary.cycles} cycles, ${summary.totalIssues} issues (${summary.ok} ok, ${summary.failed} fail) | ${repoSlug} | next ${nextTick}`,
+      listAgents: () => [],
+      clock: () => Date.parse('2026-04-29T12:00:00Z'),
+      ...overrides,
+    }
+  }
+
+  it('summarizes the last 24h and sends the formatted message via WhatsApp', async () => {
+    const deps = heartbeatBaseDeps()
+    const result = await scheduleHeartbeatCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(deps.sendWa.calls).toHaveLength(1)
+    expect(deps.sendWa.calls[0].message).toMatch(/Ralph 24h/)
+    expect(deps.sendWa.calls[0].message).toMatch(/6 cycles/)
+    expect(deps.sendWa.calls[0].message).toMatch(/next 09:00/)
+    expect(deps.sendWa.calls[0].phone).toBe('+1')
+    expect(deps.sendWa.calls[0].apiKey).toBe('k')
+  })
+
+  it('skips WhatsApp send when CALLMEBOT_KEY/WHATSAPP_PHONE are missing', async () => {
+    const deps = heartbeatBaseDeps({ processEnv: { RALPH_DAILY_SUMMARY_TIME: '09:00' } })
+    const result = await scheduleHeartbeatCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(deps.sendWa.calls).toEqual([])
+  })
+
+  it('falls back to a failure message when summarize throws', async () => {
+    const deps = heartbeatBaseDeps({
+      summarize: () => {
+        throw new Error('disk full')
+      },
+    })
+    const result = await scheduleHeartbeatCommand(deps)
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toMatch(/❌ Ralph 24h summary failed/)
+    expect(result.message).toMatch(/disk full/)
+    expect(deps.sendWa.calls[0].message).toMatch(/❌/)
+    expect(deps.stderr.output()).toMatch(/disk full/)
+  })
+
+  it('aborts on non-mac platforms', async () => {
+    const deps = heartbeatBaseDeps({ platform: 'linux' })
+    await expect(scheduleHeartbeatCommand(deps)).rejects.toMatchObject({
+      exitCode: 1,
+    })
+  })
+})

--- a/packages/ralph/lib/commands/schedule.test.js
+++ b/packages/ralph/lib/commands/schedule.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
+  parseHeartbeatTime,
   parseInterval,
+  scheduleHeartbeatCommand,
   scheduleInstallCommand,
   schedulePauseCommand,
   scheduleResumeCommand,

--- a/packages/ralph/lib/heartbeat.js
+++ b/packages/ralph/lib/heartbeat.js
@@ -1,0 +1,148 @@
+import { readFileSync as realReadFileSync, readdirSync as realReaddirSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const RALPH_CYCLE_EVENT_TAG = 'RALPH_CYCLE_EVENT'
+const ABORTED_STATUSES = new Set(['preflight-failed', 'lock-held', 'tmux-active'])
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000
+const LOG_BASENAME = 'ralph-cycle.out.log'
+
+export function summarizeLast24h({
+  logDir,
+  fs,
+  clock = Date.now,
+} = {}) {
+  const empty = {
+    cycles: 0,
+    totalIssues: 0,
+    ok: 0,
+    failed: 0,
+    abortedCycles: 0,
+    durations: [],
+    lastCycle: null,
+  }
+  if (!logDir) return empty
+
+  const reader = wrapFs(fs)
+  const cutoff = clock() - TWENTY_FOUR_HOURS_MS
+  const files = listLogFiles(reader, logDir)
+  const events = []
+
+  for (const file of files) {
+    const text = safeRead(reader, file)
+    if (!text) continue
+    for (const line of text.split(/\r?\n/)) {
+      const event = parseEventLine(line)
+      if (!event) continue
+      const tsMs = Date.parse(event.ts)
+      if (!Number.isFinite(tsMs)) continue
+      if (tsMs < cutoff) continue
+      events.push({ ...event, tsMs })
+    }
+  }
+
+  if (events.length === 0) return empty
+  events.sort((a, b) => a.tsMs - b.tsMs)
+
+  let ok = 0
+  let failed = 0
+  let abortedCycles = 0
+  const durations = []
+  for (const event of events) {
+    ok += toInt(event.ok)
+    failed += toInt(event.failed)
+    if (ABORTED_STATUSES.has(event.status)) {
+      abortedCycles += 1
+      continue
+    }
+    if (Number.isFinite(event.durationMin)) {
+      durations.push(event.durationMin)
+    }
+  }
+
+  const last = events[events.length - 1]
+  const { tsMs: _ignore, ...lastCycle } = last
+  return {
+    cycles: events.length,
+    totalIssues: ok + failed,
+    ok,
+    failed,
+    abortedCycles,
+    durations,
+    lastCycle,
+  }
+}
+
+export function formatSummary(summary, { repoSlug, nextTick } = {}) {
+  const cycles = toInt(summary?.cycles)
+  const totalIssues = toInt(summary?.totalIssues)
+  const ok = toInt(summary?.ok)
+  const failed = toInt(summary?.failed)
+  const slug = repoSlug || 'unknown-repo'
+  const tail = nextTick ? ` | next ${nextTick}` : ''
+
+  if (cycles === 0) {
+    return `📊 Ralph 24h | 0 cycles, repo ${slug}${tail}`
+  }
+  const warn = ok === 0 && failed > 0 ? ' ⚠️' : ''
+  return `📊 Ralph 24h | ${cycles} cycles, ${totalIssues} issues (${ok} ok, ${failed} fail)${warn} | ${slug}${tail}`
+}
+
+function listLogFiles(fs, logDir) {
+  let entries = []
+  try {
+    entries = fs.readdirSync(logDir) || []
+  } catch {
+    return []
+  }
+  const candidates = entries.filter(
+    (name) => typeof name === 'string' && name.startsWith(LOG_BASENAME),
+  )
+  candidates.sort()
+  return candidates.map((name) => join(logDir, name))
+}
+
+function safeRead(fs, path) {
+  try {
+    const data = fs.readFileSync(path, 'utf8')
+    return typeof data === 'string' ? data : data?.toString?.() ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function parseEventLine(line) {
+  if (!line) return null
+  const idx = line.indexOf(RALPH_CYCLE_EVENT_TAG)
+  if (idx === -1) return null
+  const jsonPart = line.slice(idx + RALPH_CYCLE_EVENT_TAG.length).trim()
+  if (!jsonPart) return null
+  try {
+    const obj = JSON.parse(jsonPart)
+    if (!obj || typeof obj !== 'object') return null
+    return obj
+  } catch {
+    return null
+  }
+}
+
+function toInt(value) {
+  const n = Number(value)
+  return Number.isFinite(n) ? Math.trunc(n) : 0
+}
+
+function wrapFs(fsImpl) {
+  if (!fsImpl) {
+    return {
+      readFileSync: realReadFileSync,
+      readdirSync: realReaddirSync,
+    }
+  }
+  return {
+    readFileSync: fsImpl.readFileSync
+      ? fsImpl.readFileSync.bind(fsImpl)
+      : realReadFileSync,
+    readdirSync: fsImpl.readdirSync
+      ? fsImpl.readdirSync.bind(fsImpl)
+      : realReaddirSync,
+  }
+}

--- a/packages/ralph/lib/heartbeat.test.js
+++ b/packages/ralph/lib/heartbeat.test.js
@@ -1,0 +1,311 @@
+import { describe, it, expect } from 'vitest'
+import { formatSummary, summarizeLast24h } from './heartbeat.js'
+
+const LOG_DIR = '/repo/logs'
+const NOW = Date.parse('2026-04-29T12:00:00Z')
+const clock = () => NOW
+
+function makeFs(files = {}) {
+  const dirs = new Set()
+  for (const path of Object.keys(files)) {
+    let parent = path
+    while (parent.includes('/')) {
+      parent = parent.slice(0, parent.lastIndexOf('/'))
+      dirs.add(parent)
+    }
+  }
+  return {
+    existsSync: (p) => Object.prototype.hasOwnProperty.call(files, p) || dirs.has(p),
+    readFileSync: (p) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) {
+        const err = new Error(`ENOENT: no such file or directory, open '${p}'`)
+        err.code = 'ENOENT'
+        throw err
+      }
+      return files[p]
+    },
+    readdirSync: (p) => {
+      const prefix = p.endsWith('/') ? p : `${p}/`
+      const entries = new Set()
+      for (const k of Object.keys(files)) {
+        if (k.startsWith(prefix)) {
+          const rest = k.slice(prefix.length)
+          const head = rest.split('/')[0]
+          if (head) entries.add(head)
+        }
+      }
+      return Array.from(entries).sort()
+    },
+  }
+}
+
+function eventLine({
+  ts,
+  status = 'success',
+  ok = 0,
+  failed = 0,
+  durationMin = 0,
+  processed = ok + failed,
+}) {
+  return `RALPH_CYCLE_EVENT ${JSON.stringify({
+    ts,
+    status,
+    ok,
+    failed,
+    durationMin,
+    processed,
+  })}`
+}
+
+describe('summarizeLast24h', () => {
+  it('returns zeros when log file is missing', () => {
+    const fs = makeFs({})
+    const result = summarizeLast24h({ logDir: LOG_DIR, fs, clock })
+    expect(result).toEqual({
+      cycles: 0,
+      totalIssues: 0,
+      ok: 0,
+      failed: 0,
+      abortedCycles: 0,
+      durations: [],
+      lastCycle: null,
+    })
+  })
+
+  it('ignores noise lines and malformed RALPH_CYCLE_EVENT entries', () => {
+    const lines = [
+      'random log noise',
+      'RALPH_CYCLE_EVENT not-json-at-all',
+      'RALPH_CYCLE_EVENT { "ts": "broken json',
+      eventLine({
+        ts: '2026-04-28T20:00:00Z',
+        status: 'success',
+        ok: 2,
+        failed: 0,
+        durationMin: 5,
+      }),
+    ].join('\n')
+    const fs = makeFs({ [`${LOG_DIR}/ralph-cycle.out.log`]: lines })
+    const result = summarizeLast24h({ logDir: LOG_DIR, fs, clock })
+    expect(result.cycles).toBe(1)
+    expect(result.ok).toBe(2)
+    expect(result.failed).toBe(0)
+  })
+
+  it('aggregates multiple cycles inside the 24h window', () => {
+    const lines = [
+      eventLine({
+        ts: '2026-04-28T18:00:00Z',
+        status: 'success',
+        ok: 3,
+        failed: 0,
+        durationMin: 7,
+      }),
+      eventLine({
+        ts: '2026-04-28T22:00:00Z',
+        status: 'partial',
+        ok: 2,
+        failed: 1,
+        durationMin: 12,
+      }),
+      eventLine({
+        ts: '2026-04-29T06:00:00Z',
+        status: 'failed',
+        ok: 0,
+        failed: 2,
+        durationMin: 5,
+      }),
+    ].join('\n')
+    const fs = makeFs({ [`${LOG_DIR}/ralph-cycle.out.log`]: lines })
+    const result = summarizeLast24h({ logDir: LOG_DIR, fs, clock })
+    expect(result.cycles).toBe(3)
+    expect(result.ok).toBe(5)
+    expect(result.failed).toBe(3)
+    expect(result.totalIssues).toBe(8)
+    expect(result.abortedCycles).toBe(0)
+    expect(result.durations).toEqual([7, 12, 5])
+    expect(result.lastCycle).toMatchObject({
+      ts: '2026-04-29T06:00:00Z',
+      status: 'failed',
+      ok: 0,
+      failed: 2,
+    })
+  })
+
+  it('excludes cycles older than the 24h window', () => {
+    const lines = [
+      eventLine({
+        ts: '2026-04-27T11:00:00Z',
+        status: 'success',
+        ok: 99,
+        failed: 99,
+        durationMin: 1,
+      }),
+      eventLine({
+        ts: '2026-04-29T06:00:00Z',
+        status: 'success',
+        ok: 1,
+        failed: 0,
+        durationMin: 5,
+      }),
+    ].join('\n')
+    const fs = makeFs({ [`${LOG_DIR}/ralph-cycle.out.log`]: lines })
+    const result = summarizeLast24h({ logDir: LOG_DIR, fs, clock })
+    expect(result.cycles).toBe(1)
+    expect(result.ok).toBe(1)
+    expect(result.failed).toBe(0)
+    expect(result.lastCycle.ts).toBe('2026-04-29T06:00:00Z')
+  })
+
+  it('counts aborted cycles separately and excludes them from durations', () => {
+    const lines = [
+      eventLine({
+        ts: '2026-04-29T01:00:00Z',
+        status: 'lock-held',
+        ok: 0,
+        failed: 0,
+        durationMin: 0,
+      }),
+      eventLine({
+        ts: '2026-04-29T02:00:00Z',
+        status: 'preflight-failed',
+        ok: 0,
+        failed: 0,
+        durationMin: 0,
+      }),
+      eventLine({
+        ts: '2026-04-29T03:00:00Z',
+        status: 'success',
+        ok: 1,
+        failed: 0,
+        durationMin: 5,
+      }),
+    ].join('\n')
+    const fs = makeFs({ [`${LOG_DIR}/ralph-cycle.out.log`]: lines })
+    const result = summarizeLast24h({ logDir: LOG_DIR, fs, clock })
+    expect(result.cycles).toBe(3)
+    expect(result.abortedCycles).toBe(2)
+    expect(result.durations).toEqual([5])
+    expect(result.lastCycle.status).toBe('success')
+  })
+
+  it('reads rotated log copies in addition to the main log', () => {
+    const linesMain = eventLine({
+      ts: '2026-04-29T11:00:00Z',
+      status: 'success',
+      ok: 2,
+      failed: 0,
+      durationMin: 6,
+    })
+    const linesRotated = eventLine({
+      ts: '2026-04-29T05:00:00Z',
+      status: 'success',
+      ok: 1,
+      failed: 0,
+      durationMin: 4,
+    })
+    const fs = makeFs({
+      [`${LOG_DIR}/ralph-cycle.out.log`]: linesMain,
+      [`${LOG_DIR}/ralph-cycle.out.log.1`]: linesRotated,
+    })
+    const result = summarizeLast24h({ logDir: LOG_DIR, fs, clock })
+    expect(result.cycles).toBe(2)
+    expect(result.ok).toBe(3)
+    expect(result.lastCycle.ts).toBe('2026-04-29T11:00:00Z')
+  })
+
+  it('skips events with missing or unparseable timestamps', () => {
+    const lines = [
+      'RALPH_CYCLE_EVENT {"status":"success","ok":1,"failed":0}',
+      eventLine({
+        ts: '2026-04-29T06:00:00Z',
+        status: 'success',
+        ok: 1,
+        failed: 0,
+        durationMin: 3,
+      }),
+    ].join('\n')
+    const fs = makeFs({ [`${LOG_DIR}/ralph-cycle.out.log`]: lines })
+    const result = summarizeLast24h({ logDir: LOG_DIR, fs, clock })
+    expect(result.cycles).toBe(1)
+    expect(result.ok).toBe(1)
+  })
+})
+
+describe('formatSummary', () => {
+  it('renders cycle and issue counts with next tick', () => {
+    const summary = {
+      cycles: 6,
+      totalIssues: 12,
+      ok: 10,
+      failed: 2,
+      abortedCycles: 0,
+      durations: [],
+      lastCycle: { ts: '2026-04-29T11:00:00Z', status: 'success' },
+    }
+    const out = formatSummary(summary, {
+      repoSlug: 'lucasfe/agenthub',
+      nextTick: '12:30',
+    })
+    expect(out).toMatch(/📊/)
+    expect(out).toMatch(/Ralph 24h/)
+    expect(out).toMatch(/6 cycles/)
+    expect(out).toMatch(/12 issues/)
+    expect(out).toMatch(/10 ok/)
+    expect(out).toMatch(/2 fail/)
+    expect(out).toMatch(/next.*12:30/)
+  })
+
+  it('renders zero-cycles output without crashing', () => {
+    const summary = {
+      cycles: 0,
+      totalIssues: 0,
+      ok: 0,
+      failed: 0,
+      abortedCycles: 0,
+      durations: [],
+      lastCycle: null,
+    }
+    const out = formatSummary(summary, {
+      repoSlug: 'lucasfe/agenthub',
+      nextTick: '09:00',
+    })
+    expect(out).toMatch(/0 cycles/)
+    expect(out).toMatch(/lucasfe\/agenthub/)
+    expect(out).toMatch(/next.*09:00/)
+  })
+
+  it('flags all-failed scenario with a warning marker', () => {
+    const summary = {
+      cycles: 3,
+      totalIssues: 5,
+      ok: 0,
+      failed: 5,
+      abortedCycles: 0,
+      durations: [],
+      lastCycle: null,
+    }
+    const out = formatSummary(summary, {
+      repoSlug: 'lucasfe/agenthub',
+      nextTick: '09:00',
+    })
+    expect(out).toMatch(/0 ok/)
+    expect(out).toMatch(/5 fail/)
+    expect(out).toMatch(/⚠️/)
+  })
+
+  it('falls back to a slug-only header when nextTick is missing', () => {
+    const summary = {
+      cycles: 1,
+      totalIssues: 1,
+      ok: 1,
+      failed: 0,
+      abortedCycles: 0,
+      durations: [],
+      lastCycle: null,
+    }
+    const out = formatSummary(summary, { repoSlug: 'lucasfe/agenthub' })
+    expect(out).toMatch(/lucasfe\/agenthub/)
+    expect(out).not.toMatch(/next undefined/)
+  })
+})

--- a/packages/ralph/lib/launchd.js
+++ b/packages/ralph/lib/launchd.js
@@ -11,15 +11,34 @@ import { homedir } from 'node:os'
 import { execa } from 'execa'
 
 export const LABEL_PREFIX = 'com.lucasfe.ralph.cycle'
+export const LABEL_PREFIX_HEARTBEAT = 'com.lucasfe.ralph.heartbeat'
 export const DEFAULT_PATH =
   '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+export const KINDS = ['cycle', 'heartbeat']
 
-export function labelFor(slug) {
-  return `${LABEL_PREFIX}.${slug}`
+const KIND_CONFIG = {
+  cycle: {
+    prefix: LABEL_PREFIX,
+    logBase: 'ralph-cycle',
+  },
+  heartbeat: {
+    prefix: LABEL_PREFIX_HEARTBEAT,
+    logBase: 'ralph-heartbeat',
+  },
 }
 
-export function plistPathFor(slug, home = homedir()) {
-  return join(home, 'Library', 'LaunchAgents', `${labelFor(slug)}.plist`)
+function configFor(kind = 'cycle') {
+  const cfg = KIND_CONFIG[kind]
+  if (!cfg) throw new Error(`unknown launchd kind: ${kind}`)
+  return cfg
+}
+
+export function labelFor(slug, kind = 'cycle') {
+  return `${configFor(kind).prefix}.${slug}`
+}
+
+export function plistPathFor(slug, home = homedir(), kind = 'cycle') {
+  return join(home, 'Library', 'LaunchAgents', `${labelFor(slug, kind)}.plist`)
 }
 
 export function buildPlist({
@@ -27,10 +46,13 @@ export function buildPlist({
   command,
   args = [],
   intervalSeconds,
+  startCalendarInterval,
   workingDirectory,
   logDir,
   environment,
+  kind = 'cycle',
 }) {
+  const cfg = configFor(kind)
   const env = { PATH: DEFAULT_PATH, ...(environment || {}) }
   const programArgsXml = [command, ...args]
     .map((s) => `        <string>${escapeXml(s)}</string>`)
@@ -41,22 +63,22 @@ export function buildPlist({
         `        <key>${escapeXml(k)}</key>\n        <string>${escapeXml(v)}</string>`,
     )
     .join('\n')
-  const stdoutPath = join(logDir, 'ralph-cycle.out.log')
-  const stderrPath = join(logDir, 'ralph-cycle.err.log')
+  const stdoutPath = join(logDir, `${cfg.logBase}.out.log`)
+  const stderrPath = join(logDir, `${cfg.logBase}.err.log`)
+  const scheduleXml = renderSchedule({ intervalSeconds, startCalendarInterval })
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>${escapeXml(labelFor(slug))}</string>
+    <string>${escapeXml(labelFor(slug, kind))}</string>
     <key>ProgramArguments</key>
     <array>
 ${programArgsXml}
     </array>
     <key>WorkingDirectory</key>
     <string>${escapeXml(workingDirectory)}</string>
-    <key>StartInterval</key>
-    <integer>${Number(intervalSeconds)}</integer>
+${scheduleXml}
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
@@ -72,49 +94,79 @@ ${envEntries}
 `
 }
 
+function renderSchedule({ intervalSeconds, startCalendarInterval }) {
+  if (startCalendarInterval) {
+    const hour = Number(startCalendarInterval.hour)
+    const minute = Number(startCalendarInterval.minute)
+    if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
+      throw new Error(
+        `invalid startCalendarInterval: ${JSON.stringify(startCalendarInterval)}`,
+      )
+    }
+    return [
+      '    <key>StartCalendarInterval</key>',
+      '    <dict>',
+      `        <key>Hour</key>`,
+      `        <integer>${hour}</integer>`,
+      `        <key>Minute</key>`,
+      `        <integer>${minute}</integer>`,
+      '    </dict>',
+    ].join('\n')
+  }
+  return [
+    '    <key>StartInterval</key>',
+    `    <integer>${Number(intervalSeconds)}</integer>`,
+  ].join('\n')
+}
+
 export async function installAgent({
   slug,
   command,
   args = [],
   intervalSeconds,
+  startCalendarInterval,
   workingDirectory,
   logDir,
   environment,
+  kind = 'cycle',
   home = homedir(),
   fsImpl,
   exec = execa,
 }) {
   const fs = wrapFs(fsImpl)
-  const path = plistPathFor(slug, home)
+  const path = plistPathFor(slug, home, kind)
   const body = buildPlist({
     slug,
     command,
     args,
     intervalSeconds,
+    startCalendarInterval,
     workingDirectory,
     logDir,
     environment,
+    kind,
   })
   fs.mkdirSync(dirname(path), { recursive: true })
   fs.writeFileSync(path, body)
   const loadResult = await loadAgent({ plistPath: path, exec })
-  return { plistPath: path, label: labelFor(slug), loadResult }
+  return { plistPath: path, label: labelFor(slug, kind), kind, loadResult }
 }
 
 export async function removeAgent({
   slug,
+  kind = 'cycle',
   home = homedir(),
   fsImpl,
   exec = execa,
 }) {
   const fs = wrapFs(fsImpl)
-  const path = plistPathFor(slug, home)
+  const path = plistPathFor(slug, home, kind)
   if (!fs.existsSync(path)) {
-    return { plistPath: path, removed: false, unloadResult: null }
+    return { plistPath: path, kind, removed: false, unloadResult: null }
   }
   const unloadResult = await unloadAgent({ plistPath: path, exec })
   fs.unlinkSync(path)
-  return { plistPath: path, removed: true, unloadResult }
+  return { plistPath: path, kind, removed: true, unloadResult }
 }
 
 export async function loadAgent({ plistPath, exec = execa }) {
@@ -127,32 +179,34 @@ export async function unloadAgent({ plistPath, exec = execa }) {
 
 export async function pauseAgent({
   slug,
+  kind = 'cycle',
   home = homedir(),
   fsImpl,
   exec = execa,
 }) {
   const fs = wrapFs(fsImpl)
-  const path = plistPathFor(slug, home)
+  const path = plistPathFor(slug, home, kind)
   if (!fs.existsSync(path)) {
-    return { plistPath: path, paused: false, unloadResult: null }
+    return { plistPath: path, kind, paused: false, unloadResult: null }
   }
   const unloadResult = await unloadAgent({ plistPath: path, exec })
-  return { plistPath: path, paused: true, unloadResult }
+  return { plistPath: path, kind, paused: true, unloadResult }
 }
 
 export async function resumeAgent({
   slug,
+  kind = 'cycle',
   home = homedir(),
   fsImpl,
   exec = execa,
 }) {
   const fs = wrapFs(fsImpl)
-  const path = plistPathFor(slug, home)
+  const path = plistPathFor(slug, home, kind)
   if (!fs.existsSync(path)) {
-    return { plistPath: path, resumed: false, loadResult: null }
+    return { plistPath: path, kind, resumed: false, loadResult: null }
   }
   const loadResult = await loadAgent({ plistPath: path, exec })
-  return { plistPath: path, resumed: true, loadResult }
+  return { plistPath: path, kind, resumed: true, loadResult }
 }
 
 export function listInstalledAgents({ home = homedir(), fsImpl } = {}) {
@@ -165,17 +219,19 @@ export function listInstalledAgents({ home = homedir(), fsImpl } = {}) {
   } catch {
     return []
   }
-  const matches = (entries || []).filter(
-    (n) =>
-      typeof n === 'string' &&
-      n.startsWith(`${LABEL_PREFIX}.`) &&
-      n.endsWith('.plist'),
-  )
+  const matches = []
+  for (const name of entries || []) {
+    if (typeof name !== 'string' || !name.endsWith('.plist')) continue
+    const kind = matchKind(name)
+    if (!kind) continue
+    matches.push({ name, kind })
+  }
   return matches
-    .map((name) => {
+    .map(({ name, kind }) => {
+      const cfg = configFor(kind)
       const plistPath = join(dir, name)
       const label = name.replace(/\.plist$/, '')
-      const slug = label.slice(LABEL_PREFIX.length + 1)
+      const slug = label.slice(cfg.prefix.length + 1)
       let content = ''
       try {
         content = fs.readFileSync(plistPath, 'utf8').toString()
@@ -187,20 +243,38 @@ export function listInstalledAgents({ home = homedir(), fsImpl } = {}) {
         slug,
         label,
         plistPath,
+        kind,
         workingDirectory: meta.workingDirectory,
         intervalSeconds: meta.intervalSeconds,
+        startCalendarInterval: meta.startCalendarInterval,
       }
     })
-    .sort((a, b) => a.slug.localeCompare(b.slug))
+    .sort((a, b) => {
+      if (a.slug !== b.slug) return a.slug.localeCompare(b.slug)
+      return a.kind.localeCompare(b.kind)
+    })
+}
+
+function matchKind(plistName) {
+  for (const kind of KINDS) {
+    const prefix = `${configFor(kind).prefix}.`
+    if (plistName.startsWith(prefix)) return kind
+  }
+  return null
 }
 
 export function parsePlistMetadata(xml) {
   if (!xml || typeof xml !== 'string') {
-    return { workingDirectory: null, intervalSeconds: null }
+    return {
+      workingDirectory: null,
+      intervalSeconds: null,
+      startCalendarInterval: null,
+    }
   }
   return {
     workingDirectory: matchKeyString(xml, 'WorkingDirectory'),
     intervalSeconds: matchKeyInteger(xml, 'StartInterval'),
+    startCalendarInterval: matchStartCalendarInterval(xml),
   }
 }
 
@@ -216,6 +290,22 @@ function matchKeyInteger(xml, key) {
   return m ? Number.parseInt(m[1], 10) : null
 }
 
+function matchStartCalendarInterval(xml) {
+  const blockRe = /<key>StartCalendarInterval<\/key>\s*<dict>([\s\S]*?)<\/dict>/
+  const m = xml.match(blockRe)
+  if (!m) return null
+  const inner = m[1]
+  const hourMatch = inner.match(/<key>Hour<\/key>\s*<integer>(-?\d+)<\/integer>/)
+  const minuteMatch = inner.match(
+    /<key>Minute<\/key>\s*<integer>(-?\d+)<\/integer>/,
+  )
+  if (!hourMatch || !minuteMatch) return null
+  return {
+    hour: Number.parseInt(hourMatch[1], 10),
+    minute: Number.parseInt(minuteMatch[1], 10),
+  }
+}
+
 function unescapeXml(s) {
   return String(s)
     .replace(/&lt;/g, '<')
@@ -226,10 +316,11 @@ function unescapeXml(s) {
 
 export async function getAgentStatus({
   slug,
+  kind = 'cycle',
   exec = execa,
   uid = currentUid(),
 }) {
-  const label = labelFor(slug)
+  const label = labelFor(slug, kind)
   const printRes = await exec('launchctl', ['print', `gui/${uid}/${label}`], {
     reject: false,
   })

--- a/packages/ralph/lib/launchd.test.js
+++ b/packages/ralph/lib/launchd.test.js
@@ -370,14 +370,17 @@ describe('parsePlistMetadata', () => {
     expect(parsePlistMetadata('')).toEqual({
       workingDirectory: null,
       intervalSeconds: null,
+      startCalendarInterval: null,
     })
     expect(parsePlistMetadata(null)).toEqual({
       workingDirectory: null,
       intervalSeconds: null,
+      startCalendarInterval: null,
     })
     expect(parsePlistMetadata('<plist/>')).toEqual({
       workingDirectory: null,
       intervalSeconds: null,
+      startCalendarInterval: null,
     })
   })
 

--- a/packages/ralph/lib/launchd.test.js
+++ b/packages/ralph/lib/launchd.test.js
@@ -154,6 +154,54 @@ describe('buildPlist', () => {
     )
     expect(xml).toContain('<plist version="1.0">')
   })
+
+  describe('kind: heartbeat', () => {
+    const heartbeatInput = {
+      slug: SLUG,
+      command: '/usr/local/bin/ralph',
+      args: ['schedule', 'heartbeat'],
+      startCalendarInterval: { hour: 9, minute: 0 },
+      workingDirectory: '/Users/me/repos/agenthub',
+      logDir: '/Users/me/repos/agenthub/logs',
+      environment: { PATH: '/usr/bin' },
+      kind: 'heartbeat',
+    }
+
+    it('uses the heartbeat label prefix', () => {
+      const xml = buildPlist(heartbeatInput)
+      expect(xml).toContain(
+        `<string>com.lucasfe.ralph.heartbeat.${SLUG}</string>`,
+      )
+    })
+
+    it('emits StartCalendarInterval with Hour and Minute integers', () => {
+      const xml = buildPlist(heartbeatInput)
+      expect(xml).toMatch(/<key>StartCalendarInterval<\/key>/)
+      expect(xml).toMatch(/<key>Hour<\/key>\s*<integer>9<\/integer>/)
+      expect(xml).toMatch(/<key>Minute<\/key>\s*<integer>0<\/integer>/)
+    })
+
+    it('does NOT emit StartInterval when startCalendarInterval is set', () => {
+      const xml = buildPlist(heartbeatInput)
+      expect(xml).not.toMatch(/<key>StartInterval<\/key>/)
+    })
+
+    it('writes log files under ralph-heartbeat.{out,err}.log', () => {
+      const xml = buildPlist(heartbeatInput)
+      expect(xml).toContain(
+        '<string>/Users/me/repos/agenthub/logs/ralph-heartbeat.out.log</string>',
+      )
+      expect(xml).toContain(
+        '<string>/Users/me/repos/agenthub/logs/ralph-heartbeat.err.log</string>',
+      )
+    })
+
+    it('throws when startCalendarInterval is missing valid hour/minute', () => {
+      expect(() =>
+        buildPlist({ ...heartbeatInput, startCalendarInterval: { hour: 'noon' } }),
+      ).toThrow(/startCalendarInterval/i)
+    })
+  })
 })
 
 describe('installAgent', () => {

--- a/packages/ralph/lib/launchd.test.js
+++ b/packages/ralph/lib/launchd.test.js
@@ -249,6 +249,30 @@ describe('installAgent', () => {
     expect(written).not.toBe('<old/>')
     expect(written).toContain(LABEL)
   })
+
+  it('writes a heartbeat plist at the heartbeat path when kind is "heartbeat"', async () => {
+    const v = vol()
+    const exec = makeExec()
+    const result = await installAgent({
+      slug: SLUG,
+      command: '/usr/local/bin/ralph',
+      args: ['schedule', 'heartbeat'],
+      startCalendarInterval: { hour: 9, minute: 0 },
+      workingDirectory: '/Users/me/repos/agenthub',
+      logDir: '/Users/me/repos/agenthub/logs',
+      environment: { PATH: '/usr/bin' },
+      kind: 'heartbeat',
+      home: HOME,
+      fsImpl: v,
+      exec,
+    })
+    const heartbeatPath = `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.heartbeat.${SLUG}.plist`
+    expect(result.plistPath).toBe(heartbeatPath)
+    expect(result.kind).toBe('heartbeat')
+    expect(v.existsSync(heartbeatPath)).toBe(true)
+    const written = v.readFileSync(heartbeatPath, 'utf8').toString()
+    expect(written).toMatch(/<key>StartCalendarInterval<\/key>/)
+  })
 })
 
 describe('removeAgent', () => {

--- a/packages/ralph/lib/launchd.test.js
+++ b/packages/ralph/lib/launchd.test.js
@@ -41,9 +41,19 @@ function makeExec(handlers = {}) {
 }
 
 describe('labelFor', () => {
-  it('builds com.lucasfe.ralph.cycle.<slug>', () => {
+  it('builds com.lucasfe.ralph.cycle.<slug> by default', () => {
     expect(labelFor('agenthub')).toBe('com.lucasfe.ralph.cycle.agenthub')
     expect(labelFor('my-app')).toBe('com.lucasfe.ralph.cycle.my-app')
+  })
+
+  it('builds com.lucasfe.ralph.heartbeat.<slug> when kind is "heartbeat"', () => {
+    expect(labelFor('agenthub', 'heartbeat')).toBe(
+      'com.lucasfe.ralph.heartbeat.agenthub',
+    )
+  })
+
+  it('throws on unknown kind', () => {
+    expect(() => labelFor('agenthub', 'banana')).toThrow(/banana/)
   })
 })
 
@@ -54,6 +64,12 @@ describe('plistPathFor', () => {
 
   it('differs per slug', () => {
     expect(plistPathFor('a', HOME)).not.toBe(plistPathFor('b', HOME))
+  })
+
+  it('returns the heartbeat plist path when kind is "heartbeat"', () => {
+    expect(plistPathFor('agenthub', HOME, 'heartbeat')).toBe(
+      `${HOME}/Library/LaunchAgents/com.lucasfe.ralph.heartbeat.agenthub.plist`,
+    )
   })
 })
 

--- a/packages/ralph/lib/launchd.test.js
+++ b/packages/ralph/lib/launchd.test.js
@@ -550,8 +550,44 @@ describe('listInstalledAgents', () => {
     expect(list[0]).toMatchObject({
       slug: 'broken',
       label: 'com.lucasfe.ralph.cycle.broken',
+      kind: 'cycle',
       workingDirectory: null,
       intervalSeconds: null,
+    })
+  })
+
+  it('lists heartbeat plists with kind: "heartbeat"', () => {
+    const repo = '/Users/me/repos/agenthub'
+    const cyclePlist = makePlist('agenthub', repo, 14400)
+    const heartbeatPlist = buildPlist({
+      slug: 'agenthub',
+      command: '/usr/local/bin/ralph',
+      args: ['schedule', 'heartbeat'],
+      startCalendarInterval: { hour: 9, minute: 0 },
+      workingDirectory: repo,
+      logDir: `${repo}/logs`,
+      environment: { PATH: '/usr/bin' },
+      kind: 'heartbeat',
+    })
+    const v = vol({
+      [`${LAUNCH_DIR}/com.lucasfe.ralph.cycle.agenthub.plist`]: cyclePlist,
+      [`${LAUNCH_DIR}/com.lucasfe.ralph.heartbeat.agenthub.plist`]: heartbeatPlist,
+    })
+    const list = listInstalledAgents({ home: HOME, fsImpl: v })
+    expect(list).toHaveLength(2)
+    const cycleEntry = list.find((a) => a.kind === 'cycle')
+    const heartbeatEntry = list.find((a) => a.kind === 'heartbeat')
+    expect(cycleEntry).toMatchObject({
+      slug: 'agenthub',
+      label: 'com.lucasfe.ralph.cycle.agenthub',
+      kind: 'cycle',
+      intervalSeconds: 14400,
+    })
+    expect(heartbeatEntry).toMatchObject({
+      slug: 'agenthub',
+      label: 'com.lucasfe.ralph.heartbeat.agenthub',
+      kind: 'heartbeat',
+      startCalendarInterval: { hour: 9, minute: 0 },
     })
   })
 })


### PR DESCRIPTION
Closes #223

## TDD
- Tests added/modified:
  - `packages/ralph/lib/heartbeat.test.js` (new — 11 tests)
  - `packages/ralph/lib/launchd.test.js` (extended for `kind: 'heartbeat'` + `StartCalendarInterval` — +10 tests, 45 total)
  - `packages/ralph/lib/commands/cycle.test.js` (extended to cover `RALPH_CYCLE_EVENT` log line on every exit path — +6 tests, 24 total)
  - `packages/ralph/lib/commands/schedule.test.js` (extended for dual-plist install/remove/pause/resume/status + `parseHeartbeatTime` + `scheduleHeartbeatCommand` — +13 tests, 48 total)
- Before implementation (red):
  - `lib/heartbeat.test.js` failed to load because `./heartbeat.js` did not exist.
  - The first dual-plist install test failed: only the cycle plist was installed (heartbeat call was missing), and the existing assertion `installArgs.args).toEqual(['cycle'])` started receiving `['schedule', 'heartbeat']` after the second install was wired.
- After implementation (green): all 325 tests pass via \`cd packages/ralph && npm test\` (heartbeat 11 + launchd 45 + cycle 24 + schedule 48 + the 197 pre-existing tests). Frontend suite (\`npm test\` at repo root) still 186/186. Lint clean (no new warnings).

## Notes

### `lib/heartbeat.js`
- \`summarizeLast24h({ logDir, fs, clock })\` reads \`<logDir>/ralph-cycle.out.log\` plus any rotated copies (\`*.log*\`), parses \`RALPH_CYCLE_EVENT { ... }\` lines, filters to events whose \`ts\` falls inside the 24h window ending at \`clock()\`, and returns \`{ cycles, totalIssues, ok, failed, abortedCycles, durations, lastCycle }\`. Aborted statuses (\`preflight-failed\`, \`lock-held\`, \`tmux-active\`) are counted in \`abortedCycles\` and excluded from \`durations\` — they did not actually run a queue.
- \`formatSummary(summary, { repoSlug, nextTick })\` renders the Ralph 24h string. Empty (0 cycles) and all-failed scenarios get distinct rendering — the all-failed branch tags the line with ⚠️ so silence does not look like health.
- Malformed lines, unparseable timestamps, missing log files, and unreadable rotated files are all swallowed — the heartbeat is best-effort and must never block the daily WhatsApp delivery.

### \`lib/launchd.js\` extension
- New \`kind\` parameter (default \`'cycle'\`) on \`labelFor\`, \`plistPathFor\`, \`buildPlist\`, \`installAgent\`, \`removeAgent\`, \`pauseAgent\`, \`resumeAgent\`, \`getAgentStatus\`. \`'heartbeat'\` uses the \`com.lucasfe.ralph.heartbeat.<slug>\` prefix and writes to \`ralph-heartbeat.{out,err}.log\`.
- \`buildPlist\` accepts \`startCalendarInterval: { hour, minute }\` and emits a \`StartCalendarInterval\` dict instead of \`StartInterval\` when set. Validation throws on missing/invalid hour/minute.
- \`listInstalledAgents\` now scans both prefixes and tags each entry with \`kind\`. The \`startCalendarInterval\` field is parsed back from the plist for status display.

### \`lib/commands/cycle.js\` event line
- Cycle now emits \`RALPH_CYCLE_EVENT <json>\` to stdout on every exit path (\`tmux-active\`, \`preflight-failed\`, \`lock-held\`, \`queue-empty\`, \`success\`, \`partial\`, \`failed\`). The JSON has \`ts\` (ISO from \`now()\`), \`status\`, \`ok\`, \`failed\`, \`durationMin\`, \`processed\` — exactly the shape \`summarizeLast24h\` consumes. This is purely additive — no human-readable line was removed or reformatted.

### \`lib/commands/schedule.js\` — dual plist
- \`install\` now creates BOTH plists in one go: \`com.lucasfe.ralph.cycle.<slug>\` (existing behavior) + \`com.lucasfe.ralph.heartbeat.<slug>\` (new, points at \`ralph schedule heartbeat\`, fires daily at \`--heartbeat-time\` / \`RALPH_DAILY_SUMMARY_TIME\` / \`09:00\`). \`--force\` removes both before reinstall.
- \`remove\`, \`pause\`, \`resume\` operate on both plists transparently. If one is missing (e.g. an older install), the other still gets touched — no abort.
- \`status\` prints one block per agent (\`▸ <slug> (<kind>)\`). Heartbeat blocks render \`schedule: daily at HH:MM\` instead of \`interval:\` and skip the lock line (heartbeat does not contend for the cycle lock).
- New internal command \`scheduleHeartbeatCommand\`: resolves repo root + slug, loads \`.env.local\`, runs \`summarizeLast24h\` + \`formatSummary\`, sends WhatsApp via the existing \`utils/whatsapp.js\`. \`summarize\` errors fall back to \`❌ Ralph 24h summary failed: <reason>\` so silence ≠ healthy. WhatsApp send failures are logged but never crash the heartbeat.
- New helper \`parseHeartbeatTime(input)\` — strict \`HH:MM\` parser (rejects \`25:00\`, \`12:60\`, \`foo\`).

### \`bin/ralph.js\` wiring
- \`ralph schedule install\` gains \`--heartbeat-time <hh:mm>\` (defaults to \`RALPH_DAILY_SUMMARY_TIME\` or \`09:00\`).
- \`ralph schedule heartbeat\` is the new internal subcommand the heartbeat plist invokes — described as internal in the help string.

### Manual smoke (deferred)
The acceptance criteria includes a manual smoke (install with \`RALPH_DAILY_SUMMARY_TIME=\$(date "+%H:%M" -v+2M)\`, observe the heartbeat fire two minutes later). Not run here — Ralph is producing this PR autonomously inside CI-like conditions and macOS \`launchctl\` is not available in the agent. The behavior is fully covered by unit tests against the same plist shape \`launchd\` consumes; reviewer should run the smoke before merging if landing this on a workstation.