### PR TITLE
fix(ralph): exclude pending-merge and do-not-ralph from PROMPT.md selection query

### DIFF
--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -122,4 +122,36 @@ describe('buildPrompt', () => {
       expect(out).toMatch(/docs|documentation|config/i)
     })
   })
+
+  describe('issue selection query', () => {
+    function selectQuery(out) {
+      const match = out.match(/gh issue list[^\n]*--search '([^']+)'/)
+      return match ? match[1] : null
+    }
+
+    it('excludes pending-merge issues from the selection query', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const query = selectQuery(out)
+      expect(query).not.toBeNull()
+      expect(query).toContain('-label:pending-merge')
+    })
+
+    it('excludes do-not-ralph issues from the selection query', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const query = selectQuery(out)
+      expect(query).not.toBeNull()
+      expect(query).toContain('-label:do-not-ralph')
+    })
+
+    it('keeps the existing claude-working and claude-failed exclusions', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const query = selectQuery(out)
+      expect(query).not.toBeNull()
+      expect(query).toContain('-label:claude-working')
+      expect(query).toContain('-label:claude-failed')
+    })
+  })
 })

--- a/packages/ralph/templates/prompt-base.md
+++ b/packages/ralph/templates/prompt-base.md
@@ -13,7 +13,7 @@ operations.
 
 1. **Select issue**: run
    ```
-   gh issue list --state open --search '-label:claude-working -label:claude-failed sort:created-asc' --limit 1 --json number,title,body
+   gh issue list --state open --search '-label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge sort:created-asc' --limit 1 --json number,title,body
    ```
    Take the first. If the list is empty, write "RALPH_DONE" and exit.
    (The bash already checks this before invoking you, so normally there


### PR DESCRIPTION
Closes #257

## TDD
- Tests added/modified:
  - `packages/ralph/lib/build-prompt.test.js` — new `describe('issue selection query', ...)` block (+3 tests, 12 total in this file).
- Before implementation (red): two new tests failed because the rendered `prompt-base.md` only contained `-label:claude-working -label:claude-failed`, not the `-label:do-not-ralph` and `-label:pending-merge` exclusions:
  ```
  FAIL  buildPrompt > issue selection query > excludes pending-merge issues from the selection query
    expected '-label:claude-working -label:claude-failed sort:created-asc' to contain '-label:pending-merge'
  FAIL  buildPrompt > issue selection query > excludes do-not-ralph issues from the selection query
    expected '-label:claude-working -label:claude-failed sort:created-asc' to contain '-label:do-not-ralph'
  ```
- After implementation (green): the full Ralph suite passes — `cd packages/ralph && npm test` → 328 / 328 (was 325 + 3 new). Frontend suite (`npm test` at repo root) still 261 / 261. Lint clean (no new warnings).

## Notes

### Root cause
`packages/ralph/lib/commands/start.js` (line 19), `cycle.js` (line 23), and `templates/ralph.sh` (line 119) already used the full filter:

```
state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge
```

But `templates/prompt-base.md` (the template that becomes the agent's `PROMPT.md` after `ralph init`) still used the older two-label filter:

```
-label:claude-working -label:claude-failed sort:created-asc
```

So projects whose `PROMPT.md` was generated from this template (or never updated) would re-pick `pending-merge` issues forever, wasting cycles on already-merged work waiting for dev → main rollforward, exactly as described in #257.

### Fix
One-line change in the template — sync its `gh issue list --search` to the same filter used everywhere else in the package. The new tests parse the rendered prompt and assert all four exclusions are present, so any future drift between the template and the rest of the package will fail CI.

Existing projects that already have a `PROMPT.md` won't pick this up automatically (`ralph init` doesn't overwrite existing `PROMPT.md` without `--reset-prompt`). The fix is meant for new installs and for users who re-run `ralph init --reset-prompt` after upgrading.