### PR TITLE
docs(ralph): document ralph schedule install/heartbeat in README + CHANGELOG

### DIFF
--- a/packages/ralph/CHANGELOG.md
+++ b/packages/ralph/CHANGELOG.md
@@ -106,6 +106,24 @@ and shipped across slices #14–#23.
   `ralph-notify.sh`, `PROMPT.md` (without the flag), and
   `ralph.config.sh` are guaranteed untouched on re-run, so a future
   template-management refactor cannot silently overwrite credentials.
+- `ralph schedule install / remove / pause / resume / status`:
+  macOS-only launchd integration that runs `ralph cycle` on a timer
+  (default 4h, configurable via `--interval`). `install` writes a
+  per-repo plist under `~/Library/LaunchAgents/` and loads it via
+  `launchctl`; `pause` / `resume` toggle the agent without deleting
+  the plist; `status` reports loaded/paused state, last exit code,
+  next-run interval, and live cycle-lock holder when present.
+  (slices #220, #221)
+- `ralph schedule heartbeat` + dual-plist install: in addition to the
+  cycle agent, `ralph schedule install` writes a second plist
+  (`com.lucasfe.ralph.heartbeat.<slug>.plist`) that fires daily at
+  `RALPH_DAILY_SUMMARY_TIME` (default `09:00`) and sends a one-line
+  WhatsApp summary of the last 24h of cycle logs — the *positive
+  heartbeat* that proves Ralph is alive even on days when no issues
+  moved. `pause`, `resume`, `remove`, and `status` operate on both
+  plists transparently. Failures during summary aggregation degrade
+  to `❌ Ralph 24h summary failed: <reason>` so silence never reads
+  as healthy. (slice #223)
 
 ### Configuration
 

--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -73,6 +73,38 @@ after). TDD is skipped only for changes with zero behavioral impact:
 pure documentation, plain configuration, or dependency bumps without
 logic changes — and the skip is justified in the PR body.
 
+## Scheduling Ralph (macOS launchd)
+
+Beyond the manual `ralph start` flow, Ralph can run on a launchd
+timer so it processes the queue without human intervention. This is
+macOS-only; on Linux / WSL use cron or systemd.
+
+```bash
+ralph schedule install            # cycle every 4h + heartbeat at 09:00 (defaults)
+ralph schedule install --interval 30m --heartbeat-time 07:30
+ralph schedule status             # state of every Ralph agent on this machine
+ralph schedule status --here      # only the agent for the current repo
+ralph schedule pause              # unload without deleting the plists
+ralph schedule resume             # reload after a pause
+ralph schedule remove             # unload + delete plists for this repo
+ralph schedule remove --all       # unload + delete every Ralph plist (with confirm)
+```
+
+`install` writes two property lists under `~/Library/LaunchAgents/`:
+
+| Plist | Schedule | Purpose |
+| --- | --- | --- |
+| `com.lucasfe.ralph.cycle.<slug>.plist` | `StartInterval` (default 4h) | Runs `ralph cycle` — one queue-processing pass. |
+| `com.lucasfe.ralph.heartbeat.<slug>.plist` | `StartCalendarInterval` (default 09:00) | Sends the daily 24h summary. |
+
+`<slug>` is the basename of the repo's working tree, so multiple
+repos can each have their own pair of agents on the same user account.
+`pause`, `resume`, `remove`, and `status` operate on both plists
+transparently — there is no separate `ralph schedule heartbeat
+install`. The `ralph schedule heartbeat` subcommand exists, but it is
+the entry point launchd invokes when the heartbeat plist fires; you
+will not normally call it by hand.
+
 ## What survives an update
 
 `ralph init` and any future Ralph update mechanism (`npm i -g

--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -151,6 +151,36 @@ Failures sending the startup ping log a warning and never abort
 
 [callmebot]: https://www.callmebot.com/blog/free-api-whatsapp-messages/
 
+### Daily heartbeat (24h summary)
+
+When Ralph is scheduled via `ralph schedule install` (see
+[Scheduling Ralph](#scheduling-ralph-macos-launchd)), a second launchd
+agent fires once a day and posts a one-line summary of the last 24h to
+WhatsApp. This is the *positive heartbeat* — proof Ralph is alive even
+on days when no issues moved.
+
+Format:
+
+```
+📊 Ralph 24h | 6 cycles, 12 issues (10 ok, 2 fail) | lucasfe/agenthub | next 09:00
+```
+
+When the summary aggregation itself fails (corrupt logs, missing
+directories, etc.), the message degrades to
+`❌ Ralph 24h summary failed: <reason>` so silence never reads as
+healthy.
+
+The schedule defaults to `09:00` in your local timezone. Override it
+with `RALPH_DAILY_SUMMARY_TIME` in `.env.local`:
+
+```bash
+RALPH_DAILY_SUMMARY_TIME=07:30
+```
+
+The heartbeat reuses the same `CALLMEBOT_KEY` / `WHATSAPP_PHONE`
+credentials as the cycle and startup notifications. Missing credentials
+skip the WhatsApp send (the summary is still printed to the log).
+
 ### Custom hook (`ralph-notify.sh`)
 
 For Slack, Discord, email, native macOS notifications, etc., copy


### PR DESCRIPTION
Closes #223

## Summary

Issue #223 asked for `lib/heartbeat.js` + `ralph schedule heartbeat` (the daily 24h positive-heartbeat WhatsApp summary) and dual-plist `ralph schedule install/remove/pause/resume/status`. The code, tests, and CLI wiring all shipped already in PR #264 — but neither the package README nor the CHANGELOG was updated, so the feature is undiscoverable for users running `npm i -g @lucasfe/ralph` and reading the docs.

This PR closes the documentation gap so the issue's acceptance criteria are fully met end-to-end:

- `packages/ralph/README.md`
  - new top-level `## Scheduling Ralph (macOS launchd)` section explaining `ralph schedule install / remove / pause / resume / status` and the dual-plist layout (`com.lucasfe.ralph.cycle.<slug>` + `com.lucasfe.ralph.heartbeat.<slug>`)
  - new `### Daily heartbeat (24h summary)` subsection under "Notification setup" documenting the format string, the `RALPH_DAILY_SUMMARY_TIME` override (default `09:00`), the failure-mode message, and the credential reuse with the cycle/startup notifications
- `packages/ralph/CHANGELOG.md` — adds entries under `[0.1.0] - Unreleased` for slices #220, #221, and #223 (schedule install/remove/pause/resume/status + dual-plist heartbeat)

## TDD
- Skipped: docs-only update — README + CHANGELOG additions describe behavior already locked down by 11 tests in `lib/heartbeat.test.js` and 48 tests in `lib/commands/schedule.test.js` (325 ralph tests pass; 229 frontend tests pass; lint clean).

## Notes
- No code or behavior change. The runtime contract (`summarizeLast24h`, `formatSummary`, `scheduleHeartbeatCommand`, dual-plist install/remove/pause/resume/status) is exactly what landed in #264.
- README is the surface most likely to teach new users the heartbeat exists; the CHANGELOG entry keeps `[0.1.0]` honest about what the first stable release will contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)