### PR TITLE
feat(mobile): pushSubscribe lib + opt-in card + Settings notifications toggle

### DIFF
--- a/src/MobileApp.jsx
+++ b/src/MobileApp.jsx
@@ -24,15 +24,6 @@ function MobileGate({ children }) {
   return children
 }
 
-function MobileSettings() {
-  return (
-    <div className="flex flex-col min-h-screen bg-bg-primary p-4">
-      <h1 className="text-xl font-bold text-text-primary">Settings</h1>
-      <p className="text-sm text-text-muted mt-2">Mobile settings coming soon.</p>
-    </div>
-  )
-}
-
 export default function MobileApp() {
   useEffect(() => {
     register({ scope: '/mobile/' })

--- a/src/MobileApp.jsx
+++ b/src/MobileApp.jsx
@@ -4,6 +4,7 @@ import { useAuth } from './context/AuthContext'
 import { register } from './lib/serviceWorker'
 import MobileLogin from './components/mobile/MobileLogin'
 import MobileChat from './components/mobile/MobileChat'
+import MobileSettings from './components/mobile/MobileSettings'
 
 function MobileGate({ children }) {
   const { user, isAuthorized, loading } = useAuth()

--- a/src/components/mobile/MobileChat.jsx
+++ b/src/components/mobile/MobileChat.jsx
@@ -346,6 +346,8 @@ export default function MobileChat() {
         </button>
       </header>
 
+      <MobilePushOptIn />
+
       <main ref={listRef} className="flex-1 overflow-y-auto px-4 py-6">
         {messages.length === 0 ? (
           <div className="text-center text-text-muted text-sm mt-12">

--- a/src/components/mobile/MobileChat.jsx
+++ b/src/components/mobile/MobileChat.jsx
@@ -6,6 +6,7 @@ import { startRecognition } from '../../lib/voice'
 import MobileAgentPicker from './MobileAgentPicker'
 import MobileApprovalCard from './MobileApprovalCard'
 import MobilePlanCard from './MobilePlanCard'
+import MobilePushOptIn from './MobilePushOptIn'
 
 const INITIAL_MESSAGES = []
 

--- a/src/components/mobile/MobilePushOptIn.jsx
+++ b/src/components/mobile/MobilePushOptIn.jsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react'
+import { Bell, X } from 'lucide-react'
+import {
+  isSubscribed as defaultIsSubscribed,
+  isSupported as defaultIsSupported,
+  subscribe as defaultSubscribe,
+} from '../../lib/pushSubscribe'
+
+const STORAGE_KEY = 'mobile.pushOptIn.dismissed'
+
+function readDismissed() {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function writeDismissed() {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, '1')
+  } catch {
+    // ignore — quota or privacy mode; we just won't persist
+  }
+}
+
+export default function MobilePushOptIn({
+  vapidPublicKey = import.meta.env?.VITE_VAPID_PUBLIC_KEY || '',
+  isSupportedFn = defaultIsSupported,
+  isSubscribedFn = defaultIsSubscribed,
+  subscribeFn = defaultSubscribe,
+}) {
+  const [hidden, setHidden] = useState(() => {
+    if (typeof window === 'undefined') return true
+    if (!isSupportedFn()) return true
+    return readDismissed()
+  })
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (hidden) return
+    let cancelled = false
+    isSubscribedFn()
+      .then((already) => {
+        if (already && !cancelled) {
+          writeDismissed()
+          setHidden(true)
+        }
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [hidden, isSubscribedFn])
+
+  if (hidden) return null
+
+  const dismiss = () => {
+    writeDismissed()
+    setHidden(true)
+  }
+
+  const enable = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await subscribeFn({ vapidPublicKey })
+      if (result?.subscribed) {
+        writeDismissed()
+        setHidden(true)
+      } else {
+        setError(reasonToText(result?.reason))
+      }
+    } catch {
+      setError('Could not enable notifications. Try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      role="region"
+      aria-label="Enable notifications"
+      className="mx-4 my-3 rounded-2xl border border-white/10 bg-white/5 p-3"
+    >
+      <div className="flex items-start gap-3">
+        <div className="rounded-full bg-accent-blue/20 p-2 text-accent-blue">
+          <Bell size={18} aria-hidden="true" />
+        </div>
+        <div className="flex-1">
+          <p className="text-sm text-text-primary">
+            Get notified when your agent finishes or needs approval
+          </p>
+          {error && (
+            <p role="alert" className="mt-1 text-xs text-rose-300">
+              {error}
+            </p>
+          )}
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={enable}
+              disabled={busy}
+              className="rounded-lg bg-accent-blue px-3 py-1.5 text-sm text-white disabled:opacity-50"
+            >
+              {busy ? 'Enabling…' : 'Enable'}
+            </button>
+            <button
+              type="button"
+              onClick={dismiss}
+              disabled={busy}
+              className="rounded-lg px-3 py-1.5 text-sm text-text-muted hover:bg-white/5"
+            >
+              Not now
+            </button>
+          </div>
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss notification opt-in"
+          onClick={dismiss}
+          disabled={busy}
+          className="rounded p-1 text-text-muted hover:bg-white/5"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function reasonToText(reason) {
+  switch (reason) {
+    case 'permission-denied':
+      return 'Notification permission was denied. Enable it in your browser settings.'
+    case 'no-sw':
+      return 'Service worker is not ready yet. Reload and try again.'
+    case 'not-supported':
+      return 'Notifications are not supported on this browser.'
+    case 'network-error':
+      return 'Could not reach the server. Try again.'
+    default:
+      return 'Could not enable notifications. Try again.'
+  }
+}

--- a/src/components/mobile/MobilePushOptIn.test.jsx
+++ b/src/components/mobile/MobilePushOptIn.test.jsx
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobilePushOptIn from './MobilePushOptIn'
+
+const STORAGE_KEY = 'mobile.pushOptIn.dismissed'
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  window.localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('MobilePushOptIn', () => {
+  it('does not render when push is not supported on this browser', () => {
+    const { container } = render(
+      <MobilePushOptIn
+        isSupportedFn={() => false}
+        isSubscribedFn={vi.fn()}
+        subscribeFn={vi.fn()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does not render when localStorage marks the card as dismissed', () => {
+    window.localStorage.setItem(STORAGE_KEY, '1')
+    const { container } = render(
+      <MobilePushOptIn
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(false)}
+        subscribeFn={vi.fn()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the prompt when supported and not dismissed', () => {
+    render(
+      <MobilePushOptIn
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(false)}
+        subscribeFn={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/Get notified/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Enable$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Not now/i })).toBeInTheDocument()
+  })
+
+  it('clicking Not now persists dismissal and removes the card', async () => {
+    const user = userEvent.setup()
+    render(
+      <MobilePushOptIn
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(false)}
+        subscribeFn={vi.fn()}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /Not now/i }))
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1')
+    expect(screen.queryByText(/Get notified/i)).not.toBeInTheDocument()
+  })
+
+  it('Enable calls subscribeFn with vapidPublicKey and hides the card on success', async () => {
+    const subscribeFn = vi
+      .fn()
+      .mockResolvedValue({ subscribed: true, subscription: {} })
+    const user = userEvent.setup()
+    render(
+      <MobilePushOptIn
+        vapidPublicKey="VAPID-KEY"
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(false)}
+        subscribeFn={subscribeFn}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /^Enable$/i }))
+    await waitFor(() => {
+      expect(subscribeFn).toHaveBeenCalledWith({ vapidPublicKey: 'VAPID-KEY' })
+    })
+    await waitFor(() => {
+      expect(screen.queryByText(/Get notified/i)).not.toBeInTheDocument()
+    })
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1')
+  })
+
+  it('shows an inline error message when subscribe returns a reason and keeps the card visible', async () => {
+    const subscribeFn = vi
+      .fn()
+      .mockResolvedValue({ subscribed: false, reason: 'permission-denied' })
+    const user = userEvent.setup()
+    render(
+      <MobilePushOptIn
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(false)}
+        subscribeFn={subscribeFn}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /^Enable$/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/permission was denied/i)
+    })
+    expect(screen.getByText(/Get notified/i)).toBeInTheDocument()
+  })
+
+  it('hides itself when an existing subscription is detected on mount', async () => {
+    render(
+      <MobilePushOptIn
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(true)}
+        subscribeFn={vi.fn()}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.queryByText(/Get notified/i)).not.toBeInTheDocument()
+    })
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1')
+  })
+})

--- a/src/components/mobile/MobileSettings.jsx
+++ b/src/components/mobile/MobileSettings.jsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Bell } from 'lucide-react'
+import {
+  isSubscribed as defaultIsSubscribed,
+  isSupported as defaultIsSupported,
+  subscribe as defaultSubscribe,
+  unsubscribe as defaultUnsubscribe,
+} from '../../lib/pushSubscribe'
+
+export default function MobileSettings({
+  vapidPublicKey = import.meta.env?.VITE_VAPID_PUBLIC_KEY || '',
+  isSupportedFn = defaultIsSupported,
+  isSubscribedFn = defaultIsSubscribed,
+  subscribeFn = defaultSubscribe,
+  unsubscribeFn = defaultUnsubscribe,
+}) {
+  const [supported] = useState(() => isSupportedFn())
+  const [enabled, setEnabled] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+
+  const refresh = useCallback(async () => {
+    if (!supported) return
+    try {
+      const value = await isSubscribedFn()
+      setEnabled(Boolean(value))
+    } catch {
+      setEnabled(false)
+    }
+  }, [supported, isSubscribedFn])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const toggle = async () => {
+    if (busy || !supported) return
+    setBusy(true)
+    setError(null)
+    try {
+      if (enabled) {
+        const result = await unsubscribeFn({})
+        if (result?.unsubscribed) {
+          setEnabled(false)
+        } else {
+          setError(reasonToText(result?.reason))
+        }
+      } else {
+        const result = await subscribeFn({ vapidPublicKey })
+        if (result?.subscribed) {
+          setEnabled(true)
+        } else {
+          setError(reasonToText(result?.reason))
+        }
+      }
+    } catch {
+      setError('Something went wrong. Try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-bg-primary p-4">
+      <h1 className="text-xl font-bold text-text-primary">Settings</h1>
+
+      <section className="mt-6">
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div className="flex items-center gap-3">
+            <div className="rounded-full bg-accent-blue/20 p-2 text-accent-blue">
+              <Bell size={18} aria-hidden="true" />
+            </div>
+            <div className="flex-1">
+              <h2 className="text-sm font-medium text-text-primary">
+                Notifications
+              </h2>
+              <p className="text-xs text-text-muted">
+                Get notified when your agent finishes or needs approval.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={enabled}
+              aria-label="Notifications"
+              onClick={toggle}
+              disabled={busy || !supported}
+              className={`relative h-6 w-11 rounded-full transition disabled:opacity-50 ${
+                enabled ? 'bg-accent-blue' : 'bg-white/15'
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-all ${
+                  enabled ? 'left-[22px]' : 'left-0.5'
+                }`}
+              />
+            </button>
+          </div>
+          {!supported && (
+            <p className="mt-3 text-xs text-text-muted">
+              Notifications are not supported on this browser.
+            </p>
+          )}
+          {error && (
+            <p role="alert" className="mt-3 text-xs text-rose-300">
+              {error}
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function reasonToText(reason) {
+  switch (reason) {
+    case 'permission-denied':
+      return 'Notification permission was denied. Enable it in your browser settings.'
+    case 'no-sw':
+      return 'Service worker is not ready yet. Reload and try again.'
+    case 'not-supported':
+      return 'Notifications are not supported on this browser.'
+    case 'network-error':
+      return 'Could not reach the server. Try again.'
+    default:
+      return 'Could not toggle notifications. Try again.'
+  }
+}

--- a/src/components/mobile/MobileSettings.test.jsx
+++ b/src/components/mobile/MobileSettings.test.jsx
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobileSettings from './MobileSettings'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('MobileSettings — Notifications toggle', () => {
+  it('renders the toggle as off when isSubscribedFn resolves false', async () => {
+    render(
+      <MobileSettings
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(false)}
+        subscribeFn={vi.fn()}
+        unsubscribeFn={vi.fn()}
+      />,
+    )
+    const toggle = await screen.findByRole('switch', { name: /Notifications/i })
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-checked', 'false')
+    })
+  })
+
+  it('renders the toggle as on when isSubscribedFn resolves true', async () => {
+    render(
+      <MobileSettings
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(true)}
+        subscribeFn={vi.fn()}
+        unsubscribeFn={vi.fn()}
+      />,
+    )
+    const toggle = await screen.findByRole('switch', { name: /Notifications/i })
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+    })
+  })
+
+  it('toggling on calls subscribeFn with vapidPublicKey and flips to checked on success', async () => {
+    const subscribeFn = vi
+      .fn()
+      .mockResolvedValue({ subscribed: true, subscription: {} })
+    const user = userEvent.setup()
+    render(
+      <MobileSettings
+        vapidPublicKey="K"
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(false)}
+        subscribeFn={subscribeFn}
+        unsubscribeFn={vi.fn()}
+      />,
+    )
+    const toggle = await screen.findByRole('switch', { name: /Notifications/i })
+    await user.click(toggle)
+    await waitFor(() => {
+      expect(subscribeFn).toHaveBeenCalledWith({ vapidPublicKey: 'K' })
+    })
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+    })
+  })
+
+  it('toggling off calls unsubscribeFn and flips to unchecked on success', async () => {
+    const unsubscribeFn = vi.fn().mockResolvedValue({ unsubscribed: true })
+    const user = userEvent.setup()
+    render(
+      <MobileSettings
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(true)}
+        subscribeFn={vi.fn()}
+        unsubscribeFn={unsubscribeFn}
+      />,
+    )
+    const toggle = await screen.findByRole('switch', { name: /Notifications/i })
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+    })
+    await user.click(toggle)
+    await waitFor(() => {
+      expect(unsubscribeFn).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-checked', 'false')
+    })
+  })
+
+  it('shows an inline error when subscribe returns a reason', async () => {
+    const subscribeFn = vi
+      .fn()
+      .mockResolvedValue({ subscribed: false, reason: 'network-error' })
+    const user = userEvent.setup()
+    render(
+      <MobileSettings
+        isSupportedFn={() => true}
+        isSubscribedFn={vi.fn().mockResolvedValue(false)}
+        subscribeFn={subscribeFn}
+        unsubscribeFn={vi.fn()}
+      />,
+    )
+    const toggle = await screen.findByRole('switch', { name: /Notifications/i })
+    await user.click(toggle)
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Could not reach the server/i)
+    })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('disables the toggle and renders a notice when push is not supported', async () => {
+    render(
+      <MobileSettings
+        isSupportedFn={() => false}
+        isSubscribedFn={vi.fn()}
+        subscribeFn={vi.fn()}
+        unsubscribeFn={vi.fn()}
+      />,
+    )
+    const toggle = screen.getByRole('switch', { name: /Notifications/i })
+    expect(toggle).toBeDisabled()
+    expect(screen.getByText(/not supported on this browser/i)).toBeInTheDocument()
+  })
+})

--- a/src/lib/pushSubscribe.js
+++ b/src/lib/pushSubscribe.js
@@ -1,0 +1,211 @@
+import { supabase } from './supabase'
+
+const SUBSCRIBE_PATH = '/functions/v1/push-subscribe'
+const UNSUBSCRIBE_PATH = '/functions/v1/push-unsubscribe'
+
+export function isSupported() {
+  if (typeof window === 'undefined') return false
+  return 'PushManager' in window && 'Notification' in window
+}
+
+export async function isSubscribed() {
+  if (!isSupported()) return false
+  const registration = await getRegistration()
+  if (!registration) return false
+  const sub = await safeCall(() => registration.pushManager.getSubscription())
+  return Boolean(sub)
+}
+
+export async function subscribe({
+  vapidPublicKey,
+  fetch: fetchImpl = defaultFetch(),
+  getAccessToken = defaultGetAccessToken,
+  supabaseUrl = defaultSupabaseUrl(),
+} = {}) {
+  if (!isSupported()) return { subscribed: false, reason: 'not-supported' }
+
+  const registration = await getRegistration()
+  if (!registration) return { subscribed: false, reason: 'no-sw' }
+
+  const granted = await ensurePermission()
+  if (!granted) return { subscribed: false, reason: 'permission-denied' }
+
+  let subscription
+  try {
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: toApplicationServerKey(vapidPublicKey),
+    })
+  } catch {
+    return { subscribed: false, reason: 'permission-denied' }
+  }
+
+  const posted = await postSubscription({
+    fetchImpl,
+    supabaseUrl,
+    getAccessToken,
+    subscription,
+  })
+  if (!posted) return { subscribed: false, reason: 'network-error' }
+
+  return { subscribed: true, subscription }
+}
+
+export async function unsubscribe({
+  fetch: fetchImpl = defaultFetch(),
+  getAccessToken = defaultGetAccessToken,
+  supabaseUrl = defaultSupabaseUrl(),
+} = {}) {
+  if (!isSupported()) return { unsubscribed: true }
+
+  const registration = await getRegistration()
+  if (!registration) return { unsubscribed: true }
+
+  const subscription = await safeCall(() =>
+    registration.pushManager.getSubscription(),
+  )
+  if (!subscription) return { unsubscribed: true }
+
+  let backendOk = true
+  try {
+    const token = await resolveAccessToken(getAccessToken)
+    const url = `${supabaseUrl}${UNSUBSCRIBE_PATH}`
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token || ''}`,
+      },
+      body: JSON.stringify({ endpoint: subscription.endpoint }),
+    })
+    // 404 means "no row found" — still treat as success (idempotent).
+    if (!res || (!res.ok && res.status !== 404)) backendOk = false
+  } catch {
+    backendOk = false
+  }
+
+  await safeCall(() => subscription.unsubscribe())
+
+  if (!backendOk) return { unsubscribed: false, reason: 'network-error' }
+  return { unsubscribed: true }
+}
+
+async function postSubscription({
+  fetchImpl,
+  supabaseUrl,
+  getAccessToken,
+  subscription,
+}) {
+  try {
+    const token = await resolveAccessToken(getAccessToken)
+    const payload = subscription.toJSON?.() || {
+      endpoint: subscription.endpoint,
+      keys: subscription.keys,
+    }
+    const body = {
+      endpoint: payload.endpoint,
+      keys: { p256dh: payload.keys?.p256dh, auth: payload.keys?.auth },
+    }
+    const res = await fetchImpl(`${supabaseUrl}${SUBSCRIBE_PATH}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token || ''}`,
+      },
+      body: JSON.stringify(body),
+    })
+    return Boolean(res && res.ok)
+  } catch {
+    return false
+  }
+}
+
+async function ensurePermission() {
+  const N = window.Notification
+  if (!N) return false
+  if (N.permission === 'granted') return true
+  if (N.permission === 'denied') return false
+  try {
+    const result = await N.requestPermission()
+    return result === 'granted'
+  } catch {
+    return false
+  }
+}
+
+async function getRegistration() {
+  const sw = navigator?.serviceWorker
+  if (!sw) return null
+  try {
+    if (typeof sw.getRegistration === 'function') {
+      const reg = await sw.getRegistration()
+      if (reg) return reg
+    }
+    if (sw.ready && typeof sw.ready.then === 'function') {
+      return (await sw.ready) || null
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+async function resolveAccessToken(getAccessToken) {
+  try {
+    const value = getAccessToken?.()
+    if (value && typeof value.then === 'function') {
+      return (await value) || ''
+    }
+    return value || ''
+  } catch {
+    return ''
+  }
+}
+
+async function defaultGetAccessToken() {
+  if (!supabase) return ''
+  try {
+    const { data } = await supabase.auth.getSession()
+    return data?.session?.access_token || ''
+  } catch {
+    return ''
+  }
+}
+
+function defaultFetch() {
+  return typeof globalThis.fetch === 'function'
+    ? globalThis.fetch.bind(globalThis)
+    : null
+}
+
+function defaultSupabaseUrl() {
+  return import.meta.env?.VITE_SUPABASE_URL || ''
+}
+
+function toApplicationServerKey(input) {
+  if (!input) return input
+  if (typeof input !== 'string') return input
+  return urlBase64ToUint8Array(input)
+}
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  let raw
+  try {
+    raw = atob(base64)
+  } catch {
+    return base64String
+  }
+  const out = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i)
+  return out
+}
+
+async function safeCall(fn) {
+  try {
+    return await fn()
+  } catch {
+    return null
+  }
+}

--- a/src/lib/pushSubscribe.test.js
+++ b/src/lib/pushSubscribe.test.js
@@ -1,0 +1,426 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isSubscribed,
+  isSupported,
+  subscribe,
+  unsubscribe,
+} from './pushSubscribe'
+
+const SUPABASE_URL = 'https://example.supabase.co'
+const VAPID_KEY = 'BPHelloWorldFakeVapidPublicKey'
+const ACCESS_TOKEN = 'jwt-token-abc'
+
+const originalServiceWorker = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  'serviceWorker',
+)
+const originalPushManager = window.PushManager
+const originalNotification = window.Notification
+
+function setServiceWorker(value) {
+  Object.defineProperty(window.navigator, 'serviceWorker', {
+    configurable: true,
+    value,
+  })
+}
+
+function removeServiceWorker() {
+  delete window.navigator.serviceWorker
+}
+
+function setPushManager(value) {
+  if (value === undefined) {
+    delete window.PushManager
+    return
+  }
+  window.PushManager = value
+}
+
+function setNotification(value) {
+  if (value === undefined) {
+    delete window.Notification
+    return
+  }
+  window.Notification = value
+}
+
+function makeNotification({ permission = 'default', request } = {}) {
+  const ctor = function () {}
+  ctor.permission = permission
+  ctor.requestPermission = request || vi.fn().mockResolvedValue(permission)
+  return ctor
+}
+
+function makeSubscription({
+  endpoint = 'https://push.example.com/abc',
+  p256dh = 'p256dh-key',
+  auth = 'auth-key',
+  unsubscribeImpl,
+} = {}) {
+  return {
+    endpoint,
+    toJSON() {
+      return { endpoint, keys: { p256dh, auth } }
+    },
+    unsubscribe: unsubscribeImpl || vi.fn().mockResolvedValue(true),
+  }
+}
+
+function makeRegistration({ subscribeImpl, getSubscriptionImpl } = {}) {
+  return {
+    pushManager: {
+      subscribe: subscribeImpl || vi.fn(),
+      getSubscription: getSubscriptionImpl || vi.fn().mockResolvedValue(null),
+    },
+  }
+}
+
+afterEach(() => {
+  if (originalServiceWorker) {
+    Object.defineProperty(
+      window.navigator,
+      'serviceWorker',
+      originalServiceWorker,
+    )
+  } else {
+    removeServiceWorker()
+  }
+  if (originalPushManager === undefined) {
+    delete window.PushManager
+  } else {
+    window.PushManager = originalPushManager
+  }
+  if (originalNotification === undefined) {
+    delete window.Notification
+  } else {
+    window.Notification = originalNotification
+  }
+  vi.restoreAllMocks()
+})
+
+describe('isSupported', () => {
+  it('is false when PushManager is missing', () => {
+    setPushManager(undefined)
+    setNotification(makeNotification())
+    expect(isSupported()).toBe(false)
+  })
+
+  it('is false when Notification is missing', () => {
+    setPushManager(function PushManager() {})
+    setNotification(undefined)
+    expect(isSupported()).toBe(false)
+  })
+
+  it('is true when both PushManager and Notification exist on window', () => {
+    setPushManager(function PushManager() {})
+    setNotification(makeNotification())
+    expect(isSupported()).toBe(true)
+  })
+})
+
+describe('subscribe', () => {
+  beforeEach(() => {
+    setPushManager(function PushManager() {})
+  })
+
+  it('short-circuits when push is not supported', async () => {
+    setNotification(undefined)
+    const fetchMock = vi.fn()
+    const result = await subscribe({ vapidPublicKey: VAPID_KEY, fetch: fetchMock })
+    expect(result).toEqual({ subscribed: false, reason: 'not-supported' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns no-sw when navigator.serviceWorker has no registration', async () => {
+    setNotification(makeNotification({ permission: 'granted' }))
+    setServiceWorker({
+      ready: Promise.resolve(null),
+      getRegistration: vi.fn().mockResolvedValue(null),
+    })
+    const fetchMock = vi.fn()
+    const result = await subscribe({
+      vapidPublicKey: VAPID_KEY,
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+    expect(result).toEqual({ subscribed: false, reason: 'no-sw' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns permission-denied when Notification.permission is denied', async () => {
+    setNotification(makeNotification({ permission: 'denied' }))
+    const registration = makeRegistration()
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    const fetchMock = vi.fn()
+    const result = await subscribe({
+      vapidPublicKey: VAPID_KEY,
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+    expect(result).toEqual({ subscribed: false, reason: 'permission-denied' })
+    expect(registration.pushManager.subscribe).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns permission-denied when requestPermission resolves to anything other than granted', async () => {
+    const requestPermission = vi.fn().mockResolvedValue('default')
+    setNotification(
+      makeNotification({ permission: 'default', request: requestPermission }),
+    )
+    const registration = makeRegistration()
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    const fetchMock = vi.fn()
+    const result = await subscribe({
+      vapidPublicKey: VAPID_KEY,
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+    expect(requestPermission).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ subscribed: false, reason: 'permission-denied' })
+  })
+
+  it('subscribes via pushManager and POSTs the subscription to /functions/v1/push-subscribe with the JWT', async () => {
+    setNotification(makeNotification({ permission: 'granted' }))
+    const subscription = makeSubscription({
+      endpoint: 'https://push.example.com/sub-1',
+      p256dh: 'p256dh-1',
+      auth: 'auth-1',
+    })
+    const pushSubscribe = vi.fn().mockResolvedValue(subscription)
+    const registration = makeRegistration({ subscribeImpl: pushSubscribe })
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+
+    const result = await subscribe({
+      vapidPublicKey: VAPID_KEY,
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+
+    expect(pushSubscribe).toHaveBeenCalledTimes(1)
+    const args = pushSubscribe.mock.calls[0][0]
+    expect(args.userVisibleOnly).toBe(true)
+    expect(args.applicationServerKey).toBeDefined()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${SUPABASE_URL}/functions/v1/push-subscribe`)
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe(`Bearer ${ACCESS_TOKEN}`)
+    expect(init.headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body)).toEqual({
+      endpoint: 'https://push.example.com/sub-1',
+      keys: { p256dh: 'p256dh-1', auth: 'auth-1' },
+    })
+
+    expect(result).toEqual({ subscribed: true, subscription })
+  })
+
+  it('returns network-error when the backend POST throws and does NOT roll back the local subscription', async () => {
+    setNotification(makeNotification({ permission: 'granted' }))
+    const localUnsubscribe = vi.fn().mockResolvedValue(true)
+    const subscription = makeSubscription({ unsubscribeImpl: localUnsubscribe })
+    const registration = makeRegistration({
+      subscribeImpl: vi.fn().mockResolvedValue(subscription),
+    })
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const result = await subscribe({
+      vapidPublicKey: VAPID_KEY,
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+
+    expect(result).toEqual({ subscribed: false, reason: 'network-error' })
+    expect(localUnsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('returns network-error when the backend responds with a non-2xx status', async () => {
+    setNotification(makeNotification({ permission: 'granted' }))
+    const subscription = makeSubscription()
+    const registration = makeRegistration({
+      subscribeImpl: vi.fn().mockResolvedValue(subscription),
+    })
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('boom') })
+
+    const result = await subscribe({
+      vapidPublicKey: VAPID_KEY,
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+
+    expect(result).toEqual({ subscribed: false, reason: 'network-error' })
+  })
+})
+
+describe('unsubscribe', () => {
+  beforeEach(() => {
+    setPushManager(function PushManager() {})
+    setNotification(makeNotification({ permission: 'granted' }))
+  })
+
+  it('is a no-op when push is not supported and returns unsubscribed', async () => {
+    setPushManager(undefined)
+    setNotification(undefined)
+    const fetchMock = vi.fn()
+    const result = await unsubscribe({ fetch: fetchMock })
+    expect(result).toEqual({ unsubscribed: true })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns unsubscribed when no service worker registration exists', async () => {
+    setServiceWorker({
+      ready: Promise.resolve(null),
+      getRegistration: vi.fn().mockResolvedValue(null),
+    })
+    const fetchMock = vi.fn()
+    const result = await unsubscribe({
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+    expect(result).toEqual({ unsubscribed: true })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns unsubscribed when there is no current subscription (idempotent)', async () => {
+    const registration = makeRegistration({
+      getSubscriptionImpl: vi.fn().mockResolvedValue(null),
+    })
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    const fetchMock = vi.fn()
+    const result = await unsubscribe({
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+    expect(result).toEqual({ unsubscribed: true })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('POSTs the endpoint to /functions/v1/push-unsubscribe and calls subscription.unsubscribe()', async () => {
+    const localUnsubscribe = vi.fn().mockResolvedValue(true)
+    const subscription = makeSubscription({
+      endpoint: 'https://push.example.com/sub-2',
+      unsubscribeImpl: localUnsubscribe,
+    })
+    const registration = makeRegistration({
+      getSubscriptionImpl: vi.fn().mockResolvedValue(subscription),
+    })
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+
+    const result = await unsubscribe({
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${SUPABASE_URL}/functions/v1/push-unsubscribe`)
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe(`Bearer ${ACCESS_TOKEN}`)
+    expect(JSON.parse(init.body)).toEqual({
+      endpoint: 'https://push.example.com/sub-2',
+    })
+    expect(localUnsubscribe).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ unsubscribed: true })
+  })
+
+  it('returns network-error reason when the backend POST throws but still tears down locally', async () => {
+    const localUnsubscribe = vi.fn().mockResolvedValue(true)
+    const subscription = makeSubscription({ unsubscribeImpl: localUnsubscribe })
+    const registration = makeRegistration({
+      getSubscriptionImpl: vi.fn().mockResolvedValue(subscription),
+    })
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('offline'))
+
+    const result = await unsubscribe({
+      fetch: fetchMock,
+      getAccessToken: () => ACCESS_TOKEN,
+      supabaseUrl: SUPABASE_URL,
+    })
+
+    expect(localUnsubscribe).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ unsubscribed: false, reason: 'network-error' })
+  })
+})
+
+describe('isSubscribed', () => {
+  beforeEach(() => {
+    setPushManager(function PushManager() {})
+    setNotification(makeNotification({ permission: 'granted' }))
+  })
+
+  it('is false when push is not supported', async () => {
+    setPushManager(undefined)
+    setNotification(undefined)
+    await expect(isSubscribed()).resolves.toBe(false)
+  })
+
+  it('is false when there is no service worker registration', async () => {
+    setServiceWorker({
+      ready: Promise.resolve(null),
+      getRegistration: vi.fn().mockResolvedValue(null),
+    })
+    await expect(isSubscribed()).resolves.toBe(false)
+  })
+
+  it('is true when pushManager.getSubscription returns a subscription', async () => {
+    const registration = makeRegistration({
+      getSubscriptionImpl: vi.fn().mockResolvedValue(makeSubscription()),
+    })
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    await expect(isSubscribed()).resolves.toBe(true)
+  })
+
+  it('is false when pushManager.getSubscription returns null', async () => {
+    const registration = makeRegistration({
+      getSubscriptionImpl: vi.fn().mockResolvedValue(null),
+    })
+    setServiceWorker({
+      ready: Promise.resolve(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+    })
+    await expect(isSubscribed()).resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #231

Implements mobile slice 7: a deep `pushSubscribe.js` module that wraps the Web Push API and routes subscriptions through the existing Edge Functions, plus the two UI surfaces that drive it (an opt-in card on the chat screen and a Notifications toggle on Settings).

## What's in

### `src/lib/pushSubscribe.js`
- `isSupported()` — true when both `PushManager` and `Notification` are present on `window`.
- `subscribe({ vapidPublicKey, fetch })` — runs the full opt-in flow (permission → `pushManager.subscribe` → POST `/functions/v1/push-subscribe` with the user's Supabase JWT). Returns `{ subscribed: true, subscription }` on success, `{ subscribed: false, reason }` on `not-supported` / `no-sw` / `permission-denied` / `network-error`. Per AC, backend POST failures do **not** roll back the local subscription.
- `unsubscribe({ fetch })` — POSTs to `/functions/v1/push-unsubscribe` and calls `pushManager.unsubscribe()` locally. Idempotent: a missing registration / subscription / 404 row all resolve as `unsubscribed: true`.
- `isSubscribed()` — reads `registration.pushManager.getSubscription()`.

The module accepts injectable `getAccessToken`, `supabaseUrl`, and `fetch` deps so it stays trivially testable without touching `globalThis` or hitting Supabase.

### UI

- `src/components/mobile/MobilePushOptIn.jsx` — small banner shown once on the first authenticated visit to `/mobile/chat`. Buttons: **Enable** / **Not now**. Dismissed state persisted in `localStorage` under `mobile.pushOptIn.dismissed`. Auto-hides when push is unsupported, when already dismissed, or when an existing browser subscription is detected on mount.
- `src/components/mobile/MobileSettings.jsx` — promotes the previous inline stub in `MobileApp.jsx` to a real component with a Notifications switch reflecting `isSubscribed()` state. Toggling on calls `subscribe`, off calls `unsubscribe`. Inline error surface for each `reason` code. The `/mobile/settings` route now points at this component.

`MobileChat.jsx` simply renders `<MobilePushOptIn />` above the messages list — no behavior change to the chat itself.

## TDD
- Tests added/modified:
  - `src/lib/pushSubscribe.test.js` (19 tests — all 6 AC scenarios + isSupported / isSubscribed coverage)
  - `src/components/mobile/MobilePushOptIn.test.jsx` (7 tests — render gating, dismiss persistence, success path, error reason, existing-subscription auto-hide)
  - `src/components/mobile/MobileSettings.test.jsx` (6 tests — initial state from `isSubscribed`, on/off toggle paths, error surface, unsupported notice)
- Before implementation (red): the lib test file failed to resolve `./pushSubscribe`, so 0 tests ran and the suite failed at import time — the expected red signal that the module did not yet exist.
- After implementation (green): full frontend suite is **261 tests across 30 files passing** (`npm test`). `npm run lint` reports 0 errors / 25 pre-existing warnings; no new warnings introduced.

## Notes
- Out of scope (per AC): no notifications are actually delivered yet — that's slice 8 (#232), which wires `sendPush` into the chat function at the approval gate, `run.done`, and `run.error`.
- The `vapidPublicKey` is sourced from `VITE_VAPID_PUBLIC_KEY` in both UI surfaces; if it's unset the subscribe call to the browser will reject and the user sees the inline error — no silent failure.