### PR TITLE
feat: sync AI Assistant plans to Kanban board (#239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,39 @@ release-please is configured in manifest mode with a single entry for `packages/
 
 The previous manual flow (`.github/workflows/ralph-publish.yml`, triggered by pushing a `ralph-v*` git tag) is removed. release-please now owns the tag, so do not push `ralph-v*` tags by hand — the new workflow has no listener for them.
 
+## AI Assistant ↔ Kanban board sync
+
+Plans created inside the AI Assistant chat (the planner branch that emits `plan.proposed`) are mirrored as rows in the Supabase `tasks` table so the user sees the same work on the `/board` page. The mirror is one-directional and stateless: chat is the source of truth, the board reflects whatever the chat last reported.
+
+### Lifecycle mapping
+
+| Chat event                              | Board task field update                              | Board column   |
+|----------------------------------------|------------------------------------------------------|----------------|
+| `plan.proposed` (first time)            | `INSERT { status: 'todo', plan, title, description }` | Todo           |
+| `plan.proposed` (refinement)            | `UPDATE { plan }` on the same row                     | (unchanged)    |
+| User clicks Approve in chat             | `UPDATE { status: 'executing', error_message: null }` | In Progress    |
+| `run.done`                              | `UPDATE { status: 'done' }`                           | Done           |
+| User clicks Cancel in chat              | `UPDATE { status: 'cancelled', error_message }`       | Done           |
+| `run.error`                             | `UPDATE { status: 'error', error_message }`           | Done           |
+| `plan.fallback` / `plan.error` (no plan)| (no row created — there is nothing to mirror)         | —              |
+
+The title is derived from the first line of the user's original chat message (truncated to 80 characters with an ellipsis); the description is the full original message verbatim. The `plan` field stores the full planner payload (steps, agent metadata, tools), so the board's task detail panel can render the exact same plan the chat user saw.
+
+### Module layout
+
+- `src/lib/planTaskSync.js` — pure async helpers: `createTaskFromPlan`, `updateTaskPlan`, `markTaskApproved`, `markTaskDone`, `markTaskCancelled`, `markTaskError`, `deriveTitle`. Each takes the Supabase client as the first argument so it can be unit-tested with a mock and tolerates a `null` client (no-ops, matching the `BoardPage.jsx` helpers).
+- `src/components/AiAssistant.jsx` — calls the helpers from the lifecycle event handlers in `subscribeSession`, `handleApprovePlan`, and `handleCancelPlan`. Uses a `boardTaskRef` map keyed by message index that holds the in-flight `Promise<taskId>`. Holding a promise (not the resolved ID) avoids a race when the user approves or cancels before the initial insert has completed.
+
+### Race handling
+
+If the user clicks Approve or Cancel before `createTaskFromPlan` has resolved, the helper `withBoardTaskId(messageIdx, fn)` awaits the in-flight promise and only then runs the update. The board never sees a stuck "todo" task because the deferred update fires as soon as the insert completes.
+
+### What this is NOT
+
+- The board does not push state back into the chat. Dragging a chat-created task in the board does not pause the chat run, and the chat does not refetch the task row.
+- Refining a plan multiple times keeps a single row — there is no per-revision history.
+- Clearing the chat (the "Clear" button) drops the in-memory `boardTaskRef` map but leaves the rows in Supabase intact, so prior conversations still appear on the board.
+
 ## Adding a New Agent
 
 1. Add entry to `src/data/agents.json` following the schema above

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -522,7 +522,7 @@ export default function AiAssistant({ open, onClose }) {
       selectedAgentId,
     })
     sessionRef.current = { session, messageIdx: assistantIdx }
-    subscribeSession(session, assistantIdx)
+    subscribeSession(session, assistantIdx, text)
   }
 
   const handleRefinePlan = (messageIdx, instructions) => {

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -411,6 +411,7 @@ export default function AiAssistant({ open, onClose }) {
               tokens_out: event.total_tokens_out,
             },
           }))
+          withBoardTaskId(messageIdx, (id) => markTaskDone(supabase, id))
           setIsStreaming(false)
           sessionRef.current = null
           unsubscribe()

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -42,6 +42,21 @@ export default function AiAssistant({ open, onClose }) {
   const listRef = useRef(null)
   // Tracks the currently running session and which message index it writes to.
   const sessionRef = useRef(null)
+  // Per-message-index promise that resolves to the synced board task ID.
+  // Holding a promise (not the ID) avoids races when the user approves or
+  // cancels before the create-task call has resolved.
+  const boardTaskRef = useRef(new Map())
+
+  // Wait for the board-sync task to finish being created, then run a callback
+  // with its ID. Returns silently when there is no synced task (e.g. Supabase
+  // is not configured, or the message never reached `plan.proposed`).
+  const withBoardTaskId = useCallback(async (messageIdx, fn) => {
+    const promise = boardTaskRef.current.get(messageIdx)
+    if (!promise) return
+    const id = await promise
+    if (!id) return
+    await fn(id)
+  }, [])
 
   // Focus the input when the panel opens
   useEffect(() => {

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -592,7 +592,10 @@ export default function AiAssistant({ open, onClose }) {
       stepAnswers: target.stepAnswers || {},
     })
     sessionRef.current = { session, messageIdx }
-    subscribeSession(session, messageIdx)
+    subscribeSession(session, messageIdx, target.originalTask || '')
+    // Mirror "user approved" onto the synced board task — moves it from
+    // To Do into the In Progress column.
+    withBoardTaskId(messageIdx, (id) => markTaskApproved(supabase, id))
   }
 
   const handleAnswerChange = (messageIdx, stepId, key, value) => {

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -441,6 +441,9 @@ export default function AiAssistant({ open, onClose }) {
               failedStepId: event.failed_step_id,
             }
           })
+          withBoardTaskId(messageIdx, (id) =>
+            markTaskError(supabase, id, event.error),
+          )
           setIsStreaming(false)
           sessionRef.current = null
           unsubscribe()

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -635,15 +635,19 @@ export default function AiAssistant({ open, onClose }) {
 
   const handleCancelPlan = (messageIdx) => {
     const target = messages[messageIdx]
-    if (target?.planStatus === 'executing') {
+    const wasExecuting = target?.planStatus === 'executing'
+    if (wasExecuting) {
       sessionRef.current?.session?.cancel('user')
     }
     patchMessageAt(messageIdx, { planStatus: 'cancelled' })
+    const reason = wasExecuting ? 'Stopped by user during run' : 'Cancelled by user'
+    withBoardTaskId(messageIdx, (id) => markTaskCancelled(supabase, id, reason))
   }
 
   const handleClear = () => {
     sessionRef.current?.session?.cancel('clear')
     sessionRef.current = null
+    boardTaskRef.current.clear()
     setIsStreaming(false)
     setMessages(INITIAL_MESSAGES)
   }

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -125,7 +125,9 @@ export default function AiAssistant({ open, onClose }) {
   // Generic event dispatcher bound to a specific message slot. Returns an
   // unsubscribe-friendly handler that closes itself when a terminal event
   // arrives (done / error / cancelled).
-  const subscribeSession = useCallback((session, messageIdx) => {
+  // `originalTask` is passed explicitly because the closure captures the
+  // initial render's `messages`, which never has the new message in it.
+  const subscribeSession = useCallback((session, messageIdx, originalTask = '') => {
     const unsubscribe = session.subscribe((event) => {
       switch (event.type) {
         case 'router.classified':

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -194,7 +194,7 @@ export default function AiAssistant({ open, onClose }) {
         case 'plan.analyzing_requirements':
           patchMessageAt(messageIdx, { planStatus: 'analyzing' })
           break
-        case 'plan.proposed':
+        case 'plan.proposed': {
           patchMessageAt(messageIdx, (msg) => ({
             ...msg,
             plan: event.plan,
@@ -203,10 +203,26 @@ export default function AiAssistant({ open, onClose }) {
             refineError: null,
             stepAnswers: seedStepAnswers(event.plan, msg.stepAnswers),
           }))
+          // Mirror to the Kanban board. First proposal: insert a new task in
+          // the "todo" column. Subsequent re-proposals (refinements) update
+          // the existing task's plan field instead of creating a duplicate.
+          const existing = boardTaskRef.current.get(messageIdx)
+          if (existing) {
+            existing.then((id) => {
+              if (id) updateTaskPlan(supabase, id, event.plan)
+            })
+          } else {
+            const promise = createTaskFromPlan(supabase, {
+              plan: event.plan,
+              originalTask,
+            }).then((task) => task?.id ?? null)
+            boardTaskRef.current.set(messageIdx, promise)
+          }
           setIsStreaming(false)
           sessionRef.current = null
           unsubscribe()
           break
+        }
         case 'plan.fallback':
           patchMessageAt(messageIdx, (msg) => ({
             ...msg,

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -8,6 +8,15 @@ import PlanCard from './orchestration/PlanCard'
 import PlanReviewPanel from './orchestration/PlanReviewPanel'
 import PlanFallbackCard from './orchestration/PlanFallbackCard'
 import { useData } from '../context/DataContext'
+import { supabase } from '../lib/supabase'
+import {
+  createTaskFromPlan,
+  updateTaskPlan,
+  markTaskApproved,
+  markTaskDone,
+  markTaskCancelled,
+  markTaskError,
+} from '../lib/planTaskSync'
 
 const WELCOME_MESSAGE = {
   role: 'assistant',

--- a/src/components/AiAssistant.jsx
+++ b/src/components/AiAssistant.jsx
@@ -549,7 +549,7 @@ export default function AiAssistant({ open, onClose }) {
       },
     })
     sessionRef.current = { session, messageIdx }
-    subscribeSession(session, messageIdx)
+    subscribeSession(session, messageIdx, target.originalTask || '')
   }
 
   const handleApprovePlan = (messageIdx) => {

--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -775,6 +775,250 @@ describe('AiAssistant', () => {
     clickSpy.mockRestore()
   })
 
+  describe('Kanban board sync (issue #239)', () => {
+    const planFixture = {
+      steps: [
+        {
+          id: 1,
+          agent_id: 'frontend-developer',
+          agent_name: 'Frontend Developer',
+          agent_color: 'blue',
+          agent_icon: 'Monitor',
+          task: 'Sketch the landing page',
+          inputs: ['original_task'],
+          tools_used: [],
+        },
+      ],
+    }
+
+    it('creates a board task with status todo when a plan is proposed', async () => {
+      scriptSession([
+        { type: 'router.classified', mode: 'task' },
+        { type: 'plan.proposing' },
+        { type: 'plan.proposed', plan: planFixture },
+      ])
+
+      const user = userEvent.setup()
+      renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+      await user.type(screen.getByPlaceholderText('Type a message...'), 'build a landing page')
+      await user.click(screen.getByLabelText('Send message'))
+
+      await waitFor(() => {
+        expect(planTaskSyncMock.createTaskFromPlan).toHaveBeenCalledTimes(1)
+      })
+      const arg = planTaskSyncMock.createTaskFromPlan.mock.calls[0][1]
+      expect(arg).toMatchObject({
+        plan: planFixture,
+        originalTask: 'build a landing page',
+      })
+      // Task is created BEFORE the user approves — they can already see it on
+      // the board in the To Do column.
+      expect(planTaskSyncMock.markTaskApproved).not.toHaveBeenCalled()
+    })
+
+    it('marks the board task approved when the user approves the plan', async () => {
+      scriptSession([{ type: 'plan.proposed', plan: planFixture }])
+
+      const user = userEvent.setup()
+      renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+      await user.type(screen.getByPlaceholderText('Type a message...'), 'do a thing')
+      await user.click(screen.getByLabelText('Send message'))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /quick approve/i })).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(planTaskSyncMock.createTaskFromPlan).toHaveBeenCalledTimes(1)
+      })
+
+      // Arm the executor session so approving streams a real run.
+      scriptSession([
+        { type: 'run.started', run_id: 'run-approved' },
+        { type: 'step.started', step_id: 1 },
+        { type: 'step.done', step_id: 1, duration_ms: 100 },
+        { type: 'run.done', run_id: 'run-approved', duration_ms: 200 },
+      ])
+
+      await user.click(screen.getByRole('button', { name: /quick approve/i }))
+
+      await waitFor(() => {
+        expect(planTaskSyncMock.markTaskApproved).toHaveBeenCalledWith(
+          expect.anything(),
+          'sync-task-1',
+        )
+      })
+    })
+
+    it('marks the board task done when the run completes', async () => {
+      scriptSession([{ type: 'plan.proposed', plan: planFixture }])
+
+      const user = userEvent.setup()
+      renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+      await user.type(screen.getByPlaceholderText('Type a message...'), 'do a thing')
+      await user.click(screen.getByLabelText('Send message'))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /quick approve/i })).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(planTaskSyncMock.createTaskFromPlan).toHaveBeenCalled()
+      })
+
+      scriptSession([
+        { type: 'run.started', run_id: 'run-done' },
+        { type: 'step.started', step_id: 1 },
+        { type: 'step.done', step_id: 1, duration_ms: 100 },
+        { type: 'run.done', run_id: 'run-done', duration_ms: 200 },
+      ])
+
+      await user.click(screen.getByRole('button', { name: /quick approve/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Plan completed')).toBeInTheDocument()
+      })
+
+      await waitFor(() => {
+        expect(planTaskSyncMock.markTaskDone).toHaveBeenCalledWith(
+          expect.anything(),
+          'sync-task-1',
+        )
+      })
+    })
+
+    it('marks the board task cancelled when the user cancels the plan', async () => {
+      scriptSession([{ type: 'plan.proposed', plan: planFixture }])
+
+      const user = userEvent.setup()
+      renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+      await user.type(screen.getByPlaceholderText('Type a message...'), 'maybe later')
+      await user.click(screen.getByLabelText('Send message'))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /cancel plan/i })).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(planTaskSyncMock.createTaskFromPlan).toHaveBeenCalled()
+      })
+
+      await user.click(screen.getByRole('button', { name: /cancel plan/i }))
+
+      await waitFor(() => {
+        expect(planTaskSyncMock.markTaskCancelled).toHaveBeenCalledWith(
+          expect.anything(),
+          'sync-task-1',
+        )
+      })
+    })
+
+    it('marks the board task with error status when execution fails', async () => {
+      scriptSession([{ type: 'plan.proposed', plan: planFixture }])
+
+      const user = userEvent.setup()
+      renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+      await user.type(screen.getByPlaceholderText('Type a message...'), 'risky task')
+      await user.click(screen.getByLabelText('Send message'))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /quick approve/i })).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(planTaskSyncMock.createTaskFromPlan).toHaveBeenCalled()
+      })
+
+      scriptSession([
+        { type: 'run.started', run_id: 'run-err' },
+        { type: 'step.started', step_id: 1 },
+        { type: 'step.error', step_id: 1, error: 'kaboom' },
+        { type: 'run.error', run_id: 'run-err', error: 'kaboom', failed_step_id: 1 },
+      ])
+
+      await user.click(screen.getByRole('button', { name: /quick approve/i }))
+
+      await waitFor(() => {
+        expect(planTaskSyncMock.markTaskError).toHaveBeenCalledWith(
+          expect.anything(),
+          'sync-task-1',
+          'kaboom',
+        )
+      })
+    })
+
+    it('updates the existing board task plan when the user refines the plan', async () => {
+      scriptSession([{ type: 'plan.proposed', plan: planFixture }])
+
+      const user = userEvent.setup()
+      renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+      await user.type(screen.getByPlaceholderText('Type a message...'), 'plan that I will refine')
+      await user.click(screen.getByLabelText('Send message'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Plan proposed')).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(planTaskSyncMock.createTaskFromPlan).toHaveBeenCalledTimes(1)
+      })
+
+      // Open review panel to access refine input.
+      await user.click(screen.getByRole('button', { name: /review & approve/i }))
+      await waitFor(() => {
+        expect(screen.getByText('Sketch the landing page')).toBeInTheDocument()
+      })
+
+      const refinedPlan = {
+        steps: [
+          {
+            ...planFixture.steps[0],
+            task: 'Sketch the landing page (refined)',
+          },
+        ],
+      }
+      scriptSession([{ type: 'plan.proposed', plan: refinedPlan }])
+
+      const refineInput = screen.getByPlaceholderText(/refine plan/i)
+      fireEvent.change(refineInput, { target: { value: 'tighten step 1' } })
+      await user.click(screen.getByLabelText('Refine plan'))
+
+      await waitFor(() => {
+        expect(planTaskSyncMock.updateTaskPlan).toHaveBeenCalledWith(
+          expect.anything(),
+          'sync-task-1',
+          refinedPlan,
+        )
+      })
+      // Refinement should reuse the existing task — not insert a new one.
+      expect(planTaskSyncMock.createTaskFromPlan).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not create a board task when the planner falls back without a plan', async () => {
+      scriptSession([
+        { type: 'router.classified', mode: 'task' },
+        {
+          type: 'plan.fallback',
+          reason: 'No suitable agent for legal contract review',
+          suggested_agent_type: 'legal analyst',
+        },
+      ])
+
+      const user = userEvent.setup()
+      renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+
+      await user.type(screen.getByPlaceholderText('Type a message...'), 'analyze this contract')
+      await user.click(screen.getByLabelText('Send message'))
+
+      await waitFor(() => {
+        expect(screen.getByText('No suitable agent')).toBeInTheDocument()
+      })
+      // Fallback path doesn't yield a plan, so nothing to sync.
+      expect(planTaskSyncMock.createTaskFromPlan).not.toHaveBeenCalled()
+    })
+  })
+
   it('surfaces a step error during execution', async () => {
     scriptSession([
       {

--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -898,13 +898,13 @@ describe('AiAssistant', () => {
       await user.click(screen.getByLabelText('Send message'))
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /cancel plan/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
       })
       await waitFor(() => {
         expect(planTaskSyncMock.createTaskFromPlan).toHaveBeenCalled()
       })
 
-      await user.click(screen.getByRole('button', { name: /cancel plan/i }))
+      await user.click(screen.getByRole('button', { name: /^cancel$/i }))
 
       await waitFor(() => {
         expect(planTaskSyncMock.markTaskCancelled).toHaveBeenCalledWith(

--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -910,6 +910,7 @@ describe('AiAssistant', () => {
         expect(planTaskSyncMock.markTaskCancelled).toHaveBeenCalledWith(
           expect.anything(),
           'sync-task-1',
+          'Cancelled by user',
         )
       })
     })

--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -58,6 +58,19 @@ const orchestrationMock = vi.hoisted(() => {
 
 vi.mock('../lib/orchestration', () => orchestrationMock)
 
+// Mock the plan↔board sync layer so we can assert it gets called at the
+// right lifecycle moments without touching Supabase.
+const planTaskSyncMock = vi.hoisted(() => ({
+  createTaskFromPlan: vi.fn(),
+  updateTaskPlan: vi.fn(),
+  markTaskApproved: vi.fn(),
+  markTaskDone: vi.fn(),
+  markTaskCancelled: vi.fn(),
+  markTaskError: vi.fn(),
+}))
+
+vi.mock('../lib/planTaskSync', () => planTaskSyncMock)
+
 // Respond to startSession() by returning a session that will emit `events`
 // once something subscribes to it.
 function scriptSession(events) {
@@ -70,6 +83,12 @@ describe('AiAssistant', () => {
   beforeEach(() => {
     orchestrationMock.isOrchestrationConfigured.mockReturnValue(true)
     orchestrationMock.startSession.mockReset()
+    planTaskSyncMock.createTaskFromPlan.mockReset().mockResolvedValue({ id: 'sync-task-1' })
+    planTaskSyncMock.updateTaskPlan.mockReset().mockResolvedValue(undefined)
+    planTaskSyncMock.markTaskApproved.mockReset().mockResolvedValue(undefined)
+    planTaskSyncMock.markTaskDone.mockReset().mockResolvedValue(undefined)
+    planTaskSyncMock.markTaskCancelled.mockReset().mockResolvedValue(undefined)
+    planTaskSyncMock.markTaskError.mockReset().mockResolvedValue(undefined)
   })
 
   it('does not render when closed', () => {

--- a/src/lib/planTaskSync.js
+++ b/src/lib/planTaskSync.js
@@ -1,0 +1,77 @@
+// Mirrors AI Assistant chat plans onto the Kanban board's `tasks` table.
+//
+// Every helper takes the Supabase client as the first argument so it can
+// be mocked in tests and tolerates a null client (the app falls back to
+// no-op when Supabase is not configured, matching the BoardPage helpers).
+
+const TITLE_MAX = 80
+const FALLBACK_TITLE = 'AI Assistant task'
+const DEFAULT_CANCEL_REASON = 'Cancelled by user'
+const DEFAULT_ERROR_REASON = 'Run failed'
+
+export function deriveTitle(text) {
+  const raw = (text || '').toString().trim()
+  if (!raw) return FALLBACK_TITLE
+  const firstLine = raw.split(/\r?\n/)[0].trim() || FALLBACK_TITLE
+  if (firstLine.length <= TITLE_MAX) return firstLine
+  return firstLine.slice(0, TITLE_MAX - 3) + '...'
+}
+
+export async function createTaskFromPlan(supabase, { plan, originalTask }) {
+  if (!supabase) return null
+  const title = deriveTitle(originalTask)
+  const description = (originalTask || '').toString()
+  const { data, error } = await supabase
+    .from('tasks')
+    .insert({ title, description, status: 'todo', plan })
+    .select()
+    .single()
+  if (error) {
+    console.error('[plan-task-sync] createTaskFromPlan', error)
+    return null
+  }
+  return data
+}
+
+export async function updateTaskPlan(supabase, taskId, plan) {
+  if (!supabase || !taskId) return
+  const { error } = await supabase.from('tasks').update({ plan }).eq('id', taskId)
+  if (error) console.error('[plan-task-sync] updateTaskPlan', error)
+}
+
+export async function markTaskApproved(supabase, taskId) {
+  if (!supabase || !taskId) return
+  const { error } = await supabase
+    .from('tasks')
+    .update({ status: 'executing', error_message: null })
+    .eq('id', taskId)
+  if (error) console.error('[plan-task-sync] markTaskApproved', error)
+}
+
+export async function markTaskDone(supabase, taskId) {
+  if (!supabase || !taskId) return
+  const { error } = await supabase
+    .from('tasks')
+    .update({ status: 'done' })
+    .eq('id', taskId)
+  if (error) console.error('[plan-task-sync] markTaskDone', error)
+}
+
+export async function markTaskCancelled(supabase, taskId, reason = DEFAULT_CANCEL_REASON) {
+  if (!supabase || !taskId) return
+  const { error } = await supabase
+    .from('tasks')
+    .update({ status: 'cancelled', error_message: reason || DEFAULT_CANCEL_REASON })
+    .eq('id', taskId)
+  if (error) console.error('[plan-task-sync] markTaskCancelled', error)
+}
+
+export async function markTaskError(supabase, taskId, errorMessage) {
+  if (!supabase || !taskId) return
+  const message = (errorMessage && String(errorMessage)) || DEFAULT_ERROR_REASON
+  const { error } = await supabase
+    .from('tasks')
+    .update({ status: 'error', error_message: message })
+    .eq('id', taskId)
+  if (error) console.error('[plan-task-sync] markTaskError', error)
+}

--- a/src/lib/planTaskSync.test.js
+++ b/src/lib/planTaskSync.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createTaskFromPlan,
+  updateTaskPlan,
+  markTaskApproved,
+  markTaskDone,
+  markTaskCancelled,
+  markTaskError,
+  deriveTitle,
+} from './planTaskSync'
+
+function mockSupabase({
+  insertResult = { data: { id: 'task-1', status: 'todo' }, error: null },
+  updateResult = { error: null },
+} = {}) {
+  const insertSelectSingle = vi.fn().mockResolvedValue(insertResult)
+  const insertSelect = { single: insertSelectSingle }
+  const insertReturn = { select: vi.fn(() => insertSelect) }
+  const insert = vi.fn(() => insertReturn)
+  const updateEq = vi.fn().mockResolvedValue(updateResult)
+  const update = vi.fn(() => ({ eq: updateEq }))
+  const from = vi.fn(() => ({ insert, update }))
+  return { client: { from }, from, insert, update, updateEq, insertSelectSingle }
+}
+
+let consoleErrorSpy
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+describe('planTaskSync', () => {
+  describe('createTaskFromPlan', () => {
+    it('inserts a task into the tasks table with status todo, the plan, and a derived title', async () => {
+      const { client, from, insert } = mockSupabase()
+      const plan = { steps: [{ id: 1, agent_id: 'frontend-developer', task: 'Sketch UI' }] }
+      const result = await createTaskFromPlan(client, {
+        plan,
+        originalTask: 'Build a landing page for the new product launch',
+      })
+
+      expect(from).toHaveBeenCalledWith('tasks')
+      expect(insert).toHaveBeenCalledTimes(1)
+      const insertArg = insert.mock.calls[0][0]
+      expect(insertArg).toMatchObject({
+        status: 'todo',
+        plan,
+        title: 'Build a landing page for the new product launch',
+        description: 'Build a landing page for the new product launch',
+      })
+      expect(result).toEqual({ id: 'task-1', status: 'todo' })
+    })
+
+    it('truncates a long original task into a title at most 80 characters', async () => {
+      const { client, insert } = mockSupabase()
+      const longTask = 'a'.repeat(120)
+      await createTaskFromPlan(client, { plan: {}, originalTask: longTask })
+      const arg = insert.mock.calls[0][0]
+      expect(arg.title.length).toBeLessThanOrEqual(80)
+      expect(arg.description).toBe(longTask)
+    })
+
+    it('uses only the first line of the original task in the title', async () => {
+      const { client, insert } = mockSupabase()
+      await createTaskFromPlan(client, {
+        plan: {},
+        originalTask: 'First line\nSecond line\nThird line',
+      })
+      const arg = insert.mock.calls[0][0]
+      expect(arg.title).toBe('First line')
+      expect(arg.description).toBe('First line\nSecond line\nThird line')
+    })
+
+    it('falls back to a default title when originalTask is empty', async () => {
+      const { client, insert } = mockSupabase()
+      await createTaskFromPlan(client, { plan: {}, originalTask: '' })
+      const arg = insert.mock.calls[0][0]
+      expect(arg.title).toBe('AI Assistant task')
+      expect(arg.description).toBe('')
+    })
+
+    it('returns null when supabase is not configured', async () => {
+      const result = await createTaskFromPlan(null, { plan: {}, originalTask: 'x' })
+      expect(result).toBeNull()
+    })
+
+    it('returns null and logs when the insert fails', async () => {
+      const { client } = mockSupabase({
+        insertResult: { data: null, error: { message: 'oops' } },
+      })
+      const result = await createTaskFromPlan(client, { plan: {}, originalTask: 'x' })
+      expect(result).toBeNull()
+      expect(consoleErrorSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('updateTaskPlan', () => {
+    it('updates the plan field on the existing task row', async () => {
+      const { client, from, update, updateEq } = mockSupabase()
+      const plan = { steps: [{ id: 1, agent_id: 'a', task: 'refined' }] }
+      await updateTaskPlan(client, 'task-1', plan)
+
+      expect(from).toHaveBeenCalledWith('tasks')
+      expect(update).toHaveBeenCalledWith({ plan })
+      expect(updateEq).toHaveBeenCalledWith('id', 'task-1')
+    })
+
+    it('is a no-op when taskId is missing', async () => {
+      const { client, update } = mockSupabase()
+      await updateTaskPlan(client, null, {})
+      expect(update).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when supabase is not configured', async () => {
+      await expect(updateTaskPlan(null, 'task-1', {})).resolves.toBeUndefined()
+    })
+  })
+
+  describe('markTaskApproved', () => {
+    it('updates the task to status executing and clears error_message', async () => {
+      const { client, from, update, updateEq } = mockSupabase()
+      await markTaskApproved(client, 'task-1')
+      expect(from).toHaveBeenCalledWith('tasks')
+      expect(update).toHaveBeenCalledWith({ status: 'executing', error_message: null })
+      expect(updateEq).toHaveBeenCalledWith('id', 'task-1')
+    })
+
+    it('is a no-op when taskId is missing', async () => {
+      const { client, update } = mockSupabase()
+      await markTaskApproved(client, null)
+      expect(update).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when supabase is not configured', async () => {
+      await expect(markTaskApproved(null, 'task-1')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('markTaskDone', () => {
+    it('updates the task to status done', async () => {
+      const { client, update, updateEq } = mockSupabase()
+      await markTaskDone(client, 'task-1')
+      expect(update).toHaveBeenCalledWith({ status: 'done' })
+      expect(updateEq).toHaveBeenCalledWith('id', 'task-1')
+    })
+
+    it('is a no-op when taskId is missing', async () => {
+      const { client, update } = mockSupabase()
+      await markTaskDone(client, null)
+      expect(update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('markTaskCancelled', () => {
+    it('updates the task to status cancelled with the supplied reason', async () => {
+      const { client, update, updateEq } = mockSupabase()
+      await markTaskCancelled(client, 'task-1', 'User stopped run')
+      expect(update).toHaveBeenCalledWith({
+        status: 'cancelled',
+        error_message: 'User stopped run',
+      })
+      expect(updateEq).toHaveBeenCalledWith('id', 'task-1')
+    })
+
+    it('falls back to a default cancellation reason', async () => {
+      const { client, update } = mockSupabase()
+      await markTaskCancelled(client, 'task-1')
+      expect(update).toHaveBeenCalledWith({
+        status: 'cancelled',
+        error_message: 'Cancelled by user',
+      })
+    })
+
+    it('is a no-op when taskId is missing', async () => {
+      const { client, update } = mockSupabase()
+      await markTaskCancelled(client, null)
+      expect(update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('markTaskError', () => {
+    it('updates the task to status error with the supplied message', async () => {
+      const { client, update, updateEq } = mockSupabase()
+      await markTaskError(client, 'task-1', 'Sub-agent exploded')
+      expect(update).toHaveBeenCalledWith({
+        status: 'error',
+        error_message: 'Sub-agent exploded',
+      })
+      expect(updateEq).toHaveBeenCalledWith('id', 'task-1')
+    })
+
+    it('falls back to a generic error message when none is provided', async () => {
+      const { client, update } = mockSupabase()
+      await markTaskError(client, 'task-1')
+      expect(update).toHaveBeenCalledWith({
+        status: 'error',
+        error_message: 'Run failed',
+      })
+    })
+
+    it('is a no-op when taskId is missing', async () => {
+      const { client, update } = mockSupabase()
+      await markTaskError(client, null, 'x')
+      expect(update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deriveTitle', () => {
+    it('returns a fallback title for empty input', () => {
+      expect(deriveTitle('')).toBe('AI Assistant task')
+      expect(deriveTitle(null)).toBe('AI Assistant task')
+      expect(deriveTitle(undefined)).toBe('AI Assistant task')
+    })
+
+    it('returns the first line untouched when it fits within 80 characters', () => {
+      expect(deriveTitle('Short title')).toBe('Short title')
+    })
+
+    it('truncates long single-line input with an ellipsis at 80 characters', () => {
+      const input = 'a'.repeat(100)
+      const out = deriveTitle(input)
+      expect(out.length).toBe(80)
+      expect(out.endsWith('...')).toBe(true)
+    })
+
+    it('uses only the first line when the input contains line breaks', () => {
+      expect(deriveTitle('hello\nworld')).toBe('hello')
+    })
+  })
+})


### PR DESCRIPTION
Closes #239

## Summary

When the chat planner emits `plan.proposed`, mirror the plan as a row in
the Supabase `tasks` table so it appears in the `/board` page's Todo
column. Track the lifecycle through approve, refine, run.done, cancel,
and run.error so the board stays in sync with the chat conversation.

The sync layer lives in `src/lib/planTaskSync.js` as pure async helpers;
`AiAssistant.jsx` holds an in-flight `Promise<taskId>` map keyed by chat
message index to defer approve/cancel writes when the create has not yet
resolved.

## TDD
- Tests added/modified:
  - `src/lib/planTaskSync.test.js` (new — 24 unit tests for the sync helpers)
  - `src/components/AiAssistant.test.jsx` (new `Kanban board sync (issue #239)` describe block — 7 integration tests)
- Before implementation (red): `planTaskSync.test.js` failed to import the missing module; the 6 new AiAssistant integration tests asserted on `createTaskFromPlan` / `markTaskApproved` / `markTaskDone` / `markTaskCancelled` / `markTaskError` / `updateTaskPlan` mock invocations that were never made (zero calls observed).
- After implementation (green): all 31 test files / 292 tests pass (`npm test`). Lint clean (0 errors; only pre-existing warnings).

## Lifecycle mapping

| Chat event | Board task update | Column |
|---|---|---|
| `plan.proposed` (first) | `INSERT { status: 'todo', plan, title, description }` | Todo |
| `plan.proposed` (refine) | `UPDATE { plan }` (same row) | unchanged |
| User approves | `UPDATE { status: 'executing', error_message: null }` | In Progress |
| `run.done` | `UPDATE { status: 'done' }` | Done |
| User cancels | `UPDATE { status: 'cancelled', error_message }` | Done |
| `run.error` | `UPDATE { status: 'error', error_message }` | Done |
| `plan.fallback` / `plan.error` (no plan) | no-op (nothing to mirror) | — |

## Notes

- The mirror is one-directional: chat is the source of truth, the board reflects whatever the chat last reported. The board does not push state back into the chat.
- Refinement reuses the same row — no per-revision history.
- Clearing the chat (`Clear` button) drops the in-memory `boardTaskRef` map but leaves DB rows intact, so prior conversations still appear on the board.
- A race between a fast user-approval/cancel and the in-flight `INSERT` is handled by storing a `Promise<taskId>` (not the resolved ID) and awaiting it inside `withBoardTaskId(messageIdx, fn)`.
- CLAUDE.md gains a new "AI Assistant ↔ Kanban board sync" section documenting the lifecycle table and module layout.