### PR TITLE
feat(mobile): add /mobile shell with MobileApp + MobileLogin + skeleton MobileChat

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { lazy, Suspense, useMemo, useState } from 'react'
 import { Routes, Route } from 'react-router'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,8 @@ import StackButton from './components/StackButton'
 import { StackProvider } from './context/StackContext'
 import { useData } from './context/DataContext'
 
+const MobileApp = lazy(() => import('./MobileApp'))
+
 function AgentListPage() {
   const { agents, loading, error } = useData()
   const [searchQuery, setSearchQuery] = useState('')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -197,10 +197,26 @@ function ProtectedShell() {
   )
 }
 
+function MobileFallback() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-bg-primary">
+      <div className="text-text-muted">Loading...</div>
+    </div>
+  )
+}
+
 export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/mobile/*"
+        element={
+          <Suspense fallback={<MobileFallback />}>
+            <MobileApp />
+          </Suspense>
+        }
+      />
       <Route
         path="/*"
         element={

--- a/src/MobileApp.jsx
+++ b/src/MobileApp.jsx
@@ -1,0 +1,62 @@
+import { useEffect } from 'react'
+import { Navigate, Route, Routes } from 'react-router'
+import { useAuth } from './context/AuthContext'
+import { register } from './lib/serviceWorker'
+import MobileLogin from './components/mobile/MobileLogin'
+import MobileChat from './components/mobile/MobileChat'
+
+function MobileGate({ children }) {
+  const { user, isAuthorized, loading } = useAuth()
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-bg-primary">
+        <div className="text-text-muted">Loading...</div>
+      </div>
+    )
+  }
+
+  if (!user || !isAuthorized) {
+    return <Navigate to="/mobile/login" replace />
+  }
+
+  return children
+}
+
+function MobileSettings() {
+  return (
+    <div className="flex flex-col min-h-screen bg-bg-primary p-4">
+      <h1 className="text-xl font-bold text-text-primary">Settings</h1>
+      <p className="text-sm text-text-muted mt-2">Mobile settings coming soon.</p>
+    </div>
+  )
+}
+
+export default function MobileApp() {
+  useEffect(() => {
+    register({ scope: '/mobile/' })
+  }, [])
+
+  return (
+    <Routes>
+      <Route path="login" element={<MobileLogin />} />
+      <Route
+        path="chat"
+        element={
+          <MobileGate>
+            <MobileChat />
+          </MobileGate>
+        }
+      />
+      <Route
+        path="settings"
+        element={
+          <MobileGate>
+            <MobileSettings />
+          </MobileGate>
+        }
+      />
+      <Route path="*" element={<Navigate to="/mobile/chat" replace />} />
+    </Routes>
+  )
+}

--- a/src/MobileApp.test.jsx
+++ b/src/MobileApp.test.jsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router'
+
+const authState = vi.hoisted(() => ({
+  value: {
+    user: null,
+    isAuthorized: false,
+    loading: false,
+    error: null,
+    signInWithGoogle: vi.fn(),
+  },
+}))
+
+vi.mock('./context/AuthContext', () => ({
+  useAuth: () => authState.value,
+}))
+
+const swRegister = vi.hoisted(() => vi.fn().mockResolvedValue(null))
+
+vi.mock('./lib/serviceWorker', () => ({
+  register: swRegister,
+}))
+
+import MobileApp from './MobileApp'
+
+beforeEach(() => {
+  authState.value = {
+    user: null,
+    isAuthorized: false,
+    loading: false,
+    error: null,
+    signInWithGoogle: vi.fn(),
+  }
+  swRegister.mockClear()
+})
+
+function renderAt(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/mobile/*" element={<MobileApp />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+function asAuthorized() {
+  authState.value = {
+    user: { id: 'u1', email: 'lucas@example.com' },
+    isAuthorized: true,
+    loading: false,
+    error: null,
+    signInWithGoogle: vi.fn(),
+  }
+}
+
+describe('MobileApp', () => {
+  it('redirects unauthenticated users from /mobile/chat to /mobile/login', () => {
+    renderAt('/mobile/chat')
+    expect(
+      screen.getByRole('button', { name: /continue with google/i })
+    ).toBeInTheDocument()
+  })
+
+  it('lets authenticated and authorized users land on /mobile/chat', () => {
+    asAuthorized()
+    renderAt('/mobile/chat')
+    expect(
+      screen.getByRole('button', { name: /new chat/i })
+    ).toBeInTheDocument()
+  })
+
+  it('redirects /mobile (no inner path) to /mobile/chat for authenticated users', () => {
+    asAuthorized()
+    renderAt('/mobile')
+    expect(
+      screen.getByRole('button', { name: /new chat/i })
+    ).toBeInTheDocument()
+  })
+
+  it('redirects /mobile/settings for unauthenticated users to /mobile/login', () => {
+    renderAt('/mobile/settings')
+    expect(
+      screen.getByRole('button', { name: /continue with google/i })
+    ).toBeInTheDocument()
+  })
+
+  it('registers the service worker on mount with /mobile/ scope', () => {
+    renderAt('/mobile/login')
+    expect(swRegister).toHaveBeenCalled()
+    expect(swRegister.mock.calls[0][0]).toEqual({ scope: '/mobile/' })
+  })
+})

--- a/src/components/mobile/MobileChat.jsx
+++ b/src/components/mobile/MobileChat.jsx
@@ -1,0 +1,55 @@
+import { Mic, Plus, Send } from 'lucide-react'
+
+export default function MobileChat() {
+  return (
+    <div className="flex flex-col min-h-screen bg-bg-primary">
+      <header className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+        <div className="flex flex-col leading-tight">
+          <span className="text-[11px] uppercase tracking-wide text-text-muted">agenthub</span>
+          <span className="text-sm font-medium text-text-primary">Auto agent</span>
+        </div>
+        <button
+          type="button"
+          className="flex items-center gap-1 text-sm text-text-primary px-3 py-1.5 rounded-lg hover:bg-white/5"
+        >
+          <Plus size={16} />
+          New chat
+        </button>
+      </header>
+
+      <main className="flex-1 overflow-y-auto px-4 py-6">
+        <div className="text-center text-text-muted text-sm mt-12">
+          Start a conversation
+        </div>
+      </main>
+
+      <div className="sticky bottom-0 border-t border-white/10 bg-bg-primary px-4 py-3">
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            disabled
+            placeholder="Type a message..."
+            aria-label="Message"
+            className="flex-1 bg-white/5 text-text-primary text-sm px-3 py-2 rounded-xl outline-none disabled:opacity-50"
+          />
+          <button
+            type="button"
+            disabled
+            aria-label="Voice input"
+            className="p-2 rounded-xl bg-white/5 text-text-primary disabled:opacity-50"
+          >
+            <Mic size={18} />
+          </button>
+          <button
+            type="button"
+            disabled
+            aria-label="Send message"
+            className="p-2 rounded-xl bg-accent-blue text-white disabled:opacity-50"
+          >
+            <Send size={18} />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mobile/MobileLogin.jsx
+++ b/src/components/mobile/MobileLogin.jsx
@@ -1,0 +1,53 @@
+import { Bot } from 'lucide-react'
+import { Navigate } from 'react-router'
+import { useAuth } from '../../context/AuthContext'
+
+export default function MobileLogin() {
+  const { user, isAuthorized, loading, error, signInWithGoogle } = useAuth()
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-bg-primary">
+        <div className="text-text-muted">Loading...</div>
+      </div>
+    )
+  }
+
+  if (user && isAuthorized) return <Navigate to="/mobile/chat" replace />
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-bg-primary p-4">
+      <div className="w-full max-w-sm mx-auto">
+        <div className="flex flex-col items-center mb-8">
+          <div className="w-14 h-14 rounded-2xl bg-accent-blue flex items-center justify-center mb-4">
+            <Bot size={28} className="text-white" />
+          </div>
+          <h1 className="text-2xl font-bold text-text-primary">Lucas AI Hub</h1>
+          <p className="text-sm text-text-muted mt-1">Sign in to your mobile assistant</p>
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 px-4 py-3 rounded-xl bg-accent-rose/10 border border-accent-rose/30 text-sm text-text-primary"
+          >
+            {error}
+          </div>
+        )}
+
+        <button
+          onClick={signInWithGoogle}
+          className="w-full flex items-center justify-center gap-3 px-4 py-3 rounded-xl bg-white text-gray-800 font-medium text-sm hover:bg-gray-50 transition-colors border border-gray-200 shadow-sm"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z" fill="#4285F4"/>
+            <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z" fill="#34A853"/>
+            <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z" fill="#FBBC05"/>
+            <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 6.29C4.672 4.163 6.656 2.58 9 3.58Z" fill="#EA4335"/>
+          </svg>
+          Continue with Google
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mobile/MobileLogin.test.jsx
+++ b/src/components/mobile/MobileLogin.test.jsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router'
+import MobileLogin from './MobileLogin'
+
+const authState = vi.hoisted(() => ({
+  value: {
+    user: null,
+    isAuthorized: false,
+    loading: false,
+    error: null,
+    signInWithGoogle: vi.fn(),
+  },
+}))
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => authState.value,
+}))
+
+beforeEach(() => {
+  authState.value = {
+    user: null,
+    isAuthorized: false,
+    loading: false,
+    error: null,
+    signInWithGoogle: vi.fn(),
+  }
+})
+
+function renderLogin() {
+  return render(
+    <MemoryRouter initialEntries={['/mobile/login']}>
+      <Routes>
+        <Route path="/mobile/login" element={<MobileLogin />} />
+        <Route path="/mobile/chat" element={<div>Chat home</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('MobileLogin', () => {
+  it('renders the Continue with Google button', () => {
+    renderLogin()
+    expect(
+      screen.getByRole('button', { name: /continue with google/i })
+    ).toBeInTheDocument()
+  })
+
+  it('calls signInWithGoogle when the button is clicked', () => {
+    renderLogin()
+    fireEvent.click(screen.getByRole('button', { name: /continue with google/i }))
+    expect(authState.value.signInWithGoogle).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders an inline error banner when the auth context exposes an error', () => {
+    authState.value = {
+      user: null,
+      isAuthorized: false,
+      loading: false,
+      error: 'This Google account is not authorized.',
+      signInWithGoogle: vi.fn(),
+    }
+    renderLogin()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'This Google account is not authorized.'
+    )
+  })
+
+  it('redirects authenticated and authorized users to /mobile/chat', () => {
+    authState.value = {
+      user: { id: 'u1', email: 'lucas@example.com' },
+      isAuthorized: true,
+      loading: false,
+      error: null,
+      signInWithGoogle: vi.fn(),
+    }
+    renderLogin()
+    expect(screen.getByText('Chat home')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /continue with google/i })
+    ).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #228

## Summary

Adds the mobile shell for the upcoming PWA chat experience:

- **`/mobile/*`** route in `src/App.jsx`, code-split via `React.lazy` + `Suspense` so the mobile bundle stays out of the desktop bundle.
- **`src/MobileApp.jsx`** owns internal routes (`login`, `chat`, `settings`) and the mobile auth gate. Unauthenticated users land on `/mobile/login`; authenticated users default to `/mobile/chat`. Service worker is registered with scope `/mobile/` only when MobileApp mounts — never on desktop routes.
- **`src/components/mobile/MobileLogin.jsx`** — single "Sign in with Google" button via `useAuth().signInWithGoogle`, surfaces auth context errors inline (e.g. unauthorized email).
- **`src/components/mobile/MobileChat.jsx`** — skeleton layout: header with repo/agent indicator + "+ New chat", scrollable empty message area, bottom-fixed ChatBar (input + mic + send, all disabled stubs). The real chat wiring lands in slice 4.
- **`src/components/AiAssistant.jsx`** and its test are byte-identical (zero modifications) per the AC.

## TDD

- **Tests added**: `src/components/mobile/MobileLogin.test.jsx`, `src/MobileApp.test.jsx`
- **Before implementation (red)**: both files failed at module-resolution (`Failed to resolve import "./MobileLogin"` / `"./MobileApp"`) — Vitest reported `2 failed, no tests` because the source modules did not exist yet.
- **After implementation (green)**: 9/9 new tests pass. Full suite: **221/221 tests across 26 files** still pass via ``npm test``. ``npm run lint`` reports 0 errors (only pre-existing warnings in unrelated files).

### What the new tests cover

- `MobileLogin` — button renders, click invokes `signInWithGoogle`, error banner renders when auth context exposes an error, authenticated users are redirected to `/mobile/chat`.
- `MobileApp` — unauthenticated `/mobile/chat` and `/mobile/settings` redirect to `/mobile/login`; authenticated users land on `/mobile/chat`; the bare `/mobile` path redirects to `/mobile/chat`; the service worker is registered on mount with `{ scope: '/mobile/' }`.

## Notes

- Existing desktop E2E tests (`e2e/*.spec.js`) are unaffected — the new `/mobile/*` route is added before the catch-all `/*` route, and the existing routes/component tree are untouched.
- The branch carries multiple ``auto: update ...`` commits from the local auto-commit hook; squash-merge will collapse them into a single commit on `dev` with this PR title.