### PR TITLE
feat(templates): edit and delete via slide-in drawer (#251)

### DIFF
--- a/src/components/TemplateCard.jsx
+++ b/src/components/TemplateCard.jsx
@@ -8,13 +8,15 @@ function describePlan(plan) {
   return `${count} ${count === 1 ? 'step' : 'steps'}`
 }
 
-export default function TemplateCard({ template }) {
+export default function TemplateCard({ template, onClick }) {
   const planLabel = describePlan(template.plan)
 
   return (
-    <article
+    <button
+      type="button"
+      onClick={onClick}
       aria-label={template.name}
-      className="group relative p-5 bg-bg-card border border-border-subtle rounded-2xl card-glow transition-all duration-200 flex flex-col"
+      className="group relative p-5 bg-bg-card border border-border-subtle rounded-2xl card-glow transition-all duration-200 flex flex-col text-left w-full hover:border-border-hover focus:outline-none focus:border-border-hover"
     >
       <div className="flex items-start justify-between mb-3">
         <div className="card-icon w-11 h-11 rounded-xl bg-gradient-to-br from-purple-500/15 to-purple-600/5 flex items-center justify-center">
@@ -35,6 +37,6 @@ export default function TemplateCard({ template }) {
       <div className="mt-auto pt-3 border-t border-border-subtle/50 flex items-center justify-between text-xs text-text-muted">
         <span>{planLabel}</span>
       </div>
-    </article>
+    </button>
   )
 }

--- a/src/components/TemplateEditDrawer.jsx
+++ b/src/components/TemplateEditDrawer.jsx
@@ -1,0 +1,273 @@
+import { useEffect, useState } from 'react'
+import { X, Loader2, Trash2 } from 'lucide-react'
+
+function clonePlanForEdit(plan) {
+  if (!plan || !Array.isArray(plan.steps)) return plan
+  return {
+    ...plan,
+    steps: plan.steps.map((step) => ({ ...step })),
+  }
+}
+
+export default function TemplateEditDrawer({ template, onClose, onSave, onDelete }) {
+  const [name, setName] = useState(template.name ?? '')
+  const [description, setDescription] = useState(template.description ?? '')
+  const [taskTitle, setTaskTitle] = useState(template.task_title ?? '')
+  const [taskDescription, setTaskDescription] = useState(template.task_description ?? '')
+  const [stepTasks, setStepTasks] = useState(() => {
+    const steps = template.plan?.steps
+    if (!Array.isArray(steps)) return {}
+    const map = {}
+    for (const step of steps) {
+      map[step.id] = step.task ?? ''
+    }
+    return map
+  })
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'Escape' && !saving && !deleting) onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose, saving, deleting])
+
+  const trimmedName = name.trim()
+  const trimmedTaskTitle = taskTitle.trim()
+  const canSave =
+    trimmedName.length > 0 && trimmedTaskTitle.length > 0 && !saving && !deleting
+
+  const handleSave = async () => {
+    if (!canSave) return
+    setSaving(true)
+    setError(null)
+    try {
+      const planSteps = template.plan?.steps
+      const updatedPlan = Array.isArray(planSteps)
+        ? {
+            ...clonePlanForEdit(template.plan),
+            steps: planSteps.map((step) => ({
+              ...step,
+              task: stepTasks[step.id] ?? step.task ?? '',
+            })),
+          }
+        : template.plan ?? null
+      await onSave({
+        name: trimmedName,
+        description: description.trim() || null,
+        task_title: trimmedTaskTitle,
+        task_description: taskDescription.trim(),
+        plan: updatedPlan,
+      })
+      onClose()
+    } catch (err) {
+      setError(err?.message || 'Failed to save template')
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    setError(null)
+    try {
+      await onDelete()
+      onClose()
+    } catch (err) {
+      setError(err?.message || 'Failed to delete template')
+      setDeleting(false)
+      setConfirmDelete(false)
+    }
+  }
+
+  const planSteps = template.plan?.steps
+  const hasPlanSteps = Array.isArray(planSteps) && planSteps.length > 0
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={() => {
+          if (!saving && !deleting) onClose()
+        }}
+      />
+      <div
+        role="dialog"
+        aria-label="Edit template"
+        className="fixed top-0 right-0 h-full w-full max-w-lg bg-bg-sidebar border-l border-border-subtle z-50 flex flex-col shadow-2xl animate-slide-in-right"
+      >
+        <div className="h-14 border-b border-border-subtle px-5 flex items-center justify-between shrink-0">
+          <h2 className="text-sm font-semibold text-text-primary">Edit template</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving || deleting}
+            className="p-1.5 rounded-lg hover:bg-bg-input text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-5 space-y-4">
+          <div>
+            <label
+              htmlFor="edit-template-name"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Template name
+            </label>
+            <input
+              id="edit-template-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover transition-colors"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="edit-template-description"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Template description
+            </label>
+            <textarea
+              id="edit-template-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover resize-none transition-colors"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="edit-template-task-title"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Task title
+            </label>
+            <input
+              id="edit-template-task-title"
+              value={taskTitle}
+              onChange={(e) => setTaskTitle(e.target.value)}
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover transition-colors"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="edit-template-task-description"
+              className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+            >
+              Task description
+            </label>
+            <textarea
+              id="edit-template-task-description"
+              value={taskDescription}
+              onChange={(e) => setTaskDescription(e.target.value)}
+              rows={3}
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover resize-none transition-colors"
+            />
+          </div>
+
+          <div>
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-2">
+              Plan steps
+            </span>
+            {hasPlanSteps ? (
+              <div className="space-y-3">
+                {planSteps.map((step, idx) => {
+                  const inputId = `edit-template-step-${step.id}`
+                  const stepLabel = `Step ${idx + 1} — ${step.agent_name || step.agent_id || 'Agent'}`
+                  return (
+                    <div key={step.id}>
+                      <label
+                        htmlFor={inputId}
+                        className="text-xs font-medium text-text-secondary block mb-1.5"
+                      >
+                        {stepLabel}
+                      </label>
+                      <textarea
+                        id={inputId}
+                        value={stepTasks[step.id] ?? ''}
+                        onChange={(e) =>
+                          setStepTasks((prev) => ({ ...prev, [step.id]: e.target.value }))
+                        }
+                        rows={2}
+                        className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover resize-none transition-colors"
+                      />
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-xs text-text-muted italic">No plan attached</p>
+            )}
+          </div>
+
+          {error && (
+            <p className="text-xs text-rose-300" role="alert">{error}</p>
+          )}
+        </div>
+
+        <div className="border-t border-border-subtle px-5 py-3 shrink-0 flex items-center gap-2">
+          {confirmDelete ? (
+            <>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-white bg-rose-500 hover:bg-rose-600 transition-colors disabled:opacity-50"
+              >
+                {deleting && <Loader2 size={12} className="animate-spin" />}
+                Confirm delete
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(false)}
+                disabled={deleting}
+                className="px-3 py-1.5 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-white/5 transition-colors disabled:opacity-50"
+              >
+                Cancel delete
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(true)}
+              disabled={saving || deleting}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-rose-400 hover:bg-rose-500/10 border border-rose-500/20 transition-colors disabled:opacity-50"
+            >
+              <Trash2 size={12} />
+              Delete template
+            </button>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving || deleting}
+              className="px-3 py-1.5 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-white/5 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!canSave}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving && <Loader2 size={12} className="animate-spin" />}
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/TemplatesPage.jsx
+++ b/src/components/TemplatesPage.jsx
@@ -3,13 +3,20 @@ import { LayoutTemplate, Plus } from 'lucide-react'
 import Header from './Header'
 import TemplateCard from './TemplateCard'
 import CreateTemplateModal from './CreateTemplateModal'
-import { fetchTemplates, insertTemplate } from '../lib/templatesApi'
+import TemplateEditDrawer from './TemplateEditDrawer'
+import {
+  fetchTemplates,
+  insertTemplate,
+  updateTemplate,
+  deleteTemplate,
+} from '../lib/templatesApi'
 
 export default function TemplatesPage() {
   const [templates, setTemplates] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [createOpen, setCreateOpen] = useState(false)
+  const [selectedId, setSelectedId] = useState(null)
 
   useEffect(() => {
     let cancelled = false
@@ -34,6 +41,24 @@ export default function TemplatesPage() {
     const inserted = await insertTemplate(payload)
     if (inserted) setTemplates((prev) => [...prev, inserted])
   }
+
+  const handleSave = async (id, updates) => {
+    const updated = await updateTemplate(id, updates)
+    if (updated) {
+      setTemplates((prev) => prev.map((tpl) => (tpl.id === id ? updated : tpl)))
+    } else {
+      setTemplates((prev) =>
+        prev.map((tpl) => (tpl.id === id ? { ...tpl, ...updates } : tpl)),
+      )
+    }
+  }
+
+  const handleDelete = async (id) => {
+    await deleteTemplate(id)
+    setTemplates((prev) => prev.filter((tpl) => tpl.id !== id))
+  }
+
+  const selected = templates.find((tpl) => tpl.id === selectedId) || null
 
   return (
     <>
@@ -80,7 +105,11 @@ export default function TemplatesPage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {templates.map((template) => (
-              <TemplateCard key={template.id} template={template} />
+              <TemplateCard
+                key={template.id}
+                template={template}
+                onClick={() => setSelectedId(template.id)}
+              />
             ))}
           </div>
         )}
@@ -90,6 +119,16 @@ export default function TemplatesPage() {
         <CreateTemplateModal
           onClose={() => setCreateOpen(false)}
           onCreate={handleCreate}
+        />
+      )}
+
+      {selected && (
+        <TemplateEditDrawer
+          key={selected.id}
+          template={selected}
+          onClose={() => setSelectedId(null)}
+          onSave={(updates) => handleSave(selected.id, updates)}
+          onDelete={() => handleDelete(selected.id)}
         />
       )}
     </>

--- a/src/components/TemplatesPage.test.jsx
+++ b/src/components/TemplatesPage.test.jsx
@@ -27,7 +27,7 @@ vi.mock('../context/AuthContext', () => ({
   AuthProvider: ({ children }) => children,
 }))
 
-import { fetchTemplates, insertTemplate } from '../lib/templatesApi'
+import { fetchTemplates, insertTemplate, updateTemplate, deleteTemplate } from '../lib/templatesApi'
 
 beforeEach(() => {
   vi.clearAllMocks()

--- a/src/components/TemplatesPage.test.jsx
+++ b/src/components/TemplatesPage.test.jsx
@@ -224,4 +224,262 @@ describe('TemplatesPage', () => {
       expect(screen.queryByText(/no templates yet/i)).not.toBeInTheDocument()
     })
   })
+
+  describe('Edit drawer flow', () => {
+    const sampleTemplate = {
+      id: 'tpl-edit',
+      name: 'Bug fix template',
+      description: 'For routine bug fixes',
+      task_title: 'Fix bug',
+      task_description: 'Investigate and fix',
+      plan: {
+        steps: [
+          {
+            id: 1,
+            agent_id: 'frontend-developer',
+            agent_name: 'Frontend Dev',
+            task: 'Reproduce the bug',
+            requirements: [{ key: 'env', label: 'Environment', required: true }],
+          },
+          {
+            id: 2,
+            agent_id: 'qa-engineer',
+            agent_name: 'QA Engineer',
+            task: 'Add a regression test',
+            requirements: [],
+          },
+        ],
+      },
+    }
+
+    it('opens the edit drawer when a template card is clicked', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /bug fix template/i }))
+
+      expect(
+        await screen.findByRole('heading', { name: /edit template/i }),
+      ).toBeInTheDocument()
+      expect(screen.getByLabelText(/^template name$/i)).toHaveValue('Bug fix template')
+      expect(screen.getByLabelText(/template description/i)).toHaveValue('For routine bug fixes')
+      expect(screen.getByLabelText(/^task title$/i)).toHaveValue('Fix bug')
+      expect(screen.getByLabelText(/task description/i)).toHaveValue('Investigate and fix')
+    })
+
+    it('renders one editable textarea per plan step labelled with the agent name', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /bug fix template/i }))
+
+      expect(await screen.findByLabelText(/step 1 — frontend dev/i)).toHaveValue('Reproduce the bug')
+      expect(screen.getByLabelText(/step 2 — qa engineer/i)).toHaveValue('Add a regression test')
+    })
+
+    it('does NOT render editable inputs for agent_id, agent_name, requirements, or step order', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /bug fix template/i }))
+      await screen.findByRole('heading', { name: /edit template/i })
+
+      // Per acceptance criteria, agent identity and requirements stay read-only.
+      expect(screen.queryByLabelText(/agent id/i)).not.toBeInTheDocument()
+      expect(screen.queryByLabelText(/^agent name$/i)).not.toBeInTheDocument()
+      expect(screen.queryByLabelText(/requirements/i)).not.toBeInTheDocument()
+      expect(screen.queryByLabelText(/step order/i)).not.toBeInTheDocument()
+    })
+
+    it('Save persists top-level edits via updateTemplate and reflects the new name on the card', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      updateTemplate.mockImplementation((id, updates) =>
+        Promise.resolve({ ...sampleTemplate, ...updates }),
+      )
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /bug fix template/i }))
+
+      const nameInput = screen.getByLabelText(/^template name$/i)
+      await user.clear(nameInput)
+      await user.type(nameInput, 'Renamed template')
+
+      await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+      await waitFor(() => expect(updateTemplate).toHaveBeenCalledTimes(1))
+      expect(updateTemplate).toHaveBeenCalledWith('tpl-edit', expect.objectContaining({
+        name: 'Renamed template',
+        description: 'For routine bug fixes',
+        task_title: 'Fix bug',
+        task_description: 'Investigate and fix',
+      }))
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: /edit template/i }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(await screen.findByText('Renamed template')).toBeInTheDocument()
+    })
+
+    it('Save persists step.task edits via updateTemplate while preserving non-editable plan fields', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      updateTemplate.mockImplementation((id, updates) =>
+        Promise.resolve({ ...sampleTemplate, ...updates }),
+      )
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /bug fix template/i }))
+
+      const stepInput = await screen.findByLabelText(/step 1 — frontend dev/i)
+      await user.clear(stepInput)
+      await user.type(stepInput, 'Reproduce the bug locally with the new fixture')
+
+      await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+      await waitFor(() => expect(updateTemplate).toHaveBeenCalledTimes(1))
+      const call = updateTemplate.mock.calls[0]
+      expect(call[0]).toBe('tpl-edit')
+      const updatedPlan = call[1].plan
+      expect(updatedPlan.steps[0]).toMatchObject({
+        id: 1,
+        agent_id: 'frontend-developer',
+        agent_name: 'Frontend Dev',
+        task: 'Reproduce the bug locally with the new fixture',
+      })
+      expect(updatedPlan.steps[0].requirements).toEqual([
+        { key: 'env', label: 'Environment', required: true },
+      ])
+      expect(updatedPlan.steps[1]).toMatchObject({
+        id: 2,
+        agent_id: 'qa-engineer',
+        agent_name: 'QA Engineer',
+        task: 'Add a regression test',
+      })
+    })
+
+    it('Cancel closes the drawer without calling updateTemplate', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /bug fix template/i }))
+
+      const nameInput = await screen.findByLabelText(/^template name$/i)
+      await user.clear(nameInput)
+      await user.type(nameInput, 'Local edit that should be discarded')
+
+      await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: /edit template/i }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(updateTemplate).not.toHaveBeenCalled()
+      expect(screen.getByText('Bug fix template')).toBeInTheDocument()
+    })
+
+    it('Escape closes the drawer without calling updateTemplate', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /bug fix template/i }))
+      await screen.findByRole('heading', { name: /edit template/i })
+
+      await user.keyboard('{Escape}')
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: /edit template/i }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(updateTemplate).not.toHaveBeenCalled()
+    })
+
+    it('renders a clear "no plan attached" message and no step editor for null-plan templates', async () => {
+      fetchTemplates.mockResolvedValue([
+        {
+          id: 'tpl-no-plan',
+          name: 'Plain template',
+          description: 'No plan yet',
+          task_title: 'Just a title',
+          task_description: '',
+          plan: null,
+        },
+      ])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /plain template/i }))
+
+      expect(await screen.findByLabelText(/^template name$/i)).toHaveValue('Plain template')
+      expect(screen.getByText(/no plan attached/i)).toBeInTheDocument()
+      expect(screen.queryByLabelText(/^step 1 /i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Delete flow', () => {
+    const sampleTemplate = {
+      id: 'tpl-del',
+      name: 'Disposable template',
+      description: 'Will be deleted',
+      task_title: 'Title',
+      task_description: '',
+      plan: null,
+    }
+
+    it('asks for confirmation before calling deleteTemplate', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /disposable template/i }))
+      await user.click(await screen.findByRole('button', { name: /^delete template$/i }))
+
+      // First click reveals confirmation, doesn't fire delete yet.
+      expect(deleteTemplate).not.toHaveBeenCalled()
+      expect(await screen.findByRole('button', { name: /^confirm delete$/i })).toBeInTheDocument()
+    })
+
+    it('confirming delete removes the card and closes the drawer', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      deleteTemplate.mockResolvedValue(undefined)
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /disposable template/i }))
+      await user.click(await screen.findByRole('button', { name: /^delete template$/i }))
+      await user.click(await screen.findByRole('button', { name: /^confirm delete$/i }))
+
+      await waitFor(() => expect(deleteTemplate).toHaveBeenCalledWith('tpl-del'))
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: /edit template/i }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(screen.queryByText('Disposable template')).not.toBeInTheDocument()
+    })
+
+    it('cancelling the confirmation keeps the template visible', async () => {
+      fetchTemplates.mockResolvedValue([sampleTemplate])
+      const user = userEvent.setup()
+      renderWithProviders(<TemplatesPage />)
+
+      await user.click(await screen.findByRole('button', { name: /disposable template/i }))
+      await user.click(await screen.findByRole('button', { name: /^delete template$/i }))
+
+      // After clicking the destructive trigger, a "Cancel delete" appears alongside "Confirm delete".
+      await user.click(await screen.findByRole('button', { name: /^cancel delete$/i }))
+
+      expect(deleteTemplate).not.toHaveBeenCalled()
+      expect(await screen.findByRole('button', { name: /^delete template$/i })).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
Closes #251

## Summary

- Cards on `/templates` are now clickable buttons that open a `TemplateEditDrawer` (right-side slide-in, same visual pattern as `TaskDetailPanel`).
- The drawer edits the four top-level texts (`name`, `description`, `task_title`, `task_description`) and the `task` text of every step in the plan. Agent identity, requirements, ordering and step count remain read-only — power users restructure via the existing "instantiate → edit → save as template" path.
- Save persists via `templatesApi.updateTemplate` (which already stamps `updated_at`); Cancel / Escape / outside-click discards.
- Delete uses an inline two-step confirmation in the footer (Delete template → Confirm delete / Cancel delete) and removes the row via `templatesApi.deleteTemplate`.
- Templates with `plan = null` render the four top-level fields and a clear "No plan attached" message instead of the steps editor.

## TDD

- Tests added/modified: `src/components/TemplatesPage.test.jsx`
- Before implementation (red): 11 new tests in the `Edit drawer flow` and `Delete flow` describe blocks failed because the card was not a button (no role) and the drawer did not exist.
- After implementation (green): full frontend suite passes — 376/376 tests across 35 files.

## Notes

- `TemplateCard` is now a `<button type="button">` so the click target reads as `role="button"` for accessibility and tests.
- The drawer clones plan steps locally on edit and only writes back on Save; non-`task` step fields pass through untouched, satisfying the "preserve agent_id / requirements / order" criterion.
- Lint warnings are unchanged — the only warning on `TemplatesPage.jsx` (the `setLoading` inside the mount effect, line 23) was already present on `dev` and is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)