### PR TITLE
feat(templates): + New template action on /templates page (#250)

### DIFF
--- a/src/components/CreateTemplateModal.jsx
+++ b/src/components/CreateTemplateModal.jsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef, useState } from 'react'
+import { X, Loader2 } from 'lucide-react'
+
+export default function CreateTemplateModal({ onClose, onCreate }) {
+  const [name, setName] = useState('')
+  const [taskTitle, setTaskTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [taskDescription, setTaskDescription] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+  const nameRef = useRef(null)
+
+  useEffect(() => {
+    nameRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    const handleKey = (e) => { if (e.key === 'Escape' && !saving) onClose() }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose, saving])
+
+  const trimmedName = name.trim()
+  const trimmedTaskTitle = taskTitle.trim()
+  const canSave = trimmedName.length > 0 && trimmedTaskTitle.length > 0 && !saving
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!canSave) return
+    setSaving(true)
+    setError(null)
+    try {
+      await onCreate({
+        name: trimmedName,
+        description: description.trim() || null,
+        task_title: trimmedTaskTitle,
+        task_description: taskDescription.trim(),
+        plan: null,
+      })
+      onClose()
+    } catch (err) {
+      setError(err?.message || 'Failed to create template')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
+      onClick={() => { if (!saving) onClose() }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md mx-4 rounded-2xl bg-bg-sidebar border border-border-subtle shadow-2xl"
+      >
+        <div className="h-12 border-b border-border-subtle px-5 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text-primary">New template</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="p-1.5 rounded-lg hover:bg-bg-input text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-4">
+          <div>
+            <label
+              htmlFor="create-template-name"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Template name
+            </label>
+            <input
+              id="create-template-name"
+              ref={nameRef}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              placeholder="e.g. Bug fix"
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover transition-colors"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="create-template-description"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Template description
+            </label>
+            <textarea
+              id="create-template-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional — describe when to reuse this template"
+              rows={2}
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover resize-none transition-colors"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="create-template-task-title"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Task title
+            </label>
+            <input
+              id="create-template-task-title"
+              value={taskTitle}
+              onChange={(e) => setTaskTitle(e.target.value)}
+              required
+              placeholder="The title shown on the Kanban ticket"
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover transition-colors"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="create-template-task-description"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Task description
+            </label>
+            <textarea
+              id="create-template-task-description"
+              value={taskDescription}
+              onChange={(e) => setTaskDescription(e.target.value)}
+              placeholder="Optional — extra detail for the ticket body"
+              rows={3}
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover resize-none transition-colors"
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-rose-300" role="alert">{error}</p>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving}
+              className="px-3 py-1.5 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-white/5 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSave}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving && <Loader2 size={12} className="animate-spin" />}
+              Create
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TemplatesPage.jsx
+++ b/src/components/TemplatesPage.jsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
-import { LayoutTemplate } from 'lucide-react'
+import { LayoutTemplate, Plus } from 'lucide-react'
 import Header from './Header'
 import TemplateCard from './TemplateCard'
-import { fetchTemplates } from '../lib/templatesApi'
+import CreateTemplateModal from './CreateTemplateModal'
+import { fetchTemplates, insertTemplate } from '../lib/templatesApi'
 
 export default function TemplatesPage() {
   const [templates, setTemplates] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [createOpen, setCreateOpen] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -28,6 +30,11 @@ export default function TemplatesPage() {
     return () => { cancelled = true }
   }, [])
 
+  const handleCreate = async (payload) => {
+    const inserted = await insertTemplate(payload)
+    if (inserted) setTemplates((prev) => [...prev, inserted])
+  }
+
   return (
     <>
       <Header />
@@ -42,6 +49,14 @@ export default function TemplatesPage() {
               Reusable Kanban tickets you can spin up in one click
             </p>
           </div>
+          <button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            className="flex items-center gap-2 px-5 py-2.5 bg-accent-blue text-white text-sm font-medium rounded-xl hover:bg-accent-blue/90 transition-colors"
+          >
+            <Plus size={16} />
+            New template
+          </button>
         </div>
       </section>
 
@@ -70,6 +85,13 @@ export default function TemplatesPage() {
           </div>
         )}
       </div>
+
+      {createOpen && (
+        <CreateTemplateModal
+          onClose={() => setCreateOpen(false)}
+          onCreate={handleCreate}
+        />
+      )}
     </>
   )
 }

--- a/src/components/TemplatesPage.test.jsx
+++ b/src/components/TemplatesPage.test.jsx
@@ -86,4 +86,142 @@ describe('TemplatesPage', () => {
     expect(await screen.findByText(/failed to load templates/i)).toBeInTheDocument()
     expect(screen.getByText(/network down/i)).toBeInTheDocument()
   })
+
+  describe('+ New template flow', () => {
+    it('shows a "+ New template" button on the page', async () => {
+      fetchTemplates.mockResolvedValue([])
+      renderWithProviders(<TemplatesPage />)
+      expect(
+        await screen.findByRole('button', { name: /new template/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('opens the create modal when the "+ New template" button is clicked', async () => {
+      fetchTemplates.mockResolvedValue([])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(
+        await screen.findByRole('button', { name: /new template/i }),
+      )
+
+      expect(
+        screen.getByRole('heading', { name: /new template/i }),
+      ).toBeInTheDocument()
+      expect(screen.getByLabelText(/^template name$/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/^task title$/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/template description/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/task description/i)).toBeInTheDocument()
+    })
+
+    it('cancel closes the modal without calling insertTemplate', async () => {
+      fetchTemplates.mockResolvedValue([])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(
+        await screen.findByRole('button', { name: /new template/i }),
+      )
+      expect(
+        screen.getByRole('heading', { name: /new template/i }),
+      ).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: /new template/i }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(insertTemplate).not.toHaveBeenCalled()
+    })
+
+    it('blocks submit when name or task title is empty', async () => {
+      fetchTemplates.mockResolvedValue([])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(
+        await screen.findByRole('button', { name: /new template/i }),
+      )
+
+      const submit = screen.getByRole('button', { name: /^create$/i })
+      expect(submit).toBeDisabled()
+
+      await user.type(screen.getByLabelText(/^template name$/i), 'My template')
+      expect(submit).toBeDisabled()
+
+      await user.type(screen.getByLabelText(/^task title$/i), 'Do the work')
+      expect(submit).toBeEnabled()
+    })
+
+    it('submits and calls insertTemplate with plan:null and the user-provided fields', async () => {
+      fetchTemplates.mockResolvedValue([])
+      insertTemplate.mockResolvedValue({
+        id: 'tpl-new',
+        name: 'My template',
+        description: 'When to use',
+        task_title: 'Do the work',
+        task_description: 'More detail',
+        plan: null,
+      })
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(
+        await screen.findByRole('button', { name: /new template/i }),
+      )
+
+      await user.type(screen.getByLabelText(/^template name$/i), 'My template')
+      await user.type(screen.getByLabelText(/^task title$/i), 'Do the work')
+      await user.type(
+        screen.getByLabelText(/template description/i),
+        'When to use',
+      )
+      await user.type(
+        screen.getByLabelText(/task description/i),
+        'More detail',
+      )
+
+      await user.click(screen.getByRole('button', { name: /^create$/i }))
+
+      await waitFor(() => {
+        expect(insertTemplate).toHaveBeenCalledTimes(1)
+      })
+      expect(insertTemplate).toHaveBeenCalledWith({
+        name: 'My template',
+        description: 'When to use',
+        task_title: 'Do the work',
+        task_description: 'More detail',
+        plan: null,
+      })
+    })
+
+    it('renders the new card in the grid after a successful insert', async () => {
+      fetchTemplates.mockResolvedValue([])
+      insertTemplate.mockResolvedValue({
+        id: 'tpl-new',
+        name: 'Fresh template',
+        description: null,
+        task_title: 'Some title',
+        task_description: '',
+        plan: null,
+      })
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      expect(await screen.findByText(/no templates yet/i)).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: /new template/i }))
+      await user.type(
+        screen.getByLabelText(/^template name$/i),
+        'Fresh template',
+      )
+      await user.type(screen.getByLabelText(/^task title$/i), 'Some title')
+      await user.click(screen.getByRole('button', { name: /^create$/i }))
+
+      expect(await screen.findByText('Fresh template')).toBeInTheDocument()
+      expect(screen.queryByText(/no templates yet/i)).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/TemplatesPage.test.jsx
+++ b/src/components/TemplatesPage.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import TemplatesPage from './TemplatesPage'
 import { renderWithProviders } from '../test/test-utils'
 
@@ -26,7 +27,7 @@ vi.mock('../context/AuthContext', () => ({
   AuthProvider: ({ children }) => children,
 }))
 
-import { fetchTemplates } from '../lib/templatesApi'
+import { fetchTemplates, insertTemplate } from '../lib/templatesApi'
 
 beforeEach(() => {
   vi.clearAllMocks()


### PR DESCRIPTION
Closes #250

Adds a "+ New template" entry on the `/templates` page that lets the user pre-author a template from scratch — name, optional description, task title, optional task description — without going through the board. The new card lands in the grid immediately after the insert resolves.

## TDD
- Tests added/modified: `src/components/TemplatesPage.test.jsx`
- Before implementation (red): 6 new tests under `+ New template flow` failed because the button, modal, and insert wiring didn't exist (`unable to find an accessible element with the role "button" and name /new template/i`).
- After implementation (green): all 365 tests across 35 files pass.

## Changes
- New `CreateTemplateModal.jsx` with the four fields the issue asks for; `name` and `task_title` are required (submit disabled until both are non-empty after trim).
- `TemplatesPage.jsx` renders the button in the header, opens the modal, calls `insertTemplate({ ..., plan: null })`, and appends the returned row to the grid state.
- Required-field validation is enforced client-side before the insert call. ESC and outside-click also dismiss the modal (parity with `SaveAsTemplateModal`).

## Notes
- Clicking a card still does nothing in this slice — the edit drawer (#251) is out of scope.
- `plan` is inserted as `null`. The card's "no plan yet" state already handles that (verified by an existing test).