### PR TITLE
feat(mobile): MobileChat end-to-end with voice + agent picker + approval gate (#230)

### DIFF
--- a/src/components/mobile/MobileAgentPicker.jsx
+++ b/src/components/mobile/MobileAgentPicker.jsx
@@ -1,0 +1,83 @@
+import { useEffect, useMemo } from 'react'
+import { X } from 'lucide-react'
+
+export default function MobileAgentPicker({ open, agents, selectedAgentId, onSelect, onClose }) {
+  const sorted = useMemo(() => {
+    if (!Array.isArray(agents)) return []
+    return [...agents].sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+  }, [agents])
+
+  useEffect(() => {
+    if (!open) return
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') onClose?.()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col justify-end">
+      <button
+        type="button"
+        aria-label="Close picker"
+        className="absolute inset-0 bg-black/60"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-label="Pick an agent"
+        aria-modal="true"
+        className="relative bg-bg-sidebar rounded-t-2xl border-t border-white/10 max-h-[75vh] flex flex-col"
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+          <h2 className="text-sm font-semibold text-text-primary">Pick an agent</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded-lg hover:bg-white/5 text-text-muted"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="overflow-y-auto py-1">
+          <button
+            type="button"
+            onClick={() => {
+              onSelect?.(null)
+              onClose?.()
+            }}
+            className={`w-full text-left px-4 py-3 hover:bg-white/5 ${
+              selectedAgentId == null ? 'text-text-primary' : 'text-text-secondary'
+            }`}
+          >
+            <div className="text-sm font-medium">Auto</div>
+            <div className="text-xs text-text-muted">Let the router pick the best path</div>
+          </button>
+          {sorted.length > 0 && <div className="border-t border-white/10 mx-4" />}
+          {sorted.map((agent) => (
+            <button
+              key={agent.id}
+              type="button"
+              onClick={() => {
+                onSelect?.(agent.id)
+                onClose?.()
+              }}
+              className={`w-full text-left px-4 py-3 hover:bg-white/5 ${
+                selectedAgentId === agent.id ? 'text-text-primary' : 'text-text-secondary'
+              }`}
+            >
+              <div className="text-sm font-medium truncate">{agent.name}</div>
+              {agent.category && (
+                <div className="text-xs text-text-muted truncate">{agent.category}</div>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mobile/MobileApprovalCard.jsx
+++ b/src/components/mobile/MobileApprovalCard.jsx
@@ -1,0 +1,52 @@
+import { ShieldAlert } from 'lucide-react'
+
+export default function MobileApprovalCard({ name, input, onApprove, onReject, status = 'pending' }) {
+  const inputPreview = input ? JSON.stringify(input, null, 2) : ''
+  const isApproved = status === 'approved'
+  const isRejected = status === 'rejected'
+
+  const handleApprove = () => {
+    if (status !== 'pending') return
+    onApprove?.()
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      try {
+        navigator.vibrate(20)
+      } catch {
+        // vibration is best-effort, ignore failures (e.g. policy block)
+      }
+    }
+  }
+
+  return (
+    <div className="mt-2 rounded-xl border border-amber-500/40 bg-amber-500/10 p-3 text-text-primary">
+      <div className="flex items-center gap-2 text-amber-300 text-xs font-semibold uppercase tracking-wide">
+        <ShieldAlert size={14} />
+        <span>Approval required</span>
+      </div>
+      <div className="mt-2 text-sm font-mono text-text-primary truncate">{name}</div>
+      {inputPreview && (
+        <pre className="mt-2 max-h-32 overflow-auto rounded-md bg-black/30 p-2 text-[11px] text-text-secondary whitespace-pre-wrap break-words">
+          {inputPreview}
+        </pre>
+      )}
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={handleApprove}
+          disabled={status !== 'pending'}
+          className="flex-1 px-3 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isApproved ? 'Approved' : 'Approve'}
+        </button>
+        <button
+          type="button"
+          onClick={() => status === 'pending' && onReject?.()}
+          disabled={status !== 'pending'}
+          className="px-3 py-2 rounded-lg bg-white/10 text-text-primary text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isRejected ? 'Rejected' : 'Reject'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mobile/MobileChat.jsx
+++ b/src/components/mobile/MobileChat.jsx
@@ -10,7 +10,10 @@ import MobilePlanCard from './MobilePlanCard'
 const INITIAL_MESSAGES = []
 
 export default function MobileChat() {
-  const { agents, tools, bumpAgentUsage } = useData()
+  const data = useData() || {}
+  const agents = data.agents || []
+  const tools = data.tools || []
+  const bumpAgentUsage = data.bumpAgentUsage
   const [messages, setMessages] = useState(INITIAL_MESSAGES)
   const [input, setInput] = useState('')
   const [isStreaming, setIsStreaming] = useState(false)

--- a/src/components/mobile/MobileChat.jsx
+++ b/src/components/mobile/MobileChat.jsx
@@ -1,15 +1,339 @@
-import { Mic, Plus, Send } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Bot, Loader2, Mic, Plus, Send, Square } from 'lucide-react'
+import { useData } from '../../context/DataContext'
+import { isOrchestrationConfigured, startSession } from '../../lib/orchestration'
+import { startRecognition } from '../../lib/voice'
+import MobileAgentPicker from './MobileAgentPicker'
+import MobileApprovalCard from './MobileApprovalCard'
+import MobilePlanCard from './MobilePlanCard'
+
+const INITIAL_MESSAGES = []
 
 export default function MobileChat() {
+  const { agents, tools, bumpAgentUsage } = useData()
+  const [messages, setMessages] = useState(INITIAL_MESSAGES)
+  const [input, setInput] = useState('')
+  const [isStreaming, setIsStreaming] = useState(false)
+  const [selectedAgentId, setSelectedAgentId] = useState(null)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [listening, setListening] = useState(false)
+  const [toast, setToast] = useState(null)
+  const sessionRef = useRef(null)
+  const recognitionRef = useRef(null)
+  const listRef = useRef(null)
+
+  useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight
+  }, [messages, isStreaming])
+
+  useEffect(() => {
+    return () => {
+      sessionRef.current?.session?.cancel('unmount')
+      recognitionRef.current?.stop?.()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!toast) return
+    const handle = setTimeout(() => setToast(null), 4000)
+    return () => clearTimeout(handle)
+  }, [toast])
+
+  const patchMessageAt = (index, patch) => {
+    setMessages((prev) => {
+      if (index < 0 || index >= prev.length) return prev
+      const target = prev[index]
+      if (!target || target.role !== 'assistant') return prev
+      const next = [...prev]
+      next[index] = typeof patch === 'function' ? patch(target) : { ...target, ...patch }
+      return next
+    })
+  }
+
+  const appendDelta = (index, delta) => {
+    patchMessageAt(index, (msg) => ({ ...msg, content: (msg.content || '') + delta }))
+  }
+
+  const showErrorAt = (index, message) => {
+    setMessages((prev) => {
+      if (index < 0 || index >= prev.length) return prev
+      const target = prev[index]
+      if (!target || target.role !== 'assistant') return prev
+      const next = [...prev]
+      if (!target.content) {
+        next[index] = { role: 'assistant', content: `⚠️ ${message}`, error: true }
+      } else {
+        next[index] = { ...target }
+        next.push({ role: 'assistant', content: `⚠️ ${message}`, error: true })
+      }
+      return next
+    })
+  }
+
+  const subscribeSession = useCallback((session, messageIdx) => {
+    const unsubscribe = session.subscribe((event) => {
+      switch (event.type) {
+        case 'router.classified':
+          break
+        case 'chat.text':
+          appendDelta(messageIdx, event.value)
+          break
+        case 'chat.tool_call':
+          patchMessageAt(messageIdx, (msg) => {
+            if (event.requires_approval) {
+              return {
+                ...msg,
+                approval: {
+                  name: event.name,
+                  input: event.input,
+                  toolCallId: event.tool_call_id,
+                  status: 'pending',
+                  session,
+                },
+              }
+            }
+            return {
+              ...msg,
+              toolCall: { name: event.name, input: event.input },
+            }
+          })
+          break
+        case 'chat.tool_call_start':
+          patchMessageAt(messageIdx, (msg) => ({
+            ...msg,
+            agentToolCalls: [
+              ...(msg.agentToolCalls || []),
+              {
+                id: event.tool_call_id,
+                name: event.name,
+                input: event.input,
+                status: 'running',
+              },
+            ],
+          }))
+          break
+        case 'chat.tool_call_done':
+          patchMessageAt(messageIdx, (msg) => {
+            const list = msg.agentToolCalls || []
+            const next = list.map((tc) =>
+              tc.id === event.tool_call_id
+                ? {
+                    ...tc,
+                    status: event.status || 'done',
+                    summary: event.summary,
+                    error: event.error,
+                  }
+                : tc,
+            )
+            return { ...msg, agentToolCalls: next }
+          })
+          break
+        case 'chat.done':
+          setIsStreaming(false)
+          sessionRef.current = null
+          unsubscribe()
+          break
+        case 'chat.error':
+          showErrorAt(messageIdx, event.error || 'stream error')
+          setIsStreaming(false)
+          sessionRef.current = null
+          unsubscribe()
+          break
+        case 'plan.proposing':
+          patchMessageAt(messageIdx, { planStatus: 'proposing' })
+          break
+        case 'plan.proposed':
+          patchMessageAt(messageIdx, {
+            plan: event.plan,
+            planStatus: 'proposed',
+          })
+          setIsStreaming(false)
+          sessionRef.current = null
+          unsubscribe()
+          break
+        case 'plan.error':
+          showErrorAt(messageIdx, event.error || 'planner error')
+          setIsStreaming(false)
+          sessionRef.current = null
+          unsubscribe()
+          break
+        case 'run.started':
+          patchMessageAt(messageIdx, { planStatus: 'executing' })
+          break
+        case 'run.done':
+          patchMessageAt(messageIdx, { planStatus: 'done' })
+          setIsStreaming(false)
+          sessionRef.current = null
+          unsubscribe()
+          break
+        case 'run.error':
+          patchMessageAt(messageIdx, { planStatus: 'error', runError: event.error })
+          setIsStreaming(false)
+          sessionRef.current = null
+          unsubscribe()
+          break
+        default:
+          break
+      }
+    })
+    return unsubscribe
+  }, [])
+
+  const buildOutgoing = (allMessages) =>
+    allMessages
+      .filter((m) => !m.error)
+      .map((m) => ({ role: m.role, content: m.content }))
+      .filter((m) => m.content && m.content.trim())
+
+  const handleSend = (e) => {
+    e?.preventDefault?.()
+    const text = input.trim()
+    if (!text || isStreaming) return
+
+    if (!isOrchestrationConfigured()) {
+      setMessages((prev) => [
+        ...prev,
+        { role: 'user', content: text },
+        {
+          role: 'assistant',
+          content: 'Chat is not configured. Set Supabase env vars and deploy the chat function.',
+          error: true,
+        },
+      ])
+      setInput('')
+      return
+    }
+
+    const userMessage = { role: 'user', content: text }
+    const nextMessages = [...messages, userMessage]
+    const outgoing = buildOutgoing(nextMessages)
+    const assistantMessage = {
+      role: 'assistant',
+      content: '',
+      originalTask: text,
+      outgoingSnapshot: outgoing,
+    }
+    const withAssistant = [...nextMessages, assistantMessage]
+    const assistantIdx = withAssistant.length - 1
+
+    setMessages(withAssistant)
+    setInput('')
+    setIsStreaming(true)
+
+    if (selectedAgentId) {
+      bumpAgentUsage?.(selectedAgentId, 'orchestrator_invoke')
+    }
+
+    const session = startSession({
+      mode: 'chat',
+      messages: outgoing,
+      agents,
+      tools,
+      selectedAgentId,
+    })
+    sessionRef.current = { session, messageIdx: assistantIdx }
+    subscribeSession(session, assistantIdx)
+  }
+
+  const handleApproveTool = (messageIdx) => {
+    const msg = messages[messageIdx]
+    const approval = msg?.approval
+    if (!approval || approval.status !== 'pending') return
+    approval.session?.approve?.(approval.toolCallId)
+    patchMessageAt(messageIdx, (m) => ({
+      ...m,
+      approval: { ...m.approval, status: 'approved' },
+    }))
+  }
+
+  const handleRejectTool = (messageIdx) => {
+    const msg = messages[messageIdx]
+    const approval = msg?.approval
+    if (!approval || approval.status !== 'pending') return
+    approval.session?.reject?.(approval.toolCallId)
+    patchMessageAt(messageIdx, (m) => ({
+      ...m,
+      approval: { ...m.approval, status: 'rejected' },
+    }))
+  }
+
+  const handleNewChat = () => {
+    sessionRef.current?.session?.cancel('new-chat')
+    sessionRef.current = null
+    setIsStreaming(false)
+    setMessages(INITIAL_MESSAGES)
+    setInput('')
+  }
+
+  const stopVoice = () => {
+    recognitionRef.current?.stop?.()
+    recognitionRef.current = null
+    setListening(false)
+  }
+
+  const startVoice = () => {
+    if (listening) {
+      stopVoice()
+      return
+    }
+    let finalText = ''
+    setListening(true)
+    const handle = startRecognition({
+      lang: 'pt-BR',
+      onResult: ({ transcript, isFinal }) => {
+        if (isFinal) {
+          finalText = transcript
+        }
+      },
+      onError: (err) => {
+        if (err?.code === 'not-allowed' || err?.code === 'service-not-allowed') {
+          setToast({
+            kind: 'error',
+            text: 'Microphone permission denied. Open iOS Settings → Safari → Microphone to allow it.',
+          })
+        } else if (err?.code === 'unsupported') {
+          setToast({
+            kind: 'error',
+            text: 'Voice input is not supported on this browser.',
+          })
+        } else if (err?.code) {
+          setToast({ kind: 'error', text: `Voice error: ${err.code}` })
+        }
+      },
+      onEnd: () => {
+        recognitionRef.current = null
+        setListening(false)
+        if (finalText) {
+          setInput((prev) => (prev ? `${prev}${finalText}` : finalText))
+        }
+      },
+    })
+    recognitionRef.current = handle
+  }
+
+  const selectedAgent =
+    selectedAgentId && Array.isArray(agents)
+      ? agents.find((a) => a.id === selectedAgentId)
+      : null
+
   return (
     <div className="flex flex-col min-h-screen bg-bg-primary">
       <header className="flex items-center justify-between px-4 py-3 border-b border-white/10">
-        <div className="flex flex-col leading-tight">
-          <span className="text-[11px] uppercase tracking-wide text-text-muted">agenthub</span>
-          <span className="text-sm font-medium text-text-primary">Auto agent</span>
-        </div>
         <button
           type="button"
+          aria-label="Select agent"
+          onClick={() => setPickerOpen(true)}
+          className="flex flex-col items-start leading-tight text-left"
+        >
+          <span className="text-[11px] uppercase tracking-wide text-text-muted">agenthub</span>
+          <span className="flex items-center gap-1 text-sm font-medium text-text-primary">
+            <Bot size={14} />
+            {selectedAgent ? selectedAgent.name : 'Auto agent'}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={handleNewChat}
           className="flex items-center gap-1 text-sm text-text-primary px-3 py-1.5 rounded-lg hover:bg-white/5"
         >
           <Plus size={16} />
@@ -17,39 +341,156 @@ export default function MobileChat() {
         </button>
       </header>
 
-      <main className="flex-1 overflow-y-auto px-4 py-6">
-        <div className="text-center text-text-muted text-sm mt-12">
-          Start a conversation
-        </div>
+      <main ref={listRef} className="flex-1 overflow-y-auto px-4 py-6">
+        {messages.length === 0 ? (
+          <div className="text-center text-text-muted text-sm mt-12">
+            Start a conversation
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {messages.map((msg, i) => (
+              <li
+                key={i}
+                className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm leading-relaxed ${
+                    msg.role === 'user'
+                      ? 'bg-accent-blue text-white whitespace-pre-wrap'
+                      : msg.error
+                        ? 'bg-rose-500/10 border border-rose-500/30 text-rose-300 whitespace-pre-wrap'
+                        : 'bg-white/5 border border-white/10 text-text-primary'
+                  }`}
+                >
+                  {msg.content && <div className="whitespace-pre-wrap">{msg.content}</div>}
+                  {msg.toolCall && (
+                    <div className="mt-2 text-xs font-mono text-text-secondary">
+                      {msg.toolCall.name}
+                    </div>
+                  )}
+                  {msg.approval && (
+                    <MobileApprovalCard
+                      name={msg.approval.name}
+                      input={msg.approval.input}
+                      status={msg.approval.status}
+                      onApprove={() => handleApproveTool(i)}
+                      onReject={() => handleRejectTool(i)}
+                    />
+                  )}
+                  {msg.plan && (
+                    <MobilePlanCard
+                      plan={msg.plan}
+                      status={msg.planStatus || 'proposed'}
+                      onApprove={() => {
+                        // Plan approval kicks off an execute session; this is a
+                        // mobile-friendly pass-through that mirrors the desktop
+                        // behavior without the requirements panel.
+                        const target = messages[i]
+                        if (!target?.plan || isStreaming) return
+                        patchMessageAt(i, { planStatus: 'executing' })
+                        setIsStreaming(true)
+                        const next = startSession({
+                          mode: 'execute',
+                          messages: target.outgoingSnapshot || [],
+                          agents,
+                          tools,
+                          plan: target.plan,
+                          originalTask: target.originalTask || '',
+                        })
+                        sessionRef.current = { session: next, messageIdx: i }
+                        subscribeSession(next, i)
+                      }}
+                      onCancel={() => patchMessageAt(i, { planStatus: 'cancelled' })}
+                    />
+                  )}
+                  {Array.isArray(msg.agentToolCalls) && msg.agentToolCalls.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {msg.agentToolCalls.map((tc) => (
+                        <span
+                          key={tc.id}
+                          className="text-[11px] px-2 py-0.5 rounded bg-black/30 text-text-secondary font-mono"
+                          title={tc.summary || tc.error || ''}
+                        >
+                          {tc.name}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </li>
+            ))}
+            {isStreaming &&
+              messages[messages.length - 1]?.role === 'assistant' &&
+              !messages[messages.length - 1]?.content &&
+              !messages[messages.length - 1]?.toolCall &&
+              !messages[messages.length - 1]?.plan && (
+                <li className="flex items-center gap-2 text-text-muted text-xs">
+                  <Loader2 size={12} className="animate-spin" />
+                  <span>Thinking…</span>
+                </li>
+              )}
+          </ul>
+        )}
       </main>
 
-      <div className="sticky bottom-0 border-t border-white/10 bg-bg-primary px-4 py-3">
+      {listening && (
+        <div className="px-4 pb-2 flex items-center gap-2 text-xs text-text-muted">
+          <span className="h-2 w-2 rounded-full bg-rose-400 animate-pulse" />
+          <span>Listening…</span>
+        </div>
+      )}
+
+      {toast && (
+        <div
+          role="alert"
+          className="mx-4 mb-2 rounded-lg bg-rose-500/15 border border-rose-500/30 text-rose-300 text-xs px-3 py-2"
+        >
+          {toast.text}
+        </div>
+      )}
+
+      <form
+        onSubmit={handleSend}
+        className="sticky bottom-0 border-t border-white/10 bg-bg-primary px-4 py-3"
+      >
         <div className="flex items-center gap-2">
           <input
             type="text"
-            disabled
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
             placeholder="Type a message..."
             aria-label="Message"
+            disabled={isStreaming}
             className="flex-1 bg-white/5 text-text-primary text-sm px-3 py-2 rounded-xl outline-none disabled:opacity-50"
           />
           <button
             type="button"
-            disabled
-            aria-label="Voice input"
-            className="p-2 rounded-xl bg-white/5 text-text-primary disabled:opacity-50"
+            onClick={startVoice}
+            aria-label={listening ? 'Stop voice input' : 'Voice input'}
+            className={`p-2 rounded-xl text-white ${
+              listening ? 'bg-rose-500 animate-pulse' : 'bg-white/10 text-text-primary'
+            }`}
           >
-            <Mic size={18} />
+            {listening ? <Square size={18} /> : <Mic size={18} />}
           </button>
           <button
-            type="button"
-            disabled
+            type="submit"
+            disabled={!input.trim() || isStreaming}
             aria-label="Send message"
             className="p-2 rounded-xl bg-accent-blue text-white disabled:opacity-50"
           >
-            <Send size={18} />
+            {isStreaming ? <Loader2 size={18} className="animate-spin" /> : <Send size={18} />}
           </button>
         </div>
-      </div>
+      </form>
+
+      <MobileAgentPicker
+        open={pickerOpen}
+        agents={agents}
+        selectedAgentId={selectedAgentId}
+        onSelect={setSelectedAgentId}
+        onClose={() => setPickerOpen(false)}
+      />
     </div>
   )
 }

--- a/src/components/mobile/MobileChat.jsx
+++ b/src/components/mobile/MobileChat.jsx
@@ -180,6 +180,7 @@ export default function MobileChat() {
       }
     })
     return unsubscribe
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const buildOutgoing = (allMessages) =>

--- a/src/components/mobile/MobileChat.test.jsx
+++ b/src/components/mobile/MobileChat.test.jsx
@@ -171,16 +171,6 @@ describe('MobileChat', () => {
   })
 
   it('renders an approval card when chat.tool_call has requires_approval and approve dispatches', async () => {
-    scriptSession([
-      {
-        type: 'chat.tool_call',
-        name: 'create_github_issue',
-        input: { repo: 'lucasfe/agenthub', title: 'Test', body: 'body' },
-        requires_approval: true,
-        tool_call_id: 'tu-approval-1',
-      },
-    ])
-
     const onApprove = vi.fn()
     orchestrationMock.startSession.mockImplementationOnce(() => {
       const session = orchestrationMock._createFakeSession([

--- a/src/components/mobile/MobileChat.test.jsx
+++ b/src/components/mobile/MobileChat.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileChat from './MobileChat'
 import { renderWithProviders } from '../../test/test-utils'

--- a/src/components/mobile/MobileChat.test.jsx
+++ b/src/components/mobile/MobileChat.test.jsx
@@ -142,8 +142,10 @@ describe('MobileChat', () => {
     expect(screen.getByText(/Listening/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Stop voice input/i)).toBeInTheDocument()
 
-    callbacks.onResult({ transcript: 'world', isFinal: true })
-    callbacks.onEnd?.()
+    act(() => {
+      callbacks.onResult({ transcript: 'world', isFinal: true })
+      callbacks.onEnd?.()
+    })
 
     await waitFor(() => {
       expect(input.value).toBe('hello world')

--- a/src/components/mobile/MobileChat.test.jsx
+++ b/src/components/mobile/MobileChat.test.jsx
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobileChat from './MobileChat'
+import { renderWithProviders } from '../../test/test-utils'
+
+vi.mock('../../lib/api', () => ({
+  fetchAgents: vi.fn().mockResolvedValue([
+    {
+      id: 'frontend-developer',
+      name: 'Frontend Developer',
+      category: 'Development Team',
+      description: 'Expert in React',
+      tags: ['React', 'CSS'],
+      icon: 'Monitor',
+      color: 'blue',
+    },
+    {
+      id: 'backend-developer',
+      name: 'Backend Developer',
+      category: 'Development Team',
+      description: 'APIs & DB',
+      tags: ['API'],
+      icon: 'Server',
+      color: 'green',
+    },
+  ]),
+  fetchTeams: vi.fn().mockResolvedValue([]),
+  fetchTools: vi.fn().mockResolvedValue([]),
+  createAgent: vi.fn().mockResolvedValue({ id: 'mock' }),
+  updateAgent: vi.fn().mockResolvedValue({ id: 'frontend-developer' }),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
+}))
+
+const orchestrationMock = vi.hoisted(() => {
+  const createFakeSession = (events) => {
+    let cancelled = false
+    const session = {
+      id: 'test-session',
+      mode: 'chat',
+      status: 'streaming',
+      subscribe: (fn) => {
+        queueMicrotask(() => {
+          for (const evt of events) {
+            if (cancelled) break
+            fn(evt)
+          }
+        })
+        return () => {}
+      },
+      cancel: vi.fn(() => {
+        cancelled = true
+      }),
+    }
+    return session
+  }
+
+  return {
+    isOrchestrationConfigured: vi.fn(() => true),
+    startSession: vi.fn(),
+    _createFakeSession: createFakeSession,
+  }
+})
+
+vi.mock('../../lib/orchestration', () => orchestrationMock)
+
+const voiceMock = vi.hoisted(() => ({
+  isSupported: vi.fn(() => true),
+  startRecognition: vi.fn(),
+  stopRecognition: vi.fn(),
+}))
+
+vi.mock('../../lib/voice', () => voiceMock)
+
+function scriptSession(events) {
+  orchestrationMock.startSession.mockImplementationOnce(() =>
+    orchestrationMock._createFakeSession(events),
+  )
+}
+
+describe('MobileChat', () => {
+  beforeEach(() => {
+    orchestrationMock.isOrchestrationConfigured.mockReturnValue(true)
+    orchestrationMock.startSession.mockReset()
+    voiceMock.isSupported.mockReset().mockReturnValue(true)
+    voiceMock.startRecognition.mockReset()
+    voiceMock.stopRecognition.mockReset()
+  })
+
+  it('renders empty state, header, and input controls', () => {
+    renderWithProviders(<MobileChat />)
+    expect(screen.getByText(/Start a conversation/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/Type a message/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Voice input/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Send message/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /New chat/i })).toBeInTheDocument()
+  })
+
+  it('sends a text message and renders streaming assistant reply', async () => {
+    scriptSession([
+      { type: 'chat.text', value: 'Hello' },
+      { type: 'chat.text', value: ' world' },
+      { type: 'chat.done' },
+    ])
+
+    const user = userEvent.setup()
+    renderWithProviders(<MobileChat />)
+
+    const input = screen.getByPlaceholderText(/Type a message/i)
+    await user.type(input, 'oi')
+    await user.click(screen.getByLabelText(/Send message/i))
+
+    expect(screen.getByText('oi')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello world')).toBeInTheDocument()
+    })
+
+    expect(orchestrationMock.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'chat',
+        messages: [{ role: 'user', content: 'oi' }],
+      }),
+    )
+  })
+
+  it('mic FAB starts speech recognition and appends transcript to input', async () => {
+    let callbacks = null
+    voiceMock.startRecognition.mockImplementation((opts) => {
+      callbacks = opts
+      return { stop: vi.fn() }
+    })
+
+    const user = userEvent.setup()
+    renderWithProviders(<MobileChat />)
+
+    const input = screen.getByPlaceholderText(/Type a message/i)
+    await user.type(input, 'hello ')
+
+    await user.click(screen.getByLabelText(/Voice input/i))
+    expect(voiceMock.startRecognition).toHaveBeenCalledTimes(1)
+    expect(screen.getByText(/Listening/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Stop voice input/i)).toBeInTheDocument()
+
+    callbacks.onResult({ transcript: 'world', isFinal: true })
+    callbacks.onEnd?.()
+
+    await waitFor(() => {
+      expect(input.value).toBe('hello world')
+    })
+    expect(screen.queryByText(/Listening/i)).not.toBeInTheDocument()
+  })
+
+  it('shows toast when speech recognition reports not-allowed (permission denied)', async () => {
+    let callbacks = null
+    voiceMock.startRecognition.mockImplementation((opts) => {
+      callbacks = opts
+      return { stop: vi.fn() }
+    })
+
+    const user = userEvent.setup()
+    renderWithProviders(<MobileChat />)
+
+    await user.click(screen.getByLabelText(/Voice input/i))
+    callbacks.onError({ code: 'not-allowed', message: 'denied' })
+    callbacks.onEnd?.()
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Microphone/i)
+    })
+  })
+
+  it('renders an approval card when chat.tool_call has requires_approval and approve dispatches', async () => {
+    scriptSession([
+      {
+        type: 'chat.tool_call',
+        name: 'create_github_issue',
+        input: { repo: 'lucasfe/agenthub', title: 'Test', body: 'body' },
+        requires_approval: true,
+        tool_call_id: 'tu-approval-1',
+      },
+    ])
+
+    const onApprove = vi.fn()
+    orchestrationMock.startSession.mockImplementationOnce(() => {
+      const session = orchestrationMock._createFakeSession([
+        {
+          type: 'chat.tool_call',
+          name: 'create_github_issue',
+          input: { repo: 'lucasfe/agenthub', title: 'Test', body: 'body' },
+          requires_approval: true,
+          tool_call_id: 'tu-approval-1',
+        },
+      ])
+      session.approve = onApprove
+      return session
+    })
+
+    const user = userEvent.setup()
+    renderWithProviders(<MobileChat />)
+
+    await user.type(screen.getByPlaceholderText(/Type a message/i), 'open issue')
+    await user.click(screen.getByLabelText(/Send message/i))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Approval required/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/create_github_issue/i)).toBeInTheDocument()
+    const approveBtn = screen.getByRole('button', { name: /Approve/i })
+    await user.click(approveBtn)
+    expect(onApprove).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a plan summary card when plan.proposed arrives', async () => {
+    scriptSession([
+      {
+        type: 'plan.proposed',
+        plan: {
+          id: 'plan-1',
+          steps: [
+            { id: 1, agent_id: 'frontend-developer', agent_name: 'Frontend Developer', task: 'Build UI' },
+            { id: 2, agent_id: 'backend-developer', agent_name: 'Backend Developer', task: 'Add API' },
+          ],
+        },
+      },
+    ])
+
+    const user = userEvent.setup()
+    renderWithProviders(<MobileChat />)
+
+    await user.type(screen.getByPlaceholderText(/Type a message/i), 'plan something')
+    await user.click(screen.getByLabelText(/Send message/i))
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 steps/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument()
+    expect(screen.getByText('Backend Developer')).toBeInTheDocument()
+  })
+
+  it('agent picker bottom sheet selects an agent and forwards selectedAgentId to startSession', async () => {
+    scriptSession([
+      { type: 'chat.text', value: 'hello' },
+      { type: 'chat.done' },
+    ])
+
+    const user = userEvent.setup()
+    renderWithProviders(<MobileChat />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Select agent/i)).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText(/Select agent/i))
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: /Pick an agent/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Frontend Developer/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: /Pick an agent/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    await user.type(screen.getByPlaceholderText(/Type a message/i), 'oi')
+    await user.click(screen.getByLabelText(/Send message/i))
+
+    await waitFor(() => {
+      expect(orchestrationMock.startSession).toHaveBeenCalled()
+    })
+    const call = orchestrationMock.startSession.mock.calls[0][0]
+    expect(call.selectedAgentId).toBe('frontend-developer')
+  })
+
+  it('New chat resets messages and cancels active session', async () => {
+    scriptSession([
+      { type: 'chat.text', value: 'partial' },
+    ])
+
+    const user = userEvent.setup()
+    renderWithProviders(<MobileChat />)
+
+    await user.type(screen.getByPlaceholderText(/Type a message/i), 'first message')
+    await user.click(screen.getByLabelText(/Send message/i))
+
+    await waitFor(() => {
+      expect(screen.getByText('first message')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /New chat/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('first message')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText(/Start a conversation/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/mobile/MobileChat.test.jsx
+++ b/src/components/mobile/MobileChat.test.jsx
@@ -164,8 +164,10 @@ describe('MobileChat', () => {
     renderWithProviders(<MobileChat />)
 
     await user.click(screen.getByLabelText(/Voice input/i))
-    callbacks.onError({ code: 'not-allowed', message: 'denied' })
-    callbacks.onEnd?.()
+    act(() => {
+      callbacks.onError({ code: 'not-allowed', message: 'denied' })
+      callbacks.onEnd?.()
+    })
 
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent(/Microphone/i)

--- a/src/components/mobile/MobilePlanCard.jsx
+++ b/src/components/mobile/MobilePlanCard.jsx
@@ -1,0 +1,70 @@
+// Compact plan summary tailored for the mobile chat. Renders the proposed
+// steps and exposes Approve/Cancel buttons. Mirrors the desktop PlanCard but
+// drops layout that does not fit the narrow viewport.
+
+import { Loader2 } from 'lucide-react'
+
+export default function MobilePlanCard({ plan, status = 'proposed', onApprove, onCancel }) {
+  const steps = Array.isArray(plan?.steps) ? plan.steps : []
+  const stepCount = steps.length
+  const isProposed = status === 'proposed'
+  const isExecuting = status === 'executing'
+  const isDone = status === 'done'
+  const isError = status === 'error'
+
+  return (
+    <div className="mt-2 rounded-xl border border-white/10 bg-white/5 p-3">
+      <div className="flex items-center justify-between">
+        <div className="text-xs uppercase tracking-wide text-text-muted">Plan</div>
+        <div className="text-xs text-text-muted">
+          {stepCount} {stepCount === 1 ? 'step' : 'steps'}
+        </div>
+      </div>
+      <ol className="mt-2 space-y-2">
+        {steps.map((step, idx) => (
+          <li
+            key={step.id ?? idx}
+            className="rounded-lg border border-white/10 bg-black/20 px-3 py-2"
+          >
+            <div className="text-sm text-text-primary truncate">
+              {step.agent_name || step.agent_id}
+            </div>
+            {step.task && (
+              <div className="text-xs text-text-secondary mt-0.5 line-clamp-2">{step.task}</div>
+            )}
+          </li>
+        ))}
+      </ol>
+      {isProposed && (
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            onClick={onApprove}
+            className="flex-1 px-3 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium"
+          >
+            Approve
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-2 rounded-lg bg-white/10 text-text-primary text-sm"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+      {isExecuting && (
+        <div className="mt-3 flex items-center gap-2 text-xs text-text-muted">
+          <Loader2 size={12} className="animate-spin" />
+          <span>Executing…</span>
+        </div>
+      )}
+      {isDone && (
+        <div className="mt-3 text-xs text-emerald-400">Done</div>
+      )}
+      {isError && (
+        <div className="mt-3 text-xs text-rose-400">Error</div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #230

## Summary

Wires the mobile chat surface to the orchestration engine end-to-end:

- Text input + voice mic FAB with transcript appended (not overwritten) on natural end / stop
- Streams `chat.text`, renders `chat.tool_call`, `plan.proposed`, run progress
- New `MobileAgentPicker.jsx` bottom sheet for selecting an agent
- New `MobileApprovalCard.jsx` rendered inline when a `chat.tool_call` carries `requires_approval: true`; tap-to-approve calls the session's approve handler with optional Vibration API haptic feedback
- New `MobilePlanCard.jsx` compact summary (forked from the desktop `PlanCard` because the desktop layout does not collapse to a phone viewport)
- `New chat` resets messages and cancels the active session
- Permission-denied path surfaces a toast pointing to iOS Settings → Safari → Microphone

## TDD

- Tests added: `src/components/mobile/MobileChat.test.jsx` (8 tests covering empty state, send/stream, mic flow, permission-denied toast, approval card render+approve, plan card render, agent picker selection, New chat reset)
- Before implementation (red): all 7 new behavior tests failed against the placeholder skeleton (only the empty-state assertion passed)
- After implementation (green): all 229 tests pass via `npm test`

## Notes

- `src/components/AiAssistant.jsx` and `src/components/AiAssistant.test.jsx` are unchanged
- `src/lib/orchestration/engine.js` and `src/lib/orchestration/stream.js` are unchanged (100% reuse)
- `MobileChat` defaults to empty agents/tools when `DataContext` is absent so `MobileApp.test.jsx` (which renders `MobileApp` without a `DataProvider`) keeps working
- Plan card was forked rather than reused: the desktop `PlanCard` depends on `planParts` helpers and wide layout assumptions that do not fit a 375px viewport