### PR TITLE
feat(templates): Save as template action on TaskDetailPanel (#249)

### DIFF
--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -182,6 +182,7 @@ function TaskDetailPanel({ task, agents, tools, onUpdate, onDelete, onClose }) {
   const [description, setDescription] = useState(task.description)
   const [statusOpen, setStatusOpen] = useState(false)
   const [stepAnswers, setStepAnswers] = useState({})
+  const [saveTemplateOpen, setSaveTemplateOpen] = useState(false)
   const statusRef = useRef(null)
 
   const orch = useTaskOrchestration({ task, agents, tools, onTaskUpdate: onUpdate })

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -410,6 +410,13 @@ function TaskDetailPanel({ task, agents, tools, onUpdate, onDelete, onClose }) {
           )}
           <div className="ml-auto flex items-center gap-2">
             <button
+              onClick={() => setSaveTemplateOpen(true)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-white/5 border border-border-subtle transition-colors"
+            >
+              <Bookmark size={12} />
+              Save as template
+            </button>
+            <button
               onClick={() => { onDelete(task.id); onClose() }}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-rose-400 hover:bg-rose-500/10 border border-rose-500/20 transition-colors"
             >
@@ -422,6 +429,14 @@ function TaskDetailPanel({ task, agents, tools, onUpdate, onDelete, onClose }) {
           </div>
         </div>
       </div>
+
+      {saveTemplateOpen && (
+        <SaveAsTemplateModal
+          task={task}
+          onClose={() => setSaveTemplateOpen(false)}
+          onSave={insertTemplate}
+        />
+      )}
     </>
   )
 }

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -1,12 +1,14 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import {
   Plus, GripVertical, X, MoreHorizontal, Trash2, ChevronDown,
-  Loader2, AlertCircle, CheckCircle2, Clock, Play, Square, Eye, RefreshCw,
+  Loader2, AlertCircle, CheckCircle2, Clock, Play, Square, Eye, RefreshCw, Bookmark,
 } from 'lucide-react'
 import Header from './Header'
 import { supabase } from '../lib/supabase'
 import { useData } from '../context/DataContext'
 import { useTaskOrchestration } from '../lib/taskOrchestration'
+import { insertTemplate } from '../lib/templatesApi'
+import SaveAsTemplateModal from './SaveAsTemplateModal'
 import {
   StepRow,
   formatDuration,

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -89,11 +89,13 @@ vi.mock('../lib/supabase', () => {
 
 import BoardPage from './BoardPage'
 import { renderWithProviders } from '../test/test-utils'
+import { insertTemplate } from '../lib/templatesApi'
 
 beforeEach(() => {
   streamMock.stream.mockClear()
   streamMock.calls.length = 0
   supabaseHolder.set([])
+  insertTemplate.mockClear()
 })
 
 function makeTask(overrides = {}) {

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -42,6 +42,13 @@ vi.mock('../lib/orchestration/stream', () => ({
   isOrchestrationConfigured: () => true,
 }))
 
+vi.mock('../lib/templatesApi', () => ({
+  fetchTemplates: vi.fn().mockResolvedValue([]),
+  insertTemplate: vi.fn().mockResolvedValue({ id: 'tpl-new' }),
+  updateTemplate: vi.fn().mockResolvedValue(null),
+  deleteTemplate: vi.fn().mockResolvedValue(undefined),
+}))
+
 // In-memory mock of the supabase tasks table. Tests can seed it via
 // `setMockTasks([...])` before rendering.
 const supabaseHolder = vi.hoisted(() => ({

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -246,3 +246,134 @@ describe('BoardPage Re-plan button', () => {
     })
   })
 })
+
+describe('BoardPage Save as template action', () => {
+  it.each([
+    ['todo'],
+    ['awaiting_approval'],
+    ['executing'],
+    ['done'],
+    ['error'],
+    ['cancelled'],
+  ])('renders the Save as template button when status is %s', async (status) => {
+    await openTaskDetail(makeTask({ status }))
+
+    expect(
+      await screen.findByRole('button', { name: /save as template/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('opens a modal pre-filled with the ticket title on click', async () => {
+    await openTaskDetail(makeTask({ status: 'done' }))
+    const trigger = await screen.findByRole('button', { name: /save as template/i })
+
+    await userEvent.setup().click(trigger)
+
+    const nameInput = await screen.findByLabelText(/template name/i)
+    expect(nameInput).toHaveValue('Build login screen')
+    expect(screen.getByLabelText(/template description/i)).toBeInTheDocument()
+  })
+
+  it('inserts a snapshot row with the chosen name and the source ticket fields', async () => {
+    await openTaskDetail(makeTask({ status: 'done' }))
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole('button', { name: /save as template/i }))
+
+    const nameInput = await screen.findByLabelText(/template name/i)
+    await user.clear(nameInput)
+    await user.type(nameInput, 'My new template')
+    const descInput = screen.getByLabelText(/template description/i)
+    await user.type(descInput, 'A reusable bug-fix recipe')
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(insertTemplate).toHaveBeenCalledTimes(1)
+    })
+    const arg = insertTemplate.mock.calls[0][0]
+    expect(arg.name).toBe('My new template')
+    expect(arg.description).toBe('A reusable bug-fix recipe')
+    expect(arg.task_title).toBe('Build login screen')
+    expect(arg.task_description).toBe('with Google OAuth')
+    expect(arg.plan).toEqual(makeTask().plan)
+    expect(arg).not.toHaveProperty('status')
+    expect(arg).not.toHaveProperty('run_id')
+    expect(arg).not.toHaveProperty('error_message')
+    expect(arg).not.toHaveProperty('artifacts')
+    expect(arg).not.toHaveProperty('id')
+  })
+
+  it('inserts a null description when the user leaves the field blank', async () => {
+    await openTaskDetail(makeTask({ status: 'done' }))
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole('button', { name: /save as template/i }))
+
+    await screen.findByLabelText(/template name/i)
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(insertTemplate).toHaveBeenCalledTimes(1)
+    })
+    expect(insertTemplate.mock.calls[0][0].description).toBeNull()
+  })
+
+  it('inserts a null plan when the source ticket has no plan', async () => {
+    await openTaskDetail(makeTask({ status: 'todo', plan: null }))
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole('button', { name: /save as template/i }))
+
+    await screen.findByLabelText(/template name/i)
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(insertTemplate).toHaveBeenCalledTimes(1)
+    })
+    expect(insertTemplate.mock.calls[0][0].plan).toBeNull()
+  })
+
+  it('deep-copies the plan so mutating the snapshot does not affect the source ticket', async () => {
+    const sourceTask = makeTask({ status: 'done' })
+    await openTaskDetail(sourceTask)
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole('button', { name: /save as template/i }))
+
+    await screen.findByLabelText(/template name/i)
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(insertTemplate).toHaveBeenCalledTimes(1)
+    })
+    const insertedPlan = insertTemplate.mock.calls[0][0].plan
+    insertedPlan.steps[0].task = 'mutated'
+    expect(sourceTask.plan.steps[0].task).toBe('Existing plan step')
+  })
+
+  it('closes the modal on cancel without calling insertTemplate', async () => {
+    await openTaskDetail(makeTask({ status: 'done' }))
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole('button', { name: /save as template/i }))
+
+    expect(await screen.findByLabelText(/template name/i)).toBeInTheDocument()
+    await user.click(
+      screen.getByRole('button', { name: /^cancel$/i }),
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/template name/i)).not.toBeInTheDocument()
+    })
+    expect(insertTemplate).not.toHaveBeenCalled()
+  })
+
+  it('closes the modal automatically after a successful insert', async () => {
+    await openTaskDetail(makeTask({ status: 'done' }))
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole('button', { name: /save as template/i }))
+
+    await screen.findByLabelText(/template name/i)
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/template name/i)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/SaveAsTemplateModal.jsx
+++ b/src/components/SaveAsTemplateModal.jsx
@@ -1,21 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { X, Loader2 } from 'lucide-react'
-
-function deepCopy(value) {
-  if (value == null) return value
-  if (typeof structuredClone === 'function') return structuredClone(value)
-  return JSON.parse(JSON.stringify(value))
-}
-
-function buildSnapshot(task, name, description) {
-  return {
-    name: name.trim(),
-    description: description.trim() ? description.trim() : null,
-    task_title: task.title ?? '',
-    task_description: task.description ?? '',
-    plan: task.plan == null ? null : deepCopy(task.plan),
-  }
-}
+import { buildTemplateSnapshot } from '../lib/templates'
 
 export default function SaveAsTemplateModal({ task, onClose, onSave }) {
   const [name, setName] = useState(task.title ?? '')

--- a/src/components/SaveAsTemplateModal.jsx
+++ b/src/components/SaveAsTemplateModal.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from 'react'
+import { X, Loader2 } from 'lucide-react'
+
+function deepCopy(value) {
+  if (value == null) return value
+  if (typeof structuredClone === 'function') return structuredClone(value)
+  return JSON.parse(JSON.stringify(value))
+}
+
+function buildSnapshot(task, name, description) {
+  return {
+    name: name.trim(),
+    description: description.trim() ? description.trim() : null,
+    task_title: task.title ?? '',
+    task_description: task.description ?? '',
+    plan: task.plan == null ? null : deepCopy(task.plan),
+  }
+}
+
+export default function SaveAsTemplateModal({ task, onClose, onSave }) {
+  const [name, setName] = useState(task.title ?? '')
+  const [description, setDescription] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+  const nameRef = useRef(null)
+
+  useEffect(() => {
+    nameRef.current?.focus()
+    nameRef.current?.select()
+  }, [])
+
+  useEffect(() => {
+    const handleKey = (e) => { if (e.key === 'Escape' && !saving) onClose() }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose, saving])
+
+  const trimmedName = name.trim()
+  const canSave = trimmedName.length > 0 && !saving
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!canSave) return
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave(buildSnapshot(task, name, description))
+      onClose()
+    } catch (err) {
+      setError(err?.message || 'Failed to save template')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
+      onClick={() => { if (!saving) onClose() }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md mx-4 rounded-2xl bg-bg-sidebar border border-border-subtle shadow-2xl"
+      >
+        <div className="h-12 border-b border-border-subtle px-5 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text-primary">Save as template</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="p-1.5 rounded-lg hover:bg-bg-input text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-4">
+          <div>
+            <label
+              htmlFor="save-template-name"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Template name
+            </label>
+            <input
+              id="save-template-name"
+              ref={nameRef}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover transition-colors"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="save-template-description"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Template description
+            </label>
+            <textarea
+              id="save-template-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional — describe when to reuse this template"
+              rows={3}
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover resize-none transition-colors"
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-rose-300" role="alert">{error}</p>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving}
+              className="px-3 py-1.5 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-white/5 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSave}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving && <Loader2 size={12} className="animate-spin" />}
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SaveAsTemplateModal.jsx
+++ b/src/components/SaveAsTemplateModal.jsx
@@ -29,7 +29,7 @@ export default function SaveAsTemplateModal({ task, onClose, onSave }) {
     setSaving(true)
     setError(null)
     try {
-      await onSave(buildSnapshot(task, name, description))
+      await onSave(buildTemplateSnapshot(task, { name, description }))
       onClose()
     } catch (err) {
       setError(err?.message || 'Failed to save template')

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -32,6 +32,19 @@ export function cloneTemplateToTask(template) {
   }
 }
 
+export function buildTemplateSnapshot(task, { name, description } = {}) {
+  const trimmedName = (name ?? '').trim()
+  const trimmedDescription = (description ?? '').trim()
+  const plan = task?.plan ?? null
+  return {
+    name: trimmedName,
+    description: trimmedDescription ? trimmedDescription : null,
+    task_title: task?.title ?? '',
+    task_description: task?.description ?? '',
+    plan: plan == null ? null : deepCopy(plan),
+  }
+}
+
 function collectAgentIds(plan) {
   if (!plan || !Array.isArray(plan.steps)) return []
   return plan.steps

--- a/src/lib/templates.test.js
+++ b/src/lib/templates.test.js
@@ -78,6 +78,78 @@ describe('cloneTemplateToTask', () => {
   })
 })
 
+describe('buildTemplateSnapshot', () => {
+  const sampleTask = (overrides = {}) => ({
+    id: 'task-7',
+    title: 'Build login screen',
+    description: 'with Google OAuth',
+    status: 'done',
+    plan: samplePlan(),
+    run_id: 'run-1',
+    error_message: null,
+    artifacts: [{ name: 'a' }],
+    ...overrides,
+  })
+
+  it('snapshots only the columns persisted in task_templates', () => {
+    const snap = buildTemplateSnapshot(sampleTask(), {
+      name: 'Reusable login',
+      description: 'For OAuth integrations',
+    })
+    expect(snap).toEqual({
+      name: 'Reusable login',
+      description: 'For OAuth integrations',
+      task_title: 'Build login screen',
+      task_description: 'with Google OAuth',
+      plan: samplePlan(),
+    })
+    expect(snap).not.toHaveProperty('status')
+    expect(snap).not.toHaveProperty('run_id')
+    expect(snap).not.toHaveProperty('error_message')
+    expect(snap).not.toHaveProperty('artifacts')
+    expect(snap).not.toHaveProperty('id')
+  })
+
+  it('trims the name and description', () => {
+    const snap = buildTemplateSnapshot(sampleTask(), {
+      name: '   Padded name   ',
+      description: '   spaced description   ',
+    })
+    expect(snap.name).toBe('Padded name')
+    expect(snap.description).toBe('spaced description')
+  })
+
+  it('returns null description when blank or whitespace-only', () => {
+    expect(
+      buildTemplateSnapshot(sampleTask(), { name: 'x', description: '' }).description,
+    ).toBeNull()
+    expect(
+      buildTemplateSnapshot(sampleTask(), { name: 'x', description: '   ' }).description,
+    ).toBeNull()
+    expect(
+      buildTemplateSnapshot(sampleTask(), { name: 'x' }).description,
+    ).toBeNull()
+  })
+
+  it('passes a null plan through when the source task has none', () => {
+    const snap = buildTemplateSnapshot(sampleTask({ plan: null }), { name: 'x' })
+    expect(snap.plan).toBeNull()
+  })
+
+  it('deep-copies the plan so mutating the snapshot leaves the source ticket untouched', () => {
+    const task = sampleTask()
+    const snap = buildTemplateSnapshot(task, { name: 'x' })
+    snap.plan.steps[0].task = 'mutated'
+    expect(task.plan.steps[0].task).toBe('Build the form')
+  })
+
+  it('falls back to empty strings when the source task has no title or description', () => {
+    const snap = buildTemplateSnapshot({}, { name: 'x' })
+    expect(snap.task_title).toBe('')
+    expect(snap.task_description).toBe('')
+  })
+})
+
 describe('findMissingAgents', () => {
   const catalog = [
     { id: 'frontend-developer' },

--- a/src/lib/templates.test.js
+++ b/src/lib/templates.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   cloneTemplateToTask,
+  buildTemplateSnapshot,
   findMissingAgents,
   findMissingTools,
   findReferencingTemplates,


### PR DESCRIPTION
Closes #249

## What changed

Adds a "Save as template" action to the `TaskDetailPanel` footer. The button appears for tickets in every status (`todo`, `awaiting_approval`, `executing`, `done`, `error`, `cancelled`). Clicking opens a `SaveAsTemplateModal` pre-filled with the ticket title; submitting inserts a `task_templates` row whose snapshot mirrors the source ticket without any execution-time fields.

Snapshot shape (exactly what `task_templates` accepts):

| Field              | Source                                  |
|--------------------|-----------------------------------------|
| `name`             | user input (pre-filled with task title) |
| `description`      | user input, trimmed; `null` if blank    |
| `task_title`       | `tasks.title`                           |
| `task_description` | `tasks.description`                     |
| `plan`             | deep copy of `tasks.plan`, or `null`    |

Status, run_id, error_message, artifacts, and step requirement answers are intentionally NOT copied.

The deep-copy / snapshot logic lives in `src/lib/templates.js` as a pure helper `buildTemplateSnapshot(task, { name, description })`, symmetric with the existing `cloneTemplateToTask`. The modal is a thin shell over it, so the snapshot semantics (deep copy, blank handling) are unit-testable without rendering React.

## TDD
- Tests added/modified:
  - `src/components/BoardPage.test.jsx` — 13 new test cases under `BoardPage Save as template action` covering: button presence per status (6), title pre-fill, snapshot shape on submit, blank description → null, null plan passthrough, deep-copy isolation, cancel-without-insert, auto-close on success.
  - `src/lib/templates.test.js` — 6 new test cases under `buildTemplateSnapshot` covering: pure snapshot shape (no execution fields), name/description trimming, blank-description-to-null, null plan passthrough, deep-copy isolation, missing title/description fallback.
- Before implementation (red): all 13 BoardPage cases failed because no "Save as template" button or modal existed (button query timed out, no `template name` label).
- After implementation (green): all 359 frontend tests pass (`npm test`), zero lint errors (`npm run lint` shows 26 pre-existing warnings only).

## Files
- `src/components/SaveAsTemplateModal.jsx` (new) — modal with name + description fields, focus-trap-via-overlay, escape-to-close, error surfacing.
- `src/components/BoardPage.jsx` — adds button to `TaskDetailPanel` footer + renders modal; calls `insertTemplate` from `templatesApi`.
- `src/lib/templates.js` — adds `buildTemplateSnapshot` pure helper.
- Tests as listed above.

## Notes
- Followed the deep-module convention: snapshot logic is pure and reusable; modal is the thin React shell.
- The button uses the `Bookmark` lucide icon to visually distinguish from execution-state actions.
- Modal blocks clicks behind it via the standard fixed overlay pattern used elsewhere in the panel.