### PR TITLE
feat: missing-agent and missing-tool warnings on tickets and template cards

### DIFF
--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -416,7 +416,7 @@ function TaskDetailPanel({ task, agents, tools, onUpdate, onDelete, onClose }) {
           {task.status === 'awaiting_approval' && (
             <button
               onClick={() => orch.approve(stepAnswers)}
-              disabled={missingRequired > 0}
+              disabled={missingRequired > 0 || missingAgents.length > 0}
               className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Play size={12} />

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -242,6 +242,8 @@ function TaskDetailPanel({ task, agents, tools, onUpdate, onDelete, onClose }) {
   const isExecutionPhase = ['planning', 'awaiting_approval', 'executing', 'done', 'error', 'cancelled'].includes(task.status)
   const plan = task.plan
   const missingRequired = plan ? countMissingRequired(plan, stepAnswers) : 0
+  const missingAgents = plan ? findMissingAgents(plan, agents) : []
+  const missingTools = plan ? findMissingTools(plan, tools) : []
   const downloadableSteps = plan ? collectDownloadableSteps(plan, orch.stepStates) : []
   const badge = STATUS_BADGES[task.status]
 

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -9,7 +9,7 @@ import { supabase } from '../lib/supabase'
 import { useData } from '../context/DataContext'
 import { useTaskOrchestration } from '../lib/taskOrchestration'
 import { insertTemplate } from '../lib/templatesApi'
-import { cloneTemplateToTask } from '../lib/templates'
+import { cloneTemplateToTask, findMissingAgents, findMissingTools } from '../lib/templates'
 import SaveAsTemplateModal from './SaveAsTemplateModal'
 import TemplateSelectorModal from './TemplateSelectorModal'
 import {

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -301,6 +301,35 @@ function TaskDetailPanel({ task, agents, tools, onUpdate, onDelete, onClose }) {
             </div>
           )}
 
+          {/* Missing-reference warnings */}
+          {isExecutionPhase && plan && (missingAgents.length > 0 || missingTools.length > 0) && (
+            <div className="px-4 py-3 rounded-lg bg-amber-500/10 border border-amber-500/20 space-y-2">
+              {missingAgents.length > 0 && (
+                <div className="flex items-start gap-2">
+                  <AlertCircle size={14} className="text-amber-400 shrink-0 mt-0.5" />
+                  <div className="text-xs text-amber-200 leading-relaxed">
+                    <p className="font-medium">
+                      Missing agent{missingAgents.length === 1 ? '' : 's'}:{' '}
+                      <span className="font-mono">{missingAgents.join(', ')}</span>
+                    </p>
+                    <p className="text-amber-200/80 mt-0.5">
+                      Edit each step's agent or click Re-plan to refresh the plan against the current catalog.
+                    </p>
+                  </div>
+                </div>
+              )}
+              {missingTools.length > 0 && (
+                <div className="flex items-start gap-2 text-[11px] text-amber-200/80">
+                  <span className="shrink-0 mt-0.5">·</span>
+                  <p>
+                    Missing tool{missingTools.length === 1 ? '' : 's'} (run will continue without):{' '}
+                    <span className="font-mono">{missingTools.join(', ')}</span>
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
           {/* Plan section */}
           {isExecutionPhase && plan && (
             <div>

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -102,6 +102,7 @@ vi.mock('../lib/supabase', () => {
 import BoardPage from './BoardPage'
 import { renderWithProviders } from '../test/test-utils'
 import { insertTemplate, fetchTemplates } from '../lib/templatesApi'
+import { fetchAgents, fetchTools } from '../lib/api'
 
 beforeEach(() => {
   streamMock.stream.mockClear()
@@ -110,6 +111,8 @@ beforeEach(() => {
   insertTemplate.mockClear()
   fetchTemplates.mockClear()
   fetchTemplates.mockResolvedValue([])
+  fetchAgents.mockResolvedValue([])
+  fetchTools.mockResolvedValue([])
 })
 
 function makeTask(overrides = {}) {

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -624,6 +624,8 @@ describe('BoardPage missing-agent and missing-tool warnings', () => {
     await openTaskDetail(makeTaskWithTools())
 
     expect(await screen.findByText(/missing tool/i)).toBeInTheDocument()
-    expect(screen.getByText(/create_github_issue/)).toBeInTheDocument()
+    // "create_github_issue" appears in the per-step tool chip too, so just
+    // assert the warning region adds (at least) one more occurrence.
+    expect(screen.getAllByText(/create_github_issue/).length).toBeGreaterThanOrEqual(2)
   })
 })

--- a/src/components/BoardPage.test.jsx
+++ b/src/components/BoardPage.test.jsx
@@ -555,3 +555,75 @@ describe('BoardPage From template action', () => {
     expect(supabaseHolder.inserts.length).toBe(0)
   })
 })
+
+describe('BoardPage missing-agent and missing-tool warnings', () => {
+  function makeTaskWithTools(overrides = {}) {
+    return makeTask({
+      status: 'awaiting_approval',
+      plan: {
+        steps: [
+          {
+            id: 's1',
+            agent_id: 'frontend-developer',
+            agent_name: 'Frontend Developer',
+            agent_color: 'blue',
+            agent_icon: 'Monitor',
+            task: 'Implement the UI',
+            tools_used: ['create_github_issue'],
+          },
+        ],
+      },
+      ...overrides,
+    })
+  }
+
+  it('renders a banner listing missing agent_ids when the plan references an unknown agent', async () => {
+    // Agents catalog is empty, so frontend-developer is missing.
+    await openTaskDetail(makeTask({ status: 'awaiting_approval' }))
+
+    expect(await screen.findByText(/missing agent/i)).toBeInTheDocument()
+    expect(screen.getByText(/frontend-developer/)).toBeInTheDocument()
+  })
+
+  it('does not render the missing-agent banner when every agent in the plan resolves', async () => {
+    fetchAgents.mockResolvedValueOnce([
+      { id: 'frontend-developer', name: 'Frontend Developer' },
+    ])
+
+    await openTaskDetail(makeTask({ status: 'awaiting_approval' }))
+    await screen.findByRole('button', { name: /approve & run/i })
+
+    expect(screen.queryByText(/missing agent/i)).not.toBeInTheDocument()
+  })
+
+  it('disables Approve & run while any step references a missing agent_id', async () => {
+    await openTaskDetail(makeTask({ status: 'awaiting_approval' }))
+
+    const approve = await screen.findByRole('button', { name: /approve & run/i })
+    expect(approve).toBeDisabled()
+  })
+
+  it('keeps Approve & run enabled when only a tool is missing from the catalog', async () => {
+    fetchAgents.mockResolvedValueOnce([
+      { id: 'frontend-developer', name: 'Frontend Developer' },
+    ])
+    fetchTools.mockResolvedValueOnce([])
+
+    await openTaskDetail(makeTaskWithTools())
+
+    const approve = await screen.findByRole('button', { name: /approve & run/i })
+    expect(approve).toBeEnabled()
+  })
+
+  it('renders a softer, separate warning listing missing tool ids', async () => {
+    fetchAgents.mockResolvedValueOnce([
+      { id: 'frontend-developer', name: 'Frontend Developer' },
+    ])
+    fetchTools.mockResolvedValueOnce([])
+
+    await openTaskDetail(makeTaskWithTools())
+
+    expect(await screen.findByText(/missing tool/i)).toBeInTheDocument()
+    expect(screen.getByText(/create_github_issue/)).toBeInTheDocument()
+  })
+})

--- a/src/components/TemplateCard.jsx
+++ b/src/components/TemplateCard.jsx
@@ -9,16 +9,13 @@ function describePlan(plan) {
   return `${count} ${count === 1 ? 'step' : 'steps'}`
 }
 
-function countStepsWithMissingAgents(plan, missingAgentIds) {
-  if (!plan || !Array.isArray(plan.steps) || missingAgentIds.length === 0) return 0
-  const missingSet = new Set(missingAgentIds)
-  return plan.steps.filter((step) => missingSet.has(step?.agent_id)).length
-}
-
 export default function TemplateCard({ template, agents = [], onClick }) {
   const planLabel = describePlan(template.plan)
   const missingAgents = findMissingAgents(template.plan, agents)
-  const stepsNeedingAttention = countStepsWithMissingAgents(template.plan, missingAgents)
+  const missingSet = new Set(missingAgents)
+  const stepsNeedingAttention = (template.plan?.steps || []).filter(
+    (step) => missingSet.has(step?.agent_id),
+  ).length
 
   return (
     <button

--- a/src/components/TemplateCard.jsx
+++ b/src/components/TemplateCard.jsx
@@ -1,4 +1,5 @@
-import { LayoutTemplate } from 'lucide-react'
+import { AlertTriangle, LayoutTemplate } from 'lucide-react'
+import { findMissingAgents } from '../lib/templates'
 
 function describePlan(plan) {
   if (!plan || !Array.isArray(plan.steps) || plan.steps.length === 0) {
@@ -8,8 +9,16 @@ function describePlan(plan) {
   return `${count} ${count === 1 ? 'step' : 'steps'}`
 }
 
-export default function TemplateCard({ template, onClick }) {
+function countStepsWithMissingAgents(plan, missingAgentIds) {
+  if (!plan || !Array.isArray(plan.steps) || missingAgentIds.length === 0) return 0
+  const missingSet = new Set(missingAgentIds)
+  return plan.steps.filter((step) => missingSet.has(step?.agent_id)).length
+}
+
+export default function TemplateCard({ template, agents = [], onClick }) {
   const planLabel = describePlan(template.plan)
+  const missingAgents = findMissingAgents(template.plan, agents)
+  const stepsNeedingAttention = countStepsWithMissingAgents(template.plan, missingAgents)
 
   return (
     <button
@@ -32,6 +41,13 @@ export default function TemplateCard({ template, onClick }) {
         <p className="text-xs leading-relaxed text-text-secondary mb-4 flex-1 line-clamp-3">
           {template.description}
         </p>
+      )}
+
+      {stepsNeedingAttention > 0 && (
+        <div className="mb-3 inline-flex items-center self-start gap-1.5 px-2 py-1 rounded-md bg-amber-500/10 border border-amber-500/20 text-[10px] font-medium text-amber-300">
+          <AlertTriangle size={11} />
+          {stepsNeedingAttention} {stepsNeedingAttention === 1 ? 'step needs' : 'steps need'} attention
+        </div>
       )}
 
       <div className="mt-auto pt-3 border-t border-border-subtle/50 flex items-center justify-between text-xs text-text-muted">

--- a/src/components/TemplatesPage.jsx
+++ b/src/components/TemplatesPage.jsx
@@ -4,6 +4,7 @@ import Header from './Header'
 import TemplateCard from './TemplateCard'
 import CreateTemplateModal from './CreateTemplateModal'
 import TemplateEditDrawer from './TemplateEditDrawer'
+import { useData } from '../context/DataContext'
 import {
   fetchTemplates,
   insertTemplate,
@@ -17,6 +18,7 @@ export default function TemplatesPage() {
   const [error, setError] = useState(null)
   const [createOpen, setCreateOpen] = useState(false)
   const [selectedId, setSelectedId] = useState(null)
+  const { agents } = useData()
 
   useEffect(() => {
     let cancelled = false

--- a/src/components/TemplatesPage.jsx
+++ b/src/components/TemplatesPage.jsx
@@ -110,6 +110,7 @@ export default function TemplatesPage() {
               <TemplateCard
                 key={template.id}
                 template={template}
+                agents={agents}
                 onClick={() => setSelectedId(template.id)}
               />
             ))}

--- a/src/components/TemplatesPage.test.jsx
+++ b/src/components/TemplatesPage.test.jsx
@@ -11,6 +11,8 @@ vi.mock('../lib/api', () => ({
   trackAgentUsage: vi.fn().mockResolvedValue(null),
 }))
 
+import { fetchAgents } from '../lib/api'
+
 vi.mock('../lib/templatesApi', () => ({
   fetchTemplates: vi.fn(),
   insertTemplate: vi.fn(),

--- a/src/components/TemplatesPage.test.jsx
+++ b/src/components/TemplatesPage.test.jsx
@@ -484,4 +484,42 @@ describe('TemplatesPage', () => {
       expect(await screen.findByRole('button', { name: /^delete template$/i })).toBeInTheDocument()
     })
   })
+
+  describe('Missing-agent pill on template cards', () => {
+    const templateWithMissingAgent = {
+      id: 'tpl-broken',
+      name: 'Broken template',
+      description: 'Plan refs a missing agent',
+      task_title: 'Do work',
+      task_description: '',
+      plan: {
+        steps: [
+          { id: 1, agent_id: 'ghost-agent', agent_name: 'Ghost', task: 'A' },
+          { id: 2, agent_id: 'frontend-developer', agent_name: 'Frontend Dev', task: 'B' },
+        ],
+      },
+    }
+
+    it('renders a "needs attention" pill when a template plan references a missing agent', async () => {
+      fetchAgents.mockResolvedValueOnce([
+        { id: 'frontend-developer', name: 'Frontend Developer' },
+      ])
+      fetchTemplates.mockResolvedValue([templateWithMissingAgent])
+      renderWithProviders(<TemplatesPage />)
+
+      expect(await screen.findByText(/needs? attention/i)).toBeInTheDocument()
+    })
+
+    it('does not render the pill when every agent referenced by the plan resolves', async () => {
+      fetchAgents.mockResolvedValueOnce([
+        { id: 'frontend-developer', name: 'Frontend Developer' },
+        { id: 'ghost-agent', name: 'Ghost' },
+      ])
+      fetchTemplates.mockResolvedValue([templateWithMissingAgent])
+      renderWithProviders(<TemplatesPage />)
+
+      await screen.findByText('Broken template')
+      expect(screen.queryByText(/needs? attention/i)).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/TemplatesPage.test.jsx
+++ b/src/components/TemplatesPage.test.jsx
@@ -49,6 +49,12 @@ describe('TemplatesPage', () => {
   })
 
   it('renders one card per template, each showing name and step count', async () => {
+    // Seed every referenced agent so the missing-agent pill does not appear
+    // and the only "2 steps" text on the card is the plan-summary label.
+    fetchAgents.mockResolvedValueOnce([
+      { id: 'a', name: 'Agent A' },
+      { id: 'b', name: 'Agent B' },
+    ])
     fetchTemplates.mockResolvedValue([
       {
         id: 'tpl-1',


### PR DESCRIPTION
Closes #253

## TDD
- Tests added: `src/components/BoardPage.test.jsx` (new `BoardPage missing-agent and missing-tool warnings` describe block, 5 tests), `src/components/TemplatesPage.test.jsx` (new `Missing-agent pill on template cards` describe block, 2 tests).
- Tests modified: 1 pre-existing TemplatesPage test seeded the agents catalog so the new pill does not collide with `/2 steps/i`.
- Before implementation (red): 4 of the 7 new assertions failed — banner not rendered, Approve button not disabled, soft tool warning not rendered, pill not rendered. The 3 negative-case tests passed trivially because the feature was absent.
- After implementation (green): all 391 frontend tests pass (`npm test`), `npm run lint` reports 0 errors (26 pre-existing warnings unchanged).

## Changes
- `src/components/TemplateCard.jsx` — accepts an `agents` prop and renders an amber `AlertTriangle` pill ("X step(s) need attention") when `findMissingAgents` is non-empty for the template's plan. Pill is purely informational; the card stays clickable.
- `src/components/TemplatesPage.jsx` — pulls `agents` from `useData()` and forwards it to each `TemplateCard`.
- `src/components/BoardPage.jsx` (`TaskDetailPanel`) — computes `missingAgents` and `missingTools` from the helpers shipped in #247, renders a single warning region above the plan with a strong line for missing agents and a softer line for missing tools, and adds `missingAgents.length > 0` to the Approve button's `disabled` predicate (combined with the existing `missingRequired > 0` gate via `||`). Tool gaps never disable the run.
- No new pure-helper functions added — the slice consumes `findMissingAgents` and `findMissingTools` exactly as #247 shipped them.

## Notes
- The PR contains many `auto: update …` commits because the repo's auto-commit hook commits on every save. They will collapse into a single Conventional Commits message on squash-merge to `dev`.