### PR TITLE
feat(templates): + From template button + selector modal + instantiation (#252)

### DIFF
--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -638,6 +638,13 @@ export default function BoardPage() {
           onClose={() => setSelectedTaskId(null)}
         />
       )}
+
+      {templateSelectorOpen && (
+        <TemplateSelectorModal
+          onClose={() => setTemplateSelectorOpen(false)}
+          onUseTemplate={handleUseTemplate}
+        />
+      )}
     </>
   )
 }

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -622,6 +622,7 @@ export default function BoardPage() {
               onDragStart={setDraggingId}
               onDrop={handleDrop}
               onClickTask={setSelectedTaskId}
+              onOpenTemplateSelector={() => setTemplateSelectorOpen(true)}
             />
           ))}
         </div>

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -446,7 +446,7 @@ function TaskDetailPanel({ task, agents, tools, onUpdate, onDelete, onClose }) {
 
 // ─── Column ───────────────────────────────────────────────────────────────
 
-function Column({ column, tasks, onAddTask, onDeleteTask, onDragStart, onDrop, onClickTask }) {
+function Column({ column, tasks, onAddTask, onDeleteTask, onDragStart, onDrop, onClickTask, onOpenTemplateSelector }) {
   const [showForm, setShowForm] = useState(false)
   const [dragOver, setDragOver] = useState(false)
 

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -497,13 +497,22 @@ function Column({ column, tasks, onAddTask, onDeleteTask, onDragStart, onDrop, o
               onCancel={() => setShowForm(false)}
             />
           ) : (
-            <button
-              onClick={() => setShowForm(true)}
-              className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-xs text-text-muted hover:text-text-secondary hover:bg-white/5 transition-colors"
-            >
-              <Plus size={14} />
-              Add task
-            </button>
+            <div className="space-y-1">
+              <button
+                onClick={() => setShowForm(true)}
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-xs text-text-muted hover:text-text-secondary hover:bg-white/5 transition-colors"
+              >
+                <Plus size={14} />
+                Add task
+              </button>
+              <button
+                onClick={onOpenTemplateSelector}
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-xs text-text-muted hover:text-text-secondary hover:bg-white/5 transition-colors"
+              >
+                <LayoutTemplate size={14} />
+                From template
+              </button>
+            </div>
           )
         )}
       </div>

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -2,13 +2,16 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import {
   Plus, GripVertical, X, MoreHorizontal, Trash2, ChevronDown,
   Loader2, AlertCircle, CheckCircle2, Clock, Play, Square, Eye, RefreshCw, Bookmark,
+  LayoutTemplate,
 } from 'lucide-react'
 import Header from './Header'
 import { supabase } from '../lib/supabase'
 import { useData } from '../context/DataContext'
 import { useTaskOrchestration } from '../lib/taskOrchestration'
 import { insertTemplate } from '../lib/templatesApi'
+import { cloneTemplateToTask } from '../lib/templates'
 import SaveAsTemplateModal from './SaveAsTemplateModal'
+import TemplateSelectorModal from './TemplateSelectorModal'
 import {
   StepRow,
   formatDuration,

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -527,6 +527,7 @@ export default function BoardPage() {
   const [loading, setLoading] = useState(true)
   const [, setDraggingId] = useState(null)
   const [selectedTaskId, setSelectedTaskId] = useState(null)
+  const [templateSelectorOpen, setTemplateSelectorOpen] = useState(false)
   const { agents, tools } = useData()
 
   const selectedTask = selectedTaskId ? tasks.find((t) => t.id === selectedTaskId) : null

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -541,6 +541,15 @@ export default function BoardPage() {
     if (row) setTasks((prev) => [...prev, row])
   }, [])
 
+  const handleUseTemplate = useCallback(async (template) => {
+    const row = await insertTask(cloneTemplateToTask(template))
+    if (row) {
+      setTasks((prev) => [...prev, row])
+      setSelectedTaskId(row.id)
+    }
+    setTemplateSelectorOpen(false)
+  }, [])
+
   const handleDeleteTask = useCallback(async (taskId) => {
     setTasks((prev) => prev.filter((t) => t.id !== taskId))
     setSelectedTaskId((prev) => (prev === taskId ? null : prev))

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -428,7 +428,7 @@ describe('BoardPage From template action', () => {
   })
 
   it('opens the template selector modal and lists fetched templates on click', async () => {
-    fetchTemplates.mockResolvedValueOnce([
+    fetchTemplates.mockResolvedValue([
       makeTemplate({ id: 'tpl-a', name: 'First template' }),
       makeTemplate({ id: 'tpl-b', name: 'Second template' }),
     ])

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -467,7 +467,7 @@ describe('BoardPage From template action', () => {
     const trigger = await waitForBoard()
     const user = userEvent.setup()
     await user.click(trigger)
-    await user.click(await screen.findByText('Bug fix recipe'))
+    await screen.findByRole('button', { name: /Bug fix recipe/i })
     await user.click(screen.getByRole('button', { name: /use template/i }))
 
     await waitFor(() => {

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -516,7 +516,7 @@ describe('BoardPage From template action', () => {
     const trigger = await waitForBoard()
     const user = userEvent.setup()
     await user.click(trigger)
-    await user.click(await screen.findByText('Bug fix recipe'))
+    await screen.findByRole('button', { name: /Bug fix recipe/i })
     await user.click(screen.getByRole('button', { name: /use template/i }))
 
     await waitFor(() => {

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -500,7 +500,7 @@ describe('BoardPage From template action', () => {
     const trigger = await waitForBoard()
     const user = userEvent.setup()
     await user.click(trigger)
-    await user.click(await screen.findByText('Blank starter'))
+    await screen.findByRole('button', { name: /Blank starter/i })
     await user.click(screen.getByRole('button', { name: /use template/i }))
 
     await waitFor(() => {

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -50,25 +50,37 @@ vi.mock('../lib/templatesApi', () => ({
 }))
 
 // In-memory mock of the supabase tasks table. Tests can seed it via
-// `setMockTasks([...])` before rendering.
+// `setMockTasks([...])` before rendering. `inserts` accumulates every row
+// passed to `.insert()` so new tests can assert what was written.
 const supabaseHolder = vi.hoisted(() => ({
   tasks: [],
+  inserts: [],
   set(tasks) {
     this.tasks = tasks
+    this.inserts = []
   },
 }))
 
 vi.mock('../lib/supabase', () => {
   const makeQuery = () => {
-    const result = { data: supabaseHolder.tasks, error: null }
+    let pendingInsert = null
     const chain = {
       select: vi.fn(() => chain),
-      order: vi.fn(() => Promise.resolve(result)),
-      insert: vi.fn(() => chain),
+      order: vi.fn(() => Promise.resolve({ data: supabaseHolder.tasks, error: null })),
+      insert: vi.fn((row) => {
+        pendingInsert = row
+        supabaseHolder.inserts.push(row)
+        return chain
+      }),
       update: vi.fn(() => chain),
       delete: vi.fn(() => chain),
       eq: vi.fn(() => Promise.resolve({ error: null })),
-      single: vi.fn(() => Promise.resolve({ data: supabaseHolder.tasks[0] || null, error: null })),
+      single: vi.fn(() => {
+        const data = pendingInsert
+          ? { id: `task-new-${supabaseHolder.inserts.length}`, ...pendingInsert }
+          : (supabaseHolder.tasks[0] || null)
+        return Promise.resolve({ data, error: null })
+      }),
     }
     return chain
   }

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -435,6 +435,7 @@ describe('BoardPage From template action', () => {
     const trigger = await waitForBoard()
     await userEvent.setup().click(trigger)
 
+    expect(await screen.findByRole('heading', { name: /use a template/i })).toBeInTheDocument()
     expect(await screen.findByText('First template')).toBeInTheDocument()
     expect(screen.getByText('Second template')).toBeInTheDocument()
   })

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -428,7 +428,7 @@ describe('BoardPage From template action', () => {
   })
 
   it('opens the template selector modal and lists fetched templates on click', async () => {
-    fetchTemplates.mockResolvedValue([
+    fetchTemplates.mockResolvedValueOnce([
       makeTemplate({ id: 'tpl-a', name: 'First template' }),
       makeTemplate({ id: 'tpl-b', name: 'Second template' }),
     ])
@@ -436,10 +436,8 @@ describe('BoardPage From template action', () => {
     await userEvent.setup().click(trigger)
 
     expect(await screen.findByRole('heading', { name: /use a template/i })).toBeInTheDocument()
-    await new Promise((r) => setTimeout(r, 50))
-    screen.debug(undefined, 200000)
-    expect(await screen.findByText('First template')).toBeInTheDocument()
-    expect(screen.getByText('Second template')).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /First template/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Second template/i })).toBeInTheDocument()
   })
 
   it('shows the read-only preview pane when a template is selected', async () => {

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -441,18 +441,23 @@ describe('BoardPage From template action', () => {
   })
 
   it('shows the read-only preview pane when a template is selected', async () => {
-    fetchTemplates.mockResolvedValueOnce([makeTemplate()])
+    fetchTemplates.mockResolvedValueOnce([
+      makeTemplate({ id: 'tpl-a', name: 'First option', task_title: 'Wrong preview' }),
+      makeTemplate({ id: 'tpl-b', name: 'Bug fix recipe' }),
+    ])
     const trigger = await waitForBoard()
     const user = userEvent.setup()
     await user.click(trigger)
 
-    await user.click(await screen.findByText('Bug fix recipe'))
+    await user.click(await screen.findByRole('button', { name: /Bug fix recipe/i }))
 
-    // Preview surfaces both ticket fields and plan step content.
-    expect(screen.getAllByText('Fix the bug').length).toBeGreaterThan(0)
+    // Preview surfaces ticket fields and plan step content.
+    expect(screen.getByText('Fix the bug')).toBeInTheDocument()
     expect(screen.getByText('Describe how to reproduce')).toBeInTheDocument()
     expect(screen.getByText('Investigate the failing component')).toBeInTheDocument()
-    // Preview must be read-only — no editable inputs.
+    // The wrong template's title must NOT leak into the preview.
+    expect(screen.queryByText('Wrong preview')).not.toBeInTheDocument()
+    // Preview must be read-only — no editable inputs anywhere on the page yet.
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
   })
 

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -436,6 +436,8 @@ describe('BoardPage From template action', () => {
     await userEvent.setup().click(trigger)
 
     expect(await screen.findByRole('heading', { name: /use a template/i })).toBeInTheDocument()
+    await new Promise((r) => setTimeout(r, 50))
+    screen.debug(undefined, 200000)
     expect(await screen.findByText('First template')).toBeInTheDocument()
     expect(screen.getByText('Second template')).toBeInTheDocument()
   })

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -542,12 +542,12 @@ describe('BoardPage From template action', () => {
     const trigger = await waitForBoard()
     const user = userEvent.setup()
     await user.click(trigger)
-    await screen.findByText('Bug fix recipe')
+    await screen.findByRole('button', { name: /Bug fix recipe/i })
 
     await user.click(screen.getByRole('button', { name: /^cancel$/i }))
 
     await waitFor(() => {
-      expect(screen.queryByText('Bug fix recipe')).not.toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /use a template/i })).not.toBeInTheDocument()
     })
     expect(supabaseHolder.inserts.length).toBe(0)
   })

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -101,13 +101,15 @@ vi.mock('../lib/supabase', () => {
 
 import BoardPage from './BoardPage'
 import { renderWithProviders } from '../test/test-utils'
-import { insertTemplate } from '../lib/templatesApi'
+import { insertTemplate, fetchTemplates } from '../lib/templatesApi'
 
 beforeEach(() => {
   streamMock.stream.mockClear()
   streamMock.calls.length = 0
   supabaseHolder.set([])
   insertTemplate.mockClear()
+  fetchTemplates.mockClear()
+  fetchTemplates.mockResolvedValue([])
 })
 
 function makeTask(overrides = {}) {

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -391,3 +391,158 @@ describe('BoardPage Save as template action', () => {
     })
   })
 })
+
+describe('BoardPage From template action', () => {
+  function makeTemplate(overrides = {}) {
+    return {
+      id: 'tpl-1',
+      name: 'Bug fix recipe',
+      description: 'A reusable bug-fix template',
+      task_title: 'Fix the bug',
+      task_description: 'Describe how to reproduce',
+      plan: {
+        steps: [
+          {
+            id: 's1',
+            agent_id: 'frontend-developer',
+            agent_name: 'Frontend Developer',
+            agent_color: 'blue',
+            agent_icon: 'Monitor',
+            task: 'Investigate the failing component',
+          },
+        ],
+      },
+      ...overrides,
+    }
+  }
+
+  async function waitForBoard() {
+    renderWithProviders(<BoardPage />)
+    return await screen.findByRole('button', { name: /from template/i })
+  }
+
+  it('renders the + From template button alongside + Add task in the todo column', async () => {
+    await waitForBoard()
+    expect(screen.getByRole('button', { name: /^add task$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /from template/i })).toBeInTheDocument()
+  })
+
+  it('opens the template selector modal and lists fetched templates on click', async () => {
+    fetchTemplates.mockResolvedValueOnce([
+      makeTemplate({ id: 'tpl-a', name: 'First template' }),
+      makeTemplate({ id: 'tpl-b', name: 'Second template' }),
+    ])
+    const trigger = await waitForBoard()
+    await userEvent.setup().click(trigger)
+
+    expect(await screen.findByText('First template')).toBeInTheDocument()
+    expect(screen.getByText('Second template')).toBeInTheDocument()
+  })
+
+  it('shows the read-only preview pane when a template is selected', async () => {
+    fetchTemplates.mockResolvedValueOnce([makeTemplate()])
+    const trigger = await waitForBoard()
+    const user = userEvent.setup()
+    await user.click(trigger)
+
+    await user.click(await screen.findByText('Bug fix recipe'))
+
+    // Preview surfaces both ticket fields and plan step content.
+    expect(screen.getAllByText('Fix the bug').length).toBeGreaterThan(0)
+    expect(screen.getByText('Describe how to reproduce')).toBeInTheDocument()
+    expect(screen.getByText('Investigate the failing component')).toBeInTheDocument()
+    // Preview must be read-only — no editable inputs.
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('inserts an awaiting_approval task with the cloned plan and opens the panel on click of Use template', async () => {
+    const tpl = makeTemplate()
+    fetchTemplates.mockResolvedValueOnce([tpl])
+    const trigger = await waitForBoard()
+    const user = userEvent.setup()
+    await user.click(trigger)
+    await user.click(await screen.findByText('Bug fix recipe'))
+    await user.click(screen.getByRole('button', { name: /use template/i }))
+
+    await waitFor(() => {
+      expect(supabaseHolder.inserts.length).toBe(1)
+    })
+    const inserted = supabaseHolder.inserts[0]
+    expect(inserted.title).toBe('Fix the bug')
+    expect(inserted.description).toBe('Describe how to reproduce')
+    expect(inserted.status).toBe('awaiting_approval')
+    expect(inserted.plan).toEqual(tpl.plan)
+    expect(inserted.run_id).toBeNull()
+    expect(inserted.error_message).toBeNull()
+    expect(inserted.artifacts).toEqual([])
+
+    // Modal closed and the detail panel opened on the new ticket.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /use template/i })).not.toBeInTheDocument()
+    })
+    expect(await screen.findByText('TASK')).toBeInTheDocument()
+  })
+
+  it('lands the new ticket in todo when the chosen template has no plan', async () => {
+    const tpl = makeTemplate({
+      id: 'tpl-blank',
+      name: 'Blank starter',
+      task_title: 'Blank task',
+      plan: null,
+    })
+    fetchTemplates.mockResolvedValueOnce([tpl])
+    const trigger = await waitForBoard()
+    const user = userEvent.setup()
+    await user.click(trigger)
+    await user.click(await screen.findByText('Blank starter'))
+    await user.click(screen.getByRole('button', { name: /use template/i }))
+
+    await waitFor(() => {
+      expect(supabaseHolder.inserts.length).toBe(1)
+    })
+    expect(supabaseHolder.inserts[0].status).toBe('todo')
+    expect(supabaseHolder.inserts[0].plan).toBeNull()
+  })
+
+  it('does not mutate the source template plan when the new ticket plan is touched', async () => {
+    const tpl = makeTemplate()
+    fetchTemplates.mockResolvedValueOnce([tpl])
+    const trigger = await waitForBoard()
+    const user = userEvent.setup()
+    await user.click(trigger)
+    await user.click(await screen.findByText('Bug fix recipe'))
+    await user.click(screen.getByRole('button', { name: /use template/i }))
+
+    await waitFor(() => {
+      expect(supabaseHolder.inserts.length).toBe(1)
+    })
+    const insertedPlan = supabaseHolder.inserts[0].plan
+    insertedPlan.steps[0].task = 'mutated copy'
+    expect(tpl.plan.steps[0].task).toBe('Investigate the failing component')
+  })
+
+  it('keeps the existing + Add task inline form unchanged', async () => {
+    const trigger = await waitForBoard()
+    expect(trigger).toBeInTheDocument()
+    const addBtn = screen.getByRole('button', { name: /^add task$/i })
+    await userEvent.setup().click(addBtn)
+
+    expect(screen.getByPlaceholderText(/task title/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /use template/i })).not.toBeInTheDocument()
+  })
+
+  it('closes the modal on cancel without inserting anything', async () => {
+    fetchTemplates.mockResolvedValueOnce([makeTemplate()])
+    const trigger = await waitForBoard()
+    const user = userEvent.setup()
+    await user.click(trigger)
+    await screen.findByText('Bug fix recipe')
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Bug fix recipe')).not.toBeInTheDocument()
+    })
+    expect(supabaseHolder.inserts.length).toBe(0)
+  })
+})

--- a/src/components/TemplateSelectorModal.jsx
+++ b/src/components/TemplateSelectorModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { X, LayoutTemplate, Loader2, Inbox } from 'lucide-react'
 import { fetchTemplates } from '../lib/templatesApi'
 

--- a/src/components/TemplateSelectorModal.jsx
+++ b/src/components/TemplateSelectorModal.jsx
@@ -91,9 +91,6 @@ export default function TemplateSelectorModal({ onClose, onUseTemplate }) {
   const [error, setError] = useState(null)
   const [selectedId, setSelectedId] = useState(null)
   const [using, setUsing] = useState(false)
-  const closeRef = useRef(onClose)
-
-  useEffect(() => { closeRef.current = onClose }, [onClose])
 
   useEffect(() => {
     let cancelled = false
@@ -113,10 +110,10 @@ export default function TemplateSelectorModal({ onClose, onUseTemplate }) {
   }, [])
 
   useEffect(() => {
-    const handleKey = (e) => { if (e.key === 'Escape' && !using) closeRef.current?.() }
+    const handleKey = (e) => { if (e.key === 'Escape' && !using) onClose() }
     window.addEventListener('keydown', handleKey)
     return () => window.removeEventListener('keydown', handleKey)
-  }, [using])
+  }, [using, onClose])
 
   const selected = useMemo(
     () => templates.find((tpl) => tpl.id === selectedId) || null,

--- a/src/components/TemplateSelectorModal.jsx
+++ b/src/components/TemplateSelectorModal.jsx
@@ -1,0 +1,228 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { X, LayoutTemplate, Loader2, Inbox } from 'lucide-react'
+import { fetchTemplates } from '../lib/templatesApi'
+
+function describeStepCount(plan) {
+  if (!plan || !Array.isArray(plan.steps) || plan.steps.length === 0) return 'No plan'
+  const n = plan.steps.length
+  return `${n} ${n === 1 ? 'step' : 'steps'}`
+}
+
+function PreviewPane({ template }) {
+  if (!template) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center text-text-muted text-sm gap-2 px-6 text-center">
+        <Inbox size={28} className="opacity-40" />
+        Pick a template on the left to preview it here.
+      </div>
+    )
+  }
+
+  const steps = template.plan?.steps || []
+
+  return (
+    <div className="flex-1 overflow-y-auto px-5 py-5 space-y-5">
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-1">
+          Template
+        </p>
+        <h3 className="text-base font-semibold text-text-primary">{template.name}</h3>
+        {template.description && (
+          <p className="text-sm text-text-secondary mt-1 leading-relaxed">{template.description}</p>
+        )}
+      </div>
+
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-1">
+          Ticket title
+        </p>
+        <p className="text-sm text-text-primary">{template.task_title || '—'}</p>
+      </div>
+
+      {template.task_description && (
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-1">
+            Ticket description
+          </p>
+          <p className="text-sm text-text-secondary leading-relaxed whitespace-pre-wrap">
+            {template.task_description}
+          </p>
+        </div>
+      )}
+
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-2">
+          Execution plan ({steps.length} {steps.length === 1 ? 'step' : 'steps'})
+        </p>
+        {steps.length === 0 ? (
+          <p className="text-xs text-text-muted">
+            No plan attached — the new ticket will land in Todo so you can plan from scratch.
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {steps.map((step, idx) => (
+              <li
+                key={step.id ?? idx}
+                className="rounded-xl bg-bg-input border border-border-subtle px-3 py-2.5"
+              >
+                <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider text-text-muted">
+                  <span className="font-mono">Step {idx + 1}</span>
+                  {step.agent_name && (
+                    <span className="px-1.5 py-0.5 rounded bg-bg-card text-text-secondary">
+                      {step.agent_name}
+                    </span>
+                  )}
+                </div>
+                {step.task && (
+                  <p className="text-sm text-text-primary mt-1.5 leading-relaxed">{step.task}</p>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function TemplateSelectorModal({ onClose, onUseTemplate }) {
+  const [templates, setTemplates] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [selectedId, setSelectedId] = useState(null)
+  const [using, setUsing] = useState(false)
+  const closeRef = useRef(onClose)
+
+  useEffect(() => { closeRef.current = onClose }, [onClose])
+
+  useEffect(() => {
+    let cancelled = false
+    fetchTemplates()
+      .then((rows) => {
+        if (cancelled) return
+        const list = Array.isArray(rows) ? rows : []
+        setTemplates(list)
+        if (list.length > 0) setSelectedId(list[0].id)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(err?.message || 'Failed to load templates')
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    const handleKey = (e) => { if (e.key === 'Escape' && !using) closeRef.current?.() }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [using])
+
+  const selected = useMemo(
+    () => templates.find((tpl) => tpl.id === selectedId) || null,
+    [templates, selectedId],
+  )
+
+  const handleUse = async () => {
+    if (!selected || using) return
+    setUsing(true)
+    try {
+      await onUseTemplate(selected)
+    } catch {
+      setUsing(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
+      onClick={() => { if (!using) onClose() }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-3xl mx-4 max-h-[80vh] rounded-2xl bg-bg-sidebar border border-border-subtle shadow-2xl flex flex-col"
+      >
+        <div className="h-12 border-b border-border-subtle px-5 flex items-center justify-between shrink-0">
+          <h2 className="text-sm font-semibold text-text-primary">Use a template</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={using}
+            className="p-1.5 rounded-lg hover:bg-bg-input text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex-1 min-h-0 flex">
+          <div className="w-64 border-r border-border-subtle overflow-y-auto py-2">
+            {loading ? (
+              <div className="flex items-center justify-center py-8 text-text-muted text-xs">
+                <Loader2 size={14} className="animate-spin mr-2" />
+                Loading...
+              </div>
+            ) : error ? (
+              <div className="px-4 py-4 text-xs text-rose-300" role="alert">{error}</div>
+            ) : templates.length === 0 ? (
+              <div className="px-4 py-6 text-xs text-text-muted text-center">
+                No templates yet. Save a board ticket as a template first.
+              </div>
+            ) : (
+              <ul className="space-y-0.5 px-2">
+                {templates.map((tpl) => {
+                  const active = tpl.id === selectedId
+                  return (
+                    <li key={tpl.id}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedId(tpl.id)}
+                        className={`w-full text-left px-3 py-2 rounded-lg flex flex-col gap-0.5 transition-colors ${
+                          active
+                            ? 'bg-blue-500/10 border border-blue-500/30'
+                            : 'border border-transparent hover:bg-white/5'
+                        }`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <LayoutTemplate size={12} className="text-purple-400 shrink-0" />
+                          <span className="text-sm text-text-primary truncate">{tpl.name}</span>
+                        </div>
+                        <span className="text-[10px] text-text-muted ml-5">
+                          {describeStepCount(tpl.plan)}
+                        </span>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="flex-1 min-w-0 flex flex-col">
+            <PreviewPane template={selected} />
+          </div>
+        </div>
+
+        <div className="border-t border-border-subtle px-5 py-3 shrink-0 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={using}
+            className="px-3 py-1.5 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-white/5 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleUse}
+            disabled={!selected || using}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {using && <Loader2 size={12} className="animate-spin" />}
+            Use template
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #252

## Summary

Adds the "From template" instantiation flow on the Kanban board:

- New `+ From template` button in the `todo` column (alongside the existing `+ Add task` inline form, which is unchanged).
- New `TemplateSelectorModal.jsx`: two-pane layout (templates list left, read-only preview right). Auto-selects the first template; lists name + step count; preview surfaces template name/description, ticket title/description, and the full plan with each step's agent label and task text.
- "Use template" clones via the pure helper `cloneTemplateToTask` (from #247): `awaiting_approval` when a plan exists, `todo` when null. Inserts the row, closes the modal, and opens `TaskDetailPanel` on the new ticket.
- Clone-and-detach: deep-copied plan, zeroed `run_id` / `error_message` / `artifacts`. Mutating the new ticket's plan does not touch the source template.

## TDD

- Tests added: `src/components/BoardPage.test.jsx` — new `BoardPage From template action` block (8 tests).
- Test infra change: extended the inline supabase mock in `BoardPage.test.jsx` to capture every `.insert()` row in `supabaseHolder.inserts` and to return the captured row (with a synthetic id) from `.single()`. This lets the test assert both the inserted snapshot AND the panel opening on the new ticket.
- Before implementation (red): all 8 new tests failed because no `+ From template` button or selector modal existed.
- After implementation (green): full suite green — `33 passed (33)` for `BoardPage.test.jsx`, `384 passed (384)` for the whole frontend suite.

## Notes

- No regression: `+ Add task` inline form is byte-identical to before; existing `BoardPage Re-plan button` and `BoardPage Save as template action` test blocks are unchanged and still green.
- `npm run lint` reports `0 errors, 26 warnings` — all warnings are pre-existing in untouched files.