### PR TITLE
feat: push_subscriptions table + push-subscribe/unsubscribe Edge Functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run --reporter=verbose",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:functions": "deno test --allow-net --allow-env supabase/functions/",
+    "test:functions": "deno test --config supabase/functions/deno.json --allow-net --allow-env --allow-read --allow-write --allow-sys supabase/functions/",
     "test:functions:integration": "deno test --allow-net --allow-env supabase/integration/",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "auto"
+}

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1,0 +1,94 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@supabase/functions-js@^0.0.0-automated": "0.0.0-jsr-test.1",
+    "jsr:@supabase/supabase-js@2": "2.105.1",
+    "npm:@supabase/auth-js@2.105.1": "2.105.1",
+    "npm:@supabase/postgrest-js@2.105.1": "2.105.1",
+    "npm:@supabase/realtime-js@2.105.1": "2.105.1",
+    "npm:@supabase/storage-js@2.105.1": "2.105.1"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
+    "@supabase/functions-js@0.0.0-jsr-test.1": {
+      "integrity": "b1b37924af1f0011b4753201e1585a37b030e996c6682492e02575eb27d902b2"
+    },
+    "@supabase/supabase-js@2.105.1": {
+      "integrity": "f45f9322ad8bca1d98e6ea56fafde1eb3fd3438f6f20805c797080fe7157132a",
+      "dependencies": [
+        "jsr:@supabase/functions-js",
+        "npm:@supabase/auth-js",
+        "npm:@supabase/postgrest-js",
+        "npm:@supabase/realtime-js",
+        "npm:@supabase/storage-js"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.105.1": {
+      "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.1": {
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA=="
+    },
+    "@supabase/postgrest-js@2.105.1": {
+      "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.105.1": {
+      "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "@types/ws",
+        "tslib",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.105.1": {
+      "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@types/node@25.6.0": {
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "undici-types@7.19.2": {
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+    },
+    "ws@8.20.0": {
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
+    }
+  }
+}

--- a/supabase/functions/push-subscribe/index.test.ts
+++ b/supabase/functions/push-subscribe/index.test.ts
@@ -1,0 +1,224 @@
+// deno-lint-ignore-file no-explicit-any
+import { assertEquals } from 'jsr:@std/assert@1'
+import { handlePushSubscribe } from './index.ts'
+
+interface MockClientCalls {
+  authHeader?: string
+  from: { table: string }[]
+  upsert: { values: any; options: any }[]
+}
+
+function makeMockClient(opts: {
+  user?: { id: string } | null
+  authError?: { message: string } | null
+  upsertResult?: { data: any; error: any }
+}) {
+  const calls: MockClientCalls = { from: [], upsert: [] }
+  let captured = ''
+  const factory = (_url: string, _key: string, init?: any) => {
+    captured = init?.global?.headers?.Authorization ?? ''
+    calls.authHeader = captured
+    const upsertChain: any = {
+      select(_cols: string) {
+        return this
+      },
+      single() {
+        return Promise.resolve(
+          opts.upsertResult ?? { data: { id: 'sub-1' }, error: null },
+        )
+      },
+    }
+    return {
+      auth: {
+        getUser: async () => ({
+          data: { user: opts.user ?? null },
+          error: opts.authError ?? null,
+        }),
+      },
+      from(table: string) {
+        calls.from.push({ table })
+        return {
+          upsert(values: any, options: any) {
+            calls.upsert.push({ values, options })
+            return upsertChain
+          },
+        }
+      },
+    } as any
+  }
+  return { factory, calls }
+}
+
+const baseDeps = (factory: any) => ({
+  createClient: factory as any,
+  supabaseUrl: 'http://localhost',
+  supabaseAnonKey: 'anon',
+})
+
+function makeReq(body: unknown, headers: Record<string, string> = {}) {
+  return new Request('http://localhost/push-subscribe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+Deno.test('push-subscribe — rejects missing Authorization header with 401', async () => {
+  const { factory } = makeMockClient({})
+  const res = await handlePushSubscribe(
+    new Request('http://localhost/push-subscribe', { method: 'POST' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 401)
+})
+
+Deno.test('push-subscribe — rejects invalid JWT with 401', async () => {
+  const { factory } = makeMockClient({
+    user: null,
+    authError: { message: 'invalid jwt' },
+  })
+  const res = await handlePushSubscribe(
+    makeReq({ endpoint: 'https://x', keys: { p256dh: 'a', auth: 'b' } }, {
+      Authorization: 'Bearer bad',
+    }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 401)
+})
+
+Deno.test('push-subscribe — rejects non-POST with 405', async () => {
+  const { factory } = makeMockClient({})
+  const res = await handlePushSubscribe(
+    new Request('http://localhost/push-subscribe', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer x' },
+    }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 405)
+})
+
+Deno.test('push-subscribe — handles OPTIONS preflight', async () => {
+  const { factory } = makeMockClient({})
+  const res = await handlePushSubscribe(
+    new Request('http://localhost/push-subscribe', { method: 'OPTIONS' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 200)
+  assertEquals(
+    res.headers.get('Access-Control-Allow-Methods')?.includes('POST'),
+    true,
+  )
+})
+
+Deno.test('push-subscribe — rejects missing endpoint with 400', async () => {
+  const { factory } = makeMockClient({ user: { id: 'u1' } })
+  const res = await handlePushSubscribe(
+    makeReq({ keys: { p256dh: 'a', auth: 'b' } }, { Authorization: 'Bearer t' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 400)
+})
+
+Deno.test('push-subscribe — rejects missing keys.p256dh with 400', async () => {
+  const { factory } = makeMockClient({ user: { id: 'u1' } })
+  const res = await handlePushSubscribe(
+    makeReq({ endpoint: 'https://x', keys: { auth: 'b' } }, {
+      Authorization: 'Bearer t',
+    }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 400)
+})
+
+Deno.test('push-subscribe — rejects missing keys.auth with 400', async () => {
+  const { factory } = makeMockClient({ user: { id: 'u1' } })
+  const res = await handlePushSubscribe(
+    makeReq({ endpoint: 'https://x', keys: { p256dh: 'a' } }, {
+      Authorization: 'Bearer t',
+    }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 400)
+})
+
+Deno.test('push-subscribe — rejects invalid JSON body with 400', async () => {
+  const { factory } = makeMockClient({ user: { id: 'u1' } })
+  const res = await handlePushSubscribe(
+    makeReq('{not-json', { Authorization: 'Bearer t' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 400)
+})
+
+Deno.test('push-subscribe — upserts with user_id from auth, returns id', async () => {
+  const { factory, calls } = makeMockClient({
+    user: { id: 'user-42' },
+    upsertResult: { data: { id: 'row-9' }, error: null },
+  })
+  const res = await handlePushSubscribe(
+    makeReq(
+      {
+        endpoint: 'https://fcm.googleapis.com/abc',
+        keys: { p256dh: 'pk', auth: 'auth-secret' },
+      },
+      { Authorization: 'Bearer good' },
+    ),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 200)
+  const json = await res.json()
+  assertEquals(json, { id: 'row-9' })
+  assertEquals(calls.from, [{ table: 'push_subscriptions' }])
+  assertEquals(calls.upsert.length, 1)
+  assertEquals(calls.upsert[0].values, {
+    user_id: 'user-42',
+    endpoint: 'https://fcm.googleapis.com/abc',
+    p256dh: 'pk',
+    auth: 'auth-secret',
+  })
+  assertEquals(calls.upsert[0].options, { onConflict: 'user_id,endpoint' })
+})
+
+Deno.test('push-subscribe — forwards Authorization header to supabase client', async () => {
+  const { factory, calls } = makeMockClient({ user: { id: 'u1' } })
+  await handlePushSubscribe(
+    makeReq(
+      { endpoint: 'https://x', keys: { p256dh: 'a', auth: 'b' } },
+      { Authorization: 'Bearer abc.def.ghi' },
+    ),
+    baseDeps(factory),
+  )
+  assertEquals(calls.authHeader, 'Bearer abc.def.ghi')
+})
+
+Deno.test('push-subscribe — ignores client-supplied user_id (RLS-safe)', async () => {
+  const { factory, calls } = makeMockClient({ user: { id: 'real-user' } })
+  await handlePushSubscribe(
+    makeReq(
+      {
+        endpoint: 'https://x',
+        keys: { p256dh: 'a', auth: 'b' },
+        user_id: 'attacker-target',
+      },
+      { Authorization: 'Bearer t' },
+    ),
+    baseDeps(factory),
+  )
+  assertEquals(calls.upsert[0].values.user_id, 'real-user')
+})
+
+Deno.test('push-subscribe — surfaces 500 when upsert fails', async () => {
+  const { factory } = makeMockClient({
+    user: { id: 'u1' },
+    upsertResult: { data: null, error: { message: 'boom' } },
+  })
+  const res = await handlePushSubscribe(
+    makeReq(
+      { endpoint: 'https://x', keys: { p256dh: 'a', auth: 'b' } },
+      { Authorization: 'Bearer t' },
+    ),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 500)
+})

--- a/supabase/functions/push-subscribe/index.ts
+++ b/supabase/functions/push-subscribe/index.ts
@@ -1,0 +1,108 @@
+// Edge Function: push-subscribe
+//
+// Persists a Web Push subscription for the authenticated user. Used by the
+// mobile shell at /mobile to register the browser's PushManager subscription
+// so the backend can send notifications later (slices 6 and 8). This function
+// only stores subscriptions — it never sends pushes.
+//
+// Auth: caller must present a valid Supabase JWT. The user's identity is
+// derived from `auth.getUser()` and used as the `user_id` of the persisted
+// row, so a client cannot register a subscription against another account
+// even if it tries to set `user_id` in the body. RLS in the migration makes
+// this defense-in-depth: the INSERT policy requires `auth.uid() = user_id`.
+
+// deno-lint-ignore-file no-explicit-any
+
+import { createClient as defaultCreateClient } from 'jsr:@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+export interface SubscribeDeps {
+  createClient: typeof defaultCreateClient
+  supabaseUrl: string
+  supabaseAnonKey: string
+}
+
+export async function handlePushSubscribe(
+  req: Request,
+  deps: SubscribeDeps,
+): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405)
+  }
+
+  const authHeader = req.headers.get('Authorization')
+  if (!authHeader) {
+    return jsonResponse({ error: 'Missing authorization' }, 401)
+  }
+
+  const userClient = deps.createClient(deps.supabaseUrl, deps.supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  })
+
+  const {
+    data: { user },
+    error: authError,
+  } = await userClient.auth.getUser()
+  if (authError || !user) {
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  let body: any
+  try {
+    body = await req.json()
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON' }, 400)
+  }
+
+  const endpoint = typeof body?.endpoint === 'string' ? body.endpoint : ''
+  const p256dh = typeof body?.keys?.p256dh === 'string' ? body.keys.p256dh : ''
+  const auth = typeof body?.keys?.auth === 'string' ? body.keys.auth : ''
+  if (!endpoint || !p256dh || !auth) {
+    return jsonResponse(
+      { error: 'Missing endpoint, keys.p256dh, or keys.auth' },
+      400,
+    )
+  }
+
+  const { data, error } = await userClient
+    .from('push_subscriptions')
+    .upsert(
+      { user_id: user.id, endpoint, p256dh, auth },
+      { onConflict: 'user_id,endpoint' },
+    )
+    .select('id')
+    .single()
+
+  if (error) {
+    console.error('[push-subscribe] upsert error', error)
+    return jsonResponse({ error: 'Failed to store subscription' }, 500)
+  }
+
+  return jsonResponse({ id: (data as any)?.id ?? null }, 200)
+}
+
+if (import.meta.main) {
+  Deno.serve((req) =>
+    handlePushSubscribe(req, {
+      createClient: defaultCreateClient,
+      supabaseUrl: Deno.env.get('SUPABASE_URL')!,
+      supabaseAnonKey: Deno.env.get('SUPABASE_ANON_KEY')!,
+    }),
+  )
+}

--- a/supabase/functions/push-unsubscribe/index.test.ts
+++ b/supabase/functions/push-unsubscribe/index.test.ts
@@ -1,0 +1,200 @@
+// deno-lint-ignore-file no-explicit-any
+import { assertEquals } from 'jsr:@std/assert@1'
+import { handlePushUnsubscribe } from './index.ts'
+
+interface MockClientCalls {
+  authHeader?: string
+  from: { table: string }[]
+  delete: number
+  filters: { col: string; val: any }[]
+}
+
+function makeMockClient(opts: {
+  user?: { id: string } | null
+  authError?: { message: string } | null
+  deleteResult?: { error: any; count?: number; data?: any }
+}) {
+  const calls: MockClientCalls = { from: [], delete: 0, filters: [] }
+  const factory = (_url: string, _key: string, init?: any) => {
+    calls.authHeader = init?.global?.headers?.Authorization ?? ''
+    const result = opts.deleteResult ?? { error: null, count: 1, data: null }
+    const chain: any = {
+      _filters: calls.filters,
+      eq(col: string, val: any) {
+        calls.filters.push({ col, val })
+        return this
+      },
+      then(onFulfilled: any, onRejected: any) {
+        return Promise.resolve(result).then(onFulfilled, onRejected)
+      },
+    }
+    return {
+      auth: {
+        getUser: async () => ({
+          data: { user: opts.user ?? null },
+          error: opts.authError ?? null,
+        }),
+      },
+      from(table: string) {
+        calls.from.push({ table })
+        return {
+          delete(_opts?: any) {
+            calls.delete += 1
+            return chain
+          },
+        }
+      },
+    } as any
+  }
+  return { factory, calls }
+}
+
+const baseDeps = (factory: any) => ({
+  createClient: factory as any,
+  supabaseUrl: 'http://localhost',
+  supabaseAnonKey: 'anon',
+})
+
+function makeReq(body: unknown, headers: Record<string, string> = {}) {
+  return new Request('http://localhost/push-unsubscribe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+Deno.test('push-unsubscribe — rejects missing Authorization header with 401', async () => {
+  const { factory } = makeMockClient({})
+  const res = await handlePushUnsubscribe(
+    new Request('http://localhost/push-unsubscribe', { method: 'POST' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 401)
+})
+
+Deno.test('push-unsubscribe — rejects invalid JWT with 401', async () => {
+  const { factory } = makeMockClient({
+    user: null,
+    authError: { message: 'invalid jwt' },
+  })
+  const res = await handlePushUnsubscribe(
+    makeReq({ endpoint: 'https://x' }, { Authorization: 'Bearer bad' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 401)
+})
+
+Deno.test('push-unsubscribe — rejects non-POST with 405', async () => {
+  const { factory } = makeMockClient({})
+  const res = await handlePushUnsubscribe(
+    new Request('http://localhost/push-unsubscribe', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer x' },
+    }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 405)
+})
+
+Deno.test('push-unsubscribe — handles OPTIONS preflight', async () => {
+  const { factory } = makeMockClient({})
+  const res = await handlePushUnsubscribe(
+    new Request('http://localhost/push-unsubscribe', { method: 'OPTIONS' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 200)
+})
+
+Deno.test('push-unsubscribe — rejects missing endpoint with 400', async () => {
+  const { factory } = makeMockClient({ user: { id: 'u1' } })
+  const res = await handlePushUnsubscribe(
+    makeReq({}, { Authorization: 'Bearer t' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 400)
+})
+
+Deno.test('push-unsubscribe — rejects invalid JSON with 400', async () => {
+  const { factory } = makeMockClient({ user: { id: 'u1' } })
+  const res = await handlePushUnsubscribe(
+    makeReq('{not-json', { Authorization: 'Bearer t' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 400)
+})
+
+Deno.test('push-unsubscribe — deletes scoped to user_id and endpoint, returns 200', async () => {
+  const { factory, calls } = makeMockClient({
+    user: { id: 'user-7' },
+    deleteResult: { error: null, count: 1 },
+  })
+  const res = await handlePushUnsubscribe(
+    makeReq(
+      { endpoint: 'https://fcm.googleapis.com/xyz' },
+      { Authorization: 'Bearer good' },
+    ),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 200)
+  assertEquals(calls.from, [{ table: 'push_subscriptions' }])
+  assertEquals(calls.delete, 1)
+  // Order matters less than presence — both filters must be applied
+  assertEquals(calls.filters.length, 2)
+  const byCol: Record<string, any> = {}
+  for (const f of calls.filters) byCol[f.col] = f.val
+  assertEquals(byCol.user_id, 'user-7')
+  assertEquals(byCol.endpoint, 'https://fcm.googleapis.com/xyz')
+})
+
+Deno.test('push-unsubscribe — returns 404 when no row matched (idempotent)', async () => {
+  const { factory } = makeMockClient({
+    user: { id: 'user-7' },
+    deleteResult: { error: null, count: 0 },
+  })
+  const res = await handlePushUnsubscribe(
+    makeReq(
+      { endpoint: 'https://nope' },
+      { Authorization: 'Bearer good' },
+    ),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 404)
+})
+
+Deno.test('push-unsubscribe — surfaces 500 when delete fails', async () => {
+  const { factory } = makeMockClient({
+    user: { id: 'u1' },
+    deleteResult: { error: { message: 'boom' }, count: null },
+  })
+  const res = await handlePushUnsubscribe(
+    makeReq({ endpoint: 'https://x' }, { Authorization: 'Bearer t' }),
+    baseDeps(factory),
+  )
+  assertEquals(res.status, 500)
+})
+
+Deno.test('push-unsubscribe — forwards Authorization header to supabase client', async () => {
+  const { factory, calls } = makeMockClient({ user: { id: 'u1' } })
+  await handlePushUnsubscribe(
+    makeReq(
+      { endpoint: 'https://x' },
+      { Authorization: 'Bearer abc.def.ghi' },
+    ),
+    baseDeps(factory),
+  )
+  assertEquals(calls.authHeader, 'Bearer abc.def.ghi')
+})
+
+Deno.test('push-unsubscribe — ignores client-supplied user_id (RLS-safe)', async () => {
+  const { factory, calls } = makeMockClient({ user: { id: 'real-user' } })
+  await handlePushUnsubscribe(
+    makeReq(
+      { endpoint: 'https://x', user_id: 'attacker-target' },
+      { Authorization: 'Bearer t' },
+    ),
+    baseDeps(factory),
+  )
+  const byCol: Record<string, any> = {}
+  for (const f of calls.filters) byCol[f.col] = f.val
+  assertEquals(byCol.user_id, 'real-user')
+})

--- a/supabase/functions/push-unsubscribe/index.test.ts
+++ b/supabase/functions/push-unsubscribe/index.test.ts
@@ -12,7 +12,7 @@ interface MockClientCalls {
 function makeMockClient(opts: {
   user?: { id: string } | null
   authError?: { message: string } | null
-  deleteResult?: { error: any; count?: number; data?: any }
+  deleteResult?: { error: any; count?: number | null; data?: any }
 }) {
   const calls: MockClientCalls = { from: [], delete: 0, filters: [] }
   const factory = (_url: string, _key: string, init?: any) => {

--- a/supabase/functions/push-unsubscribe/index.ts
+++ b/supabase/functions/push-unsubscribe/index.ts
@@ -1,0 +1,101 @@
+// Edge Function: push-unsubscribe
+//
+// Removes a stored Web Push subscription for the authenticated user. The
+// client calls this when the user opts out of notifications or when its
+// browser-side `PushManager` subscription was rotated/expired.
+//
+// The delete is scoped to `auth.uid() = user_id AND endpoint = ?`, so a
+// client cannot unsubscribe another user's device even by guessing endpoints.
+// 404 is returned when no row matched, which keeps the operation idempotent
+// from the client's perspective: re-sending an unsubscribe never errors.
+
+// deno-lint-ignore-file no-explicit-any
+
+import { createClient as defaultCreateClient } from 'jsr:@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+export interface UnsubscribeDeps {
+  createClient: typeof defaultCreateClient
+  supabaseUrl: string
+  supabaseAnonKey: string
+}
+
+export async function handlePushUnsubscribe(
+  req: Request,
+  deps: UnsubscribeDeps,
+): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405)
+  }
+
+  const authHeader = req.headers.get('Authorization')
+  if (!authHeader) {
+    return jsonResponse({ error: 'Missing authorization' }, 401)
+  }
+
+  const userClient = deps.createClient(deps.supabaseUrl, deps.supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  })
+
+  const {
+    data: { user },
+    error: authError,
+  } = await userClient.auth.getUser()
+  if (authError || !user) {
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  let body: any
+  try {
+    body = await req.json()
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON' }, 400)
+  }
+
+  const endpoint = typeof body?.endpoint === 'string' ? body.endpoint : ''
+  if (!endpoint) {
+    return jsonResponse({ error: 'Missing endpoint' }, 400)
+  }
+
+  const { error, count } = await userClient
+    .from('push_subscriptions')
+    .delete({ count: 'exact' })
+    .eq('user_id', user.id)
+    .eq('endpoint', endpoint)
+
+  if (error) {
+    console.error('[push-unsubscribe] delete error', error)
+    return jsonResponse({ error: 'Failed to delete subscription' }, 500)
+  }
+
+  if (typeof count === 'number' && count === 0) {
+    return jsonResponse({ ok: true, deleted: 0 }, 404)
+  }
+  return jsonResponse({ ok: true, deleted: count ?? null }, 200)
+}
+
+if (import.meta.main) {
+  Deno.serve((req) =>
+    handlePushUnsubscribe(req, {
+      createClient: defaultCreateClient,
+      supabaseUrl: Deno.env.get('SUPABASE_URL')!,
+      supabaseAnonKey: Deno.env.get('SUPABASE_ANON_KEY')!,
+    }),
+  )
+}

--- a/supabase/migrations/20260429000000_push_subscriptions.sql
+++ b/supabase/migrations/20260429000000_push_subscriptions.sql
@@ -1,0 +1,31 @@
+-- Web Push subscriptions for the mobile shell at /mobile.
+-- The push-subscribe Edge Function stores rows here; push-unsubscribe deletes
+-- them. RLS scopes every operation to the authenticated user, so a JWT for
+-- user A can never read/write/delete user B's subscription.
+
+create table if not exists push_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  endpoint text not null,
+  p256dh text not null,
+  auth text not null,
+  created_at timestamptz not null default now(),
+  unique (user_id, endpoint)
+);
+
+create index if not exists idx_push_subscriptions_user_id
+  on push_subscriptions (user_id);
+
+alter table push_subscriptions enable row level security;
+
+create policy "Users can read own push_subscriptions"
+  on push_subscriptions for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own push_subscriptions"
+  on push_subscriptions for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete own push_subscriptions"
+  on push_subscriptions for delete
+  using (auth.uid() = user_id);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -88,11 +88,28 @@ create table if not exists runs (
 create index if not exists idx_runs_status on runs(status);
 create index if not exists idx_runs_created_at on runs(created_at desc);
 
+-- Web Push subscriptions for the mobile shell at /mobile. Owned by the
+-- push-subscribe / push-unsubscribe Edge Functions. RLS scopes every
+-- operation to the row's owner.
+create table if not exists push_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  endpoint text not null,
+  p256dh text not null,
+  auth text not null,
+  created_at timestamptz not null default now(),
+  unique (user_id, endpoint)
+);
+
+create index if not exists idx_push_subscriptions_user_id
+  on push_subscriptions (user_id);
+
 -- Enable Row Level Security (for future auth)
 alter table agents enable row level security;
 alter table teams enable row level security;
 alter table tools enable row level security;
 alter table runs enable row level security;
+alter table push_subscriptions enable row level security;
 
 -- For now, allow public read access (no auth yet)
 create policy "Public read access for agents" on agents

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -141,3 +141,15 @@ create policy "Public read access for runs" on runs
 
 create policy "Public insert access for runs" on runs
   for insert with check (true);
+
+-- Push subscription policies: a row belongs to its user_id. The Edge
+-- Functions never touch other users' rows, so we don't expose any update or
+-- service-role policy here.
+create policy "Users can read own push_subscriptions" on push_subscriptions
+  for select using (auth.uid() = user_id);
+
+create policy "Users can insert own push_subscriptions" on push_subscriptions
+  for insert with check (auth.uid() = user_id);
+
+create policy "Users can delete own push_subscriptions" on push_subscriptions
+  for delete using (auth.uid() = user_id);


### PR DESCRIPTION
Closes #227

## Summary
- New migration `supabase/migrations/20260429000000_push_subscriptions.sql` with `push_subscriptions(id, user_id, endpoint, p256dh, auth, created_at)`, `unique(user_id, endpoint)`, `idx_push_subscriptions_user_id`, RLS enabled, plus `select`/`insert`/`delete` policies all gated on `auth.uid() = user_id`. The cumulative `supabase/schema.sql` is updated in lockstep.
- New Edge Function `supabase/functions/push-subscribe/index.ts`. POST `{ endpoint, keys: { p256dh, auth } }` → upsert on `(user_id, endpoint)` and return `{ id }`. Auth header is mandatory and `user_id` always comes from the verified JWT, never the request body.
- New Edge Function `supabase/functions/push-unsubscribe/index.ts`. POST `{ endpoint }` → delete the row matching the JWT's `auth.uid()` + `endpoint`. Returns 200 when a row was deleted, 404 when nothing matched (idempotent), 500 on driver error.

Both handlers are exported (`handlePushSubscribe`, `handlePushUnsubscribe`) and accept a `createClient` factory so tests don't need a live Supabase. The actual `Deno.serve` boot is gated behind `import.meta.main`, which keeps the module side-effect-free during `deno test`.

## TDD
- Tests added: `supabase/functions/push-subscribe/index.test.ts` (12 cases), `supabase/functions/push-unsubscribe/index.test.ts` (11 cases).
- Before implementation (red): `npm run test:functions` failed at type-check time — `Cannot find module './index.ts'` for both new test files (handlers did not exist yet).
- After implementation (green): `npm run test:functions` reports `70 passed | 0 failed` (47 pre-existing + 23 new). Frontend `npm test` still reports `212 passed`. `npm run lint` reports 0 errors (pre-existing warnings only).

Cases covered (both functions):
- Missing `Authorization` header → 401.
- Invalid/expired JWT (`auth.getUser` returns error) → 401.
- Non-POST methods → 405; `OPTIONS` preflight → 200 with CORS headers.
- Invalid JSON body → 400.
- Missing required fields (`endpoint`, `keys.p256dh`, `keys.auth`; `endpoint` for unsubscribe) → 400.
- Happy path: correct table, correct payload, `onConflict: 'user_id,endpoint'` for upsert, both `eq` filters for delete, `Authorization` header forwarded to the Supabase client.
- Spoofed `user_id` in request body is ignored — `user_id` is always derived from the verified JWT (RLS-safe).
- Driver error → 500; idempotent missing-row delete → 404.

## Notes
- The npm script `test:functions` now passes `--config supabase/functions/deno.json` and the extra perms (`--allow-read`, `--allow-write`, `--allow-sys`) needed by the auto-installed `node_modules`. The new `deno.json` only sets `nodeModulesDir: "auto"` so Deno can resolve the nested npm deps that `jsr:@supabase/supabase-js@2` pulls in. The auto-generated `supabase/functions/deno.lock` pins those versions for reproducibility.
- Mobile slice 5 is backend-only — nothing actually sends pushes yet. That arrives with slice 6 (`_shared/push.ts`) and slice 8 (sender wiring). Slice 7 wires the frontend calls into `push-subscribe` / `push-unsubscribe`.
- `verify_jwt: true` is the default for Supabase Edge Functions when no `config.toml` overrides it. The handler also performs its own `auth.getUser()` check so it can derive `user_id` for the upsert/delete — necessary regardless of the gateway flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)