### PR TITLE
test(mobile): E2E mobile suite + manual real-device smoke checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
             if curl -sf http://localhost:4173/ > /dev/null; then break; fi
             sleep 1
           done
-          PLAYWRIGHT_BASE_URL=http://localhost:4173 npx playwright test --project=chromium
+          PLAYWRIGHT_BASE_URL=http://localhost:4173 npx playwright test
           STATUS=$?
           kill $PREVIEW_PID 2>/dev/null || true
           exit $STATUS

--- a/docs/mobile-smoke-test.md
+++ b/docs/mobile-smoke-test.md
@@ -1,0 +1,92 @@
+# Mobile smoke test (manual, real-device)
+
+Playwright covers the wiring inside `MobileApp` (auth gate, chat send, voice
+result handling, push opt-in card, agent picker, approval card). The
+behaviors below cannot be faked by Playwright/Chromium — they require real
+iOS Safari, real microphone permission, and real APNs delivery — and must
+be verified manually before any release that touches `/mobile`.
+
+## Setup
+
+- Real iPhone (iOS 16+). The Playwright suite uses an iPhone 13 viewport,
+  so any iPhone 13 or newer matches the automated coverage.
+- A Google account that appears in `VITE_ALLOWED_EMAILS`.
+- The production deploy (or a Vercel preview) reachable from the device.
+
+## Checklist
+
+1. **Open the production URL in iOS Safari**
+   - Visit `https://agenthub.vercel.app/mobile`.
+   - Confirm the address bar uses the configured theme color (no system
+     fallback).
+   - Confirm the tab favicon resolves (no broken-icon glyph).
+
+2. **Add to Home Screen**
+   - Share menu → "Add to Home Screen" → keep the suggested name.
+   - Launch from the home-screen icon. The app must open in standalone
+     mode (no Safari chrome). Status bar tint should match the app theme.
+
+3. **Auth gate**
+   - On a fresh launch, you land on `/mobile/login`.
+   - Tap "Continue with Google" and complete the OAuth flow with an
+     allowlisted account → redirect to `/mobile/chat`.
+   - Sign out (or reset Safari data) and try again with a non-allowlisted
+     Google account → land back on `/mobile/login` with a visible error
+     banner naming the rejected email.
+
+4. **Send a text message**
+   - Type a short message and tap Send.
+   - Response streams in (text appears progressively, not in a single
+     chunk).
+   - The "Thinking…" placeholder is visible until the first text token
+     arrives.
+
+5. **Voice dictation**
+   - Tap the mic button.
+   - iOS Safari prompts for microphone permission. Allow.
+   - Speak a short sentence. The final transcript should populate the
+     input.
+   - Tap Send. The streaming response should arrive as in step 4.
+
+6. **Tool approval card**
+   - Send a message that triggers an approval-required tool (e.g. "Open
+     a GitHub issue saying: real-device approval test").
+   - The approval card with Approve / Reject buttons must appear.
+   - Tap Approve. The agent should resume and stream the rest of the
+     response.
+
+7. **Push opt-in card**
+   - On the first chat visit, the "Get notified…" card appears under the
+     header.
+   - Tap "Enable". iOS Safari prompts for notification permission. Allow.
+   - The card disappears.
+   - Reload the page. The card stays hidden.
+
+8. **Push: approval-required notification**
+   - From a desktop tab, trigger an approval-required tool call against
+     the same account.
+   - Within a few seconds, the iPhone receives a push notification.
+   - Tap the notification. The app deep-links back to the relevant
+     session and shows the pending approval card.
+
+9. **Push: `run.done` notification**
+   - Trigger a planned/execute run that takes more than ~10 seconds (so
+     the app likely backgrounds before completion).
+   - When the run completes, a push with the run summary should arrive.
+   - Tap the notification. The app opens the same session.
+
+10. **Push: `run.error` notification**
+    - Trigger a run you expect to fail (e.g. invalid target repo for
+      `create_github_issue`).
+    - A push describing the failure should arrive.
+    - Tap the notification. The app deep-links to the relevant session.
+
+11. **Background / foreground resilience**
+    - Background the app (swipe home), wait 60 seconds, reopen from the
+      home-screen icon.
+    - The session state and message history should be intact (or, if the
+      session was discarded, the empty state should render cleanly with
+      no stuck spinners).
+
+If any step fails, file an issue tagged `mobile` with the device, iOS
+version, and reproduction steps.

--- a/e2e/mobile/auth.spec.js
+++ b/e2e/mobile/auth.spec.js
@@ -24,6 +24,8 @@ test.describe('Mobile auth gate', () => {
     )
     await page.goto('/mobile/chat')
     await expect(page).toHaveURL(/\/mobile\/chat/)
-    await expect(page.getByLabel('Message')).toBeVisible({ timeout: MOBILE_TIMEOUT })
+    await expect(page.getByRole('textbox', { name: 'Message' })).toBeVisible({
+      timeout: MOBILE_TIMEOUT,
+    })
   })
 })

--- a/e2e/mobile/auth.spec.js
+++ b/e2e/mobile/auth.spec.js
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+
+const bypassEnabled = process.env.VITE_E2E_AUTH_BYPASS === 'true'
+
+const MOBILE_TIMEOUT = 15000
+
+test.describe('Mobile auth gate', () => {
+  test('redirects unauthenticated user to /mobile/login', async ({ page }) => {
+    test.skip(
+      bypassEnabled,
+      'cannot test the unauthenticated redirect when VITE_E2E_AUTH_BYPASS is on; covered by the bypass test in this same file in CI',
+    )
+    await page.goto('/mobile/chat')
+    await expect(page).toHaveURL(/\/mobile\/login/)
+    await expect(
+      page.getByRole('button', { name: /Continue with Google/i }),
+    ).toBeVisible({ timeout: MOBILE_TIMEOUT })
+  })
+
+  test('VITE_E2E_AUTH_BYPASS lands the user on /mobile/chat', async ({ page }) => {
+    test.skip(
+      !bypassEnabled,
+      'requires VITE_E2E_AUTH_BYPASS=true at build time; covered by the unauthenticated test in this same file locally',
+    )
+    await page.goto('/mobile/chat')
+    await expect(page).toHaveURL(/\/mobile\/chat/)
+    await expect(page.getByLabel('Message')).toBeVisible({ timeout: MOBILE_TIMEOUT })
+  })
+})

--- a/e2e/mobile/chat.spec.js
+++ b/e2e/mobile/chat.spec.js
@@ -36,7 +36,7 @@ test.describe('Mobile chat', () => {
     })
 
     await page.goto('/mobile/chat')
-    const input = page.getByLabel('Message')
+    const input = page.getByRole('textbox', { name: 'Message' })
     await expect(input).toBeVisible({ timeout: MOBILE_TIMEOUT })
 
     await input.fill('Hi from e2e')

--- a/e2e/mobile/chat.spec.js
+++ b/e2e/mobile/chat.spec.js
@@ -82,7 +82,7 @@ test.describe('Mobile chat', () => {
     })
 
     await page.goto('/mobile/chat')
-    await page.getByLabel('Message').fill('File an issue')
+    await page.getByRole('textbox', { name: 'Message' }).fill('File an issue')
     await page.getByRole('button', { name: 'Send message' }).click()
 
     const approveBtn = page.getByRole('button', { name: 'Approve', exact: true })

--- a/e2e/mobile/chat.spec.js
+++ b/e2e/mobile/chat.spec.js
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test'
+
+const bypassEnabled = process.env.VITE_E2E_AUTH_BYPASS === 'true'
+
+const MOBILE_TIMEOUT = 15000
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  Connection: 'keep-alive',
+}
+
+function sse(events) {
+  return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join('')
+}
+
+test.describe('Mobile chat', () => {
+  test.beforeEach(async () => {
+    test.skip(
+      !bypassEnabled,
+      'requires VITE_E2E_AUTH_BYPASS=true at build time so the chat route is reachable',
+    )
+  })
+
+  test('typing, sending, and seeing a streamed response', async ({ page }) => {
+    await page.route('**/functions/v1/chat', async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: SSE_HEADERS,
+        body: sse([
+          { type: 'chat.text', value: 'Hello ' },
+          { type: 'chat.text', value: 'mobile' },
+          { type: 'chat.done' },
+        ]),
+      })
+    })
+
+    await page.goto('/mobile/chat')
+    const input = page.getByLabel('Message')
+    await expect(input).toBeVisible({ timeout: MOBILE_TIMEOUT })
+
+    await input.fill('Hi from e2e')
+    await page.getByRole('button', { name: 'Send message' }).click()
+
+    await expect(page.getByText('Hi from e2e')).toBeVisible()
+    await expect(page.getByText('Hello mobile')).toBeVisible({
+      timeout: MOBILE_TIMEOUT,
+    })
+  })
+
+  test('agent picker bottom sheet opens, lists Auto, and closes after select', async ({
+    page,
+  }) => {
+    await page.goto('/mobile/chat')
+    await expect(page.getByLabel('Message')).toBeVisible({ timeout: MOBILE_TIMEOUT })
+
+    await page.getByRole('button', { name: 'Select agent' }).click()
+    const sheet = page.getByRole('dialog', { name: 'Pick an agent' })
+    await expect(sheet).toBeVisible()
+    await sheet.getByRole('button', { name: /^Auto/ }).click()
+    await expect(sheet).toBeHidden()
+  })
+
+  test('tool approval card renders and Approve flips to Approved', async ({ page }) => {
+    await page.route('**/functions/v1/chat', async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: SSE_HEADERS,
+        body: sse([
+          {
+            type: 'chat.tool_call',
+            name: 'create_github_issue',
+            input: { repo: 'lucasfe/agenthub', title: 'E2E', body: 'Body' },
+            tool_call_id: 'call-e2e-1',
+            requires_approval: true,
+          },
+          { type: 'chat.done' },
+        ]),
+      })
+    })
+
+    await page.goto('/mobile/chat')
+    await page.getByLabel('Message').fill('File an issue')
+    await page.getByRole('button', { name: 'Send message' }).click()
+
+    const approveBtn = page.getByRole('button', { name: 'Approve', exact: true })
+    await expect(approveBtn).toBeVisible({ timeout: MOBILE_TIMEOUT })
+    await approveBtn.click()
+    await expect(
+      page.getByRole('button', { name: 'Approved', exact: true }),
+    ).toBeVisible()
+  })
+})

--- a/e2e/mobile/chat.spec.js
+++ b/e2e/mobile/chat.spec.js
@@ -52,7 +52,9 @@ test.describe('Mobile chat', () => {
     page,
   }) => {
     await page.goto('/mobile/chat')
-    await expect(page.getByLabel('Message')).toBeVisible({ timeout: MOBILE_TIMEOUT })
+    await expect(page.getByRole('textbox', { name: 'Message' })).toBeVisible({
+      timeout: MOBILE_TIMEOUT,
+    })
 
     await page.getByRole('button', { name: 'Select agent' }).click()
     const sheet = page.getByRole('dialog', { name: 'Pick an agent' })

--- a/e2e/mobile/push-opt-in.spec.js
+++ b/e2e/mobile/push-opt-in.spec.js
@@ -23,6 +23,8 @@ test.describe('Mobile push opt-in card', () => {
     // localStorage was written; reloading should keep the card hidden.
     await page.reload()
     await expect(card).toBeHidden()
-    await expect(page.getByLabel('Message')).toBeVisible({ timeout: MOBILE_TIMEOUT })
+    await expect(page.getByRole('textbox', { name: 'Message' })).toBeVisible({
+      timeout: MOBILE_TIMEOUT,
+    })
   })
 })

--- a/e2e/mobile/push-opt-in.spec.js
+++ b/e2e/mobile/push-opt-in.spec.js
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+
+const bypassEnabled = process.env.VITE_E2E_AUTH_BYPASS === 'true'
+
+const MOBILE_TIMEOUT = 15000
+
+test.describe('Mobile push opt-in card', () => {
+  test.beforeEach(async () => {
+    test.skip(
+      !bypassEnabled,
+      'requires VITE_E2E_AUTH_BYPASS=true at build time so the chat route is reachable',
+    )
+  })
+
+  test('visible on first visit, dismissible, persists across reload', async ({ page }) => {
+    await page.goto('/mobile/chat')
+    const card = page.getByRole('region', { name: 'Enable notifications' })
+    await expect(card).toBeVisible({ timeout: MOBILE_TIMEOUT })
+
+    await page.getByRole('button', { name: 'Not now' }).click()
+    await expect(card).toBeHidden()
+
+    // localStorage was written; reloading should keep the card hidden.
+    await page.reload()
+    await expect(card).toBeHidden()
+    await expect(page.getByLabel('Message')).toBeVisible({ timeout: MOBILE_TIMEOUT })
+  })
+})

--- a/e2e/mobile/voice.spec.js
+++ b/e2e/mobile/voice.spec.js
@@ -71,7 +71,7 @@ test.describe('Mobile voice input', () => {
     })
 
     await page.goto('/mobile/chat')
-    const input = page.getByLabel('Message')
+    const input = page.getByRole('textbox', { name: 'Message' })
     await expect(input).toBeVisible({ timeout: MOBILE_TIMEOUT })
 
     await page.getByRole('button', { name: 'Voice input' }).click()

--- a/e2e/mobile/voice.spec.js
+++ b/e2e/mobile/voice.spec.js
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test'
+
+const bypassEnabled = process.env.VITE_E2E_AUTH_BYPASS === 'true'
+
+const MOBILE_TIMEOUT = 15000
+
+test.describe('Mobile voice input', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(
+      !bypassEnabled,
+      'requires VITE_E2E_AUTH_BYPASS=true at build time so the chat route is reachable',
+    )
+    // Stub the Web Speech API before any page script runs. The real API
+    // requires a real microphone permission and a live microphone, neither
+    // of which Playwright/Chromium can fake reliably; the contract we need to
+    // exercise is the wiring inside MobileChat (lib/voice.js → setInput),
+    // which is fully captured by emitting onresult+onend synchronously.
+    await page.addInitScript(() => {
+      class FakeSpeechRecognition {
+        constructor() {
+          this.continuous = false
+          this.interimResults = false
+          this.lang = ''
+          this.onresult = null
+          this.onerror = null
+          this.onend = null
+        }
+        start() {
+          setTimeout(() => {
+            const transcripts = [{ transcript: 'hello from voice' }]
+            transcripts.isFinal = true
+            const event = { results: [transcripts] }
+            try {
+              this.onresult && this.onresult(event)
+            } catch {
+              // swallow — listener errors are not part of this contract
+            }
+            try {
+              this.onend && this.onend()
+            } catch {
+              // swallow
+            }
+          }, 50)
+        }
+        stop() {
+          try {
+            this.onend && this.onend()
+          } catch {
+            // swallow
+          }
+        }
+      }
+      window.SpeechRecognition = FakeSpeechRecognition
+      window.webkitSpeechRecognition = FakeSpeechRecognition
+    })
+  })
+
+  test('tap mic, fire mock result, see transcript in input, send dispatches', async ({
+    page,
+  }) => {
+    let postCount = 0
+    await page.route('**/functions/v1/chat', async (route) => {
+      postCount += 1
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+        body:
+          'data: {"type":"chat.text","value":"ack"}\n\n' +
+          'data: {"type":"chat.done"}\n\n',
+      })
+    })
+
+    await page.goto('/mobile/chat')
+    const input = page.getByLabel('Message')
+    await expect(input).toBeVisible({ timeout: MOBILE_TIMEOUT })
+
+    await page.getByRole('button', { name: 'Voice input' }).click()
+    await expect(input).toHaveValue(/hello from voice/i, { timeout: 5000 })
+
+    await page.getByRole('button', { name: 'Send message' }).click()
+    await expect
+      .poll(() => postCount, { timeout: MOBILE_TIMEOUT })
+      .toBeGreaterThan(0)
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test'
 
 const isPreview = !!process.env.PLAYWRIGHT_BASE_URL
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173'
@@ -25,6 +25,21 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { browserName: 'chromium' },
+      // Desktop suite owns the top-level e2e/*.spec.js files; mobile specs
+      // live under e2e/mobile/ and must run only in the iPhone-sized project.
+      testIgnore: '**/mobile/**',
+    },
+    {
+      name: 'mobile',
+      // iPhone 13 device descriptor: 390x844 viewport, mobile Safari UA,
+      // isMobile + hasTouch. We override browserName to chromium because CI
+      // installs only the chromium browser; the viewport + UA + touch are what
+      // actually gate the mobile UI in the app.
+      use: {
+        ...devices['iPhone 13'],
+        browserName: 'chromium',
+      },
+      testMatch: '**/mobile/**/*.spec.js',
     },
   ],
   // Only start local dev server when not testing against a preview URL


### PR DESCRIPTION
Closes #233

## Summary
Adds Playwright E2E coverage for the `/mobile` flows in an iPhone 13 viewport
(390x844, mobile Safari UA, `isMobile`/`hasTouch`), plus a manual smoke
checklist for behaviors Playwright cannot fake (real iOS Safari, real
microphone, real APNs delivery, real notification deep-link).

A new `mobile` Playwright project owns `e2e/mobile/**/*.spec.js`; the existing
`chromium` project keeps the desktop suite untouched via `testIgnore: '**/mobile/**'`.
Both projects run in the existing CI E2E job — the project filter
(`--project=chromium`) was dropped so all projects run.

## TDD
- Tests added: `e2e/mobile/auth.spec.js`, `e2e/mobile/chat.spec.js`,
  `e2e/mobile/voice.spec.js`, `e2e/mobile/push-opt-in.spec.js`.
- Red: initial run failed with strict-mode locator violations on
  `getByLabel('Message')` (matched both the input and the "Send message"
  button) — 6 failed, 1 skipped.
- Green: switched to `getByRole('textbox', { name: 'Message' })` to disambiguate.
  Final run: 35 passed, 2 skipped (the `unauthenticated → /mobile/login`
  test self-skips when `VITE_E2E_AUTH_BYPASS=true`, and one pre-existing
  desktop skip).
- Unit suite: `npm test` → 261 passed.
- Lint: `npm run lint` → 0 errors (25 pre-existing warnings).

## Notes
- Mobile auth assertion is split into two complementary cases that
  self-skip based on `VITE_E2E_AUTH_BYPASS`: in CI (bypass on) the bypass
  case runs; locally (bypass off) the redirect case runs. Both branches of
  the gate are covered without needing two builds in CI.
- Chat / voice / push-opt-in specs all `test.skip` when bypass is off so
  they don't try to drive the chat surface from `/mobile/login`.
- Voice is exercised by stubbing `window.SpeechRecognition` via
  `addInitScript` — the real Web Speech API requires a live mic that
  Playwright can't fake. The wiring inside `MobileChat` (lib/voice.js →
  `setInput`) is fully covered by emitting `onresult`/`onend`.
- Chat SSE responses are mocked via `page.route('**/functions/v1/chat')`
  returning the namespaced event protocol (`chat.text`, `chat.tool_call`
  with `requires_approval`, `chat.done`).
- `docs/mobile-smoke-test.md` enumerates the 11 manual checks needed on a
  real iPhone (Add to Home Screen, mic permission, push delivery for
  approval / `run.done` / `run.error`, deep-link on notification tap, etc.)
  — these are explicitly out of automation scope per the issue.