### PR TITLE
feat(push): sendPush helper with VAPID + 410-gone cleanup (#229)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,3 +10,11 @@ WHATSAPP_PHONE=
 # Optional: customize the WhatsApp message sent when Ralph starts.
 # Defaults to "🟢 Ralph started and is active." when unset.
 # RALPH_STARTUP_MESSAGE=
+
+# --- Web Push (mobile shell at /mobile) ---
+# Public VAPID key used by the browser to subscribe via PushManager. Not a
+# secret — it is shipped in the frontend bundle. Generate the pair once with
+# `npx web-push generate-vapid-keys`. The matching private key is set as a
+# Supabase Edge Function secret (`VAPID_PRIVATE_KEY`) and never lives here.
+# See README → "Push notifications setup" for full provisioning steps.
+VITE_VAPID_PUBLIC_KEY=

--- a/README.md
+++ b/README.md
@@ -75,3 +75,41 @@ Per-iteration logs land in `logs/ralph-issue-N.log` (gitignored). They are never
 ### Excluding issues from Ralph
 
 Add the label `claude-working` or `claude-failed` to any issue manually to make Ralph skip it. Remove the label later if you want it back in the queue.
+
+## Push notifications setup
+
+The mobile shell at `/mobile` (PRD #224) uses Web Push to notify users when long-running agent runs need approval, finish, or error. Push delivery is handled by the `sendPush` helper in `supabase/functions/_shared/push.ts`, which signs each request with VAPID. Keys are generated **once** and never rotated unless compromised.
+
+### One-time VAPID key generation
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Output:
+
+```
+=======================================
+Public Key:
+B...long-base64url-string...
+
+Private Key:
+...shorter-base64url-string...
+=======================================
+```
+
+### Where the keys go
+
+| Variable | Scope | Set in | Notes |
+|---|---|---|---|
+| `VITE_VAPID_PUBLIC_KEY` | Frontend bundle | Vercel project env vars (and `.env.local` for local dev) | Shipped to the browser so `pushManager.subscribe` can include it as `applicationServerKey`. Not a secret. |
+| `VAPID_PRIVATE_KEY` | Edge Function only | `supabase secrets set VAPID_PRIVATE_KEY=...` | **Secret.** Used by `sendPush` to sign each Web Push request. Never expose to the frontend. |
+| `VAPID_SUBJECT` | Edge Function only | `supabase secrets set VAPID_SUBJECT=mailto:lucasfe@gmail.com` | Required by VAPID. Use a `mailto:` URL the push provider can contact about delivery issues. |
+
+### Behaviour without keys
+
+`sendPush` is fail-safe: if any of the three values is missing it logs an error and returns `{ sent: 0, deleted: 0 }` without crashing the caller. The chat function (slice 8) can therefore be deployed before the keys are provisioned and will simply skip notifications until they exist.
+
+### Rotation
+
+If the keys leak, regenerate with `npx web-push generate-vapid-keys` and update both the Vercel `VITE_VAPID_PUBLIC_KEY` and the Supabase `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` secrets. The new public key invalidates every existing subscription — clients will re-subscribe on next visit.

--- a/supabase/functions/_shared/push.test.ts
+++ b/supabase/functions/_shared/push.test.ts
@@ -1,0 +1,415 @@
+// deno-lint-ignore-file no-explicit-any
+import { assert, assertEquals } from 'jsr:@std/assert@1'
+import { sendPush } from './push.ts'
+
+interface Sub {
+  id: string
+  endpoint: string
+  p256dh: string
+  auth: string
+}
+
+function makeSupabase(opts: {
+  subscriptions?: Sub[]
+  loadError?: unknown
+  deleteError?: unknown
+}) {
+  const calls: {
+    selects: { table: string; userId?: string }[]
+    deletes: { id: string }[]
+  } = { selects: [], deletes: [] }
+  const subs = opts.subscriptions ?? []
+  const client = {
+    from(table: string) {
+      return {
+        select(_cols: string) {
+          return {
+            eq(_col: string, val: string) {
+              calls.selects.push({ table, userId: val })
+              return Promise.resolve({
+                data: subs,
+                error: opts.loadError ?? null,
+              })
+            },
+          }
+        },
+        delete() {
+          return {
+            eq(_col: string, val: string) {
+              calls.deletes.push({ id: val })
+              return Promise.resolve({
+                data: null,
+                error: opts.deleteError ?? null,
+              })
+            },
+          }
+        },
+      }
+    },
+  }
+  return { calls, client }
+}
+
+type SendOutcome = { ok: true } | { error: { statusCode?: number; message?: string } }
+
+function makeWebPush(opts: {
+  resultByEndpoint?: Record<string, SendOutcome>
+  defaultResult?: SendOutcome
+}) {
+  const calls: {
+    vapid: { subject: string; publicKey: string; privateKey: string }[]
+    sends: { endpoint: string; keys: any; payload: string }[]
+  } = { vapid: [], sends: [] }
+  const client = {
+    setVapidDetails(subject: string, publicKey: string, privateKey: string) {
+      calls.vapid.push({ subject, publicKey, privateKey })
+    },
+    sendNotification(sub: any, payload: string) {
+      calls.sends.push({ endpoint: sub.endpoint, keys: sub.keys, payload })
+      const outcome =
+        opts.resultByEndpoint?.[sub.endpoint] ?? opts.defaultResult ?? { ok: true }
+      if ('error' in outcome) {
+        return Promise.reject(outcome.error)
+      }
+      return Promise.resolve({ statusCode: 201 })
+    },
+  }
+  return { calls, client }
+}
+
+const VAPID = {
+  vapidSubject: 'mailto:test@example.com',
+  vapidPublicKey: 'PUB',
+  vapidPrivateKey: 'PRIV',
+}
+
+function makeLogger() {
+  const errors: { msg: string; args: unknown[] }[] = []
+  return {
+    errors,
+    logger: {
+      error(msg: string, ...args: unknown[]) {
+        errors.push({ msg, args })
+      },
+    },
+  }
+}
+
+Deno.test('sendPush — no subscriptions returns { sent: 0, deleted: 0 }', async () => {
+  const supabase = makeSupabase({ subscriptions: [] })
+  const webpush = makeWebPush({})
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'user-1',
+    title: 'Hello',
+    body: 'World',
+    deepLink: '/mobile/chat',
+    ...VAPID,
+    webpushClient: webpush.client,
+  })
+  assertEquals(result, { sent: 0, deleted: 0 })
+  assertEquals(webpush.calls.sends.length, 0)
+})
+
+Deno.test('sendPush — single subscription success', async () => {
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 'sub-a', endpoint: 'https://fcm.googleapis.com/abc', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({ defaultResult: { ok: true } })
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'user-1',
+    title: 'Hello',
+    body: 'World',
+    deepLink: '/mobile/chat',
+    ...VAPID,
+    webpushClient: webpush.client,
+  })
+  assertEquals(result, { sent: 1, deleted: 0 })
+  assertEquals(webpush.calls.sends.length, 1)
+})
+
+Deno.test('sendPush — multiple subscriptions all succeed', async () => {
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 'sub-a', endpoint: 'https://a', p256dh: 'pk', auth: 'au' },
+      { id: 'sub-b', endpoint: 'https://b', p256dh: 'pk', auth: 'au' },
+      { id: 'sub-c', endpoint: 'https://c', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({ defaultResult: { ok: true } })
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'user-1',
+    title: 'Hi',
+    body: 'B',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+  })
+  assertEquals(result, { sent: 3, deleted: 0 })
+  assertEquals(webpush.calls.sends.length, 3)
+})
+
+Deno.test('sendPush — 410 Gone deletes the subscription row', async () => {
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 'sub-good', endpoint: 'https://good', p256dh: 'pk', auth: 'au' },
+      { id: 'sub-gone', endpoint: 'https://gone', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({
+    resultByEndpoint: {
+      'https://good': { ok: true },
+      'https://gone': { error: { statusCode: 410, message: 'Gone' } },
+    },
+  })
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'user-1',
+    title: 'Hi',
+    body: 'B',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+  })
+  assertEquals(result, { sent: 1, deleted: 1 })
+  assertEquals(supabase.calls.deletes, [{ id: 'sub-gone' }])
+})
+
+Deno.test('sendPush — 404 also deletes the subscription row', async () => {
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 'sub-x', endpoint: 'https://x', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({
+    resultByEndpoint: { 'https://x': { error: { statusCode: 404 } } },
+  })
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'user-1',
+    title: 'Hi',
+    body: 'B',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+  })
+  assertEquals(result, { sent: 0, deleted: 1 })
+  assertEquals(supabase.calls.deletes, [{ id: 'sub-x' }])
+})
+
+Deno.test('sendPush — non-410 errors are logged and do not delete', async () => {
+  const { errors, logger } = makeLogger()
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 'sub-1', endpoint: 'https://x', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({
+    resultByEndpoint: { 'https://x': { error: { statusCode: 500, message: 'boom' } } },
+  })
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'user-1',
+    title: 'Hi',
+    body: 'B',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+    logger,
+  })
+  assertEquals(result, { sent: 0, deleted: 0 })
+  assertEquals(supabase.calls.deletes.length, 0)
+  assert(errors.length > 0, 'expected at least one error log')
+})
+
+Deno.test('sendPush — network error (no statusCode) logged and continues', async () => {
+  const { errors, logger } = makeLogger()
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 'sub-1', endpoint: 'https://a', p256dh: 'pk', auth: 'au' },
+      { id: 'sub-2', endpoint: 'https://b', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({
+    resultByEndpoint: {
+      'https://a': { error: { message: 'network down' } },
+      'https://b': { ok: true },
+    },
+  })
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'user-1',
+    title: 'Hi',
+    body: 'B',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+    logger,
+  })
+  assertEquals(result, { sent: 1, deleted: 0 })
+  assertEquals(supabase.calls.deletes.length, 0)
+  assert(errors.length > 0, 'expected at least one error log')
+})
+
+Deno.test('sendPush — payload JSON includes title, body, deepLink', async () => {
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 's', endpoint: 'https://x', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({ defaultResult: { ok: true } })
+  await sendPush({
+    supabase: supabase.client,
+    userId: 'u',
+    title: 'Run finished',
+    body: '5 steps',
+    deepLink: '/mobile/chat?session=42',
+    ...VAPID,
+    webpushClient: webpush.client,
+  })
+  assertEquals(webpush.calls.sends.length, 1)
+  const payload = JSON.parse(webpush.calls.sends[0].payload)
+  assertEquals(payload, {
+    title: 'Run finished',
+    body: '5 steps',
+    deepLink: '/mobile/chat?session=42',
+  })
+})
+
+Deno.test('sendPush — VAPID details applied with subject and keys', async () => {
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 's', endpoint: 'https://x', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({ defaultResult: { ok: true } })
+  await sendPush({
+    supabase: supabase.client,
+    userId: 'u',
+    title: 't',
+    body: 'b',
+    deepLink: '/m',
+    vapidSubject: 'mailto:lucasfe@gmail.com',
+    vapidPublicKey: 'PUB123',
+    vapidPrivateKey: 'PRIV123',
+    webpushClient: webpush.client,
+  })
+  assertEquals(webpush.calls.vapid, [
+    { subject: 'mailto:lucasfe@gmail.com', publicKey: 'PUB123', privateKey: 'PRIV123' },
+  ])
+})
+
+Deno.test('sendPush — passes subscription endpoint and keys to webpush', async () => {
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 's', endpoint: 'https://endpoint.test', p256dh: 'pk-val', auth: 'auth-val' },
+    ],
+  })
+  const webpush = makeWebPush({ defaultResult: { ok: true } })
+  await sendPush({
+    supabase: supabase.client,
+    userId: 'u',
+    title: 't',
+    body: 'b',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+  })
+  const call = webpush.calls.sends[0]
+  assertEquals(call.endpoint, 'https://endpoint.test')
+  assertEquals(call.keys, { p256dh: 'pk-val', auth: 'auth-val' })
+})
+
+Deno.test('sendPush — missing VAPID config returns 0 with no sends', async () => {
+  const { errors, logger } = makeLogger()
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 's', endpoint: 'https://x', p256dh: 'pk', auth: 'au' },
+    ],
+  })
+  const webpush = makeWebPush({})
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'u',
+    title: 't',
+    body: 'b',
+    deepLink: '/m',
+    vapidSubject: '',
+    vapidPublicKey: '',
+    vapidPrivateKey: '',
+    webpushClient: webpush.client,
+    logger,
+  })
+  assertEquals(result, { sent: 0, deleted: 0 })
+  assertEquals(webpush.calls.sends.length, 0)
+  assert(errors.length > 0, 'expected an error log when VAPID config is missing')
+})
+
+Deno.test('sendPush — supabase load error returns 0 and logs', async () => {
+  const { errors, logger } = makeLogger()
+  const supabase = makeSupabase({
+    subscriptions: [],
+    loadError: { message: 'db down' },
+  })
+  const webpush = makeWebPush({})
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'u',
+    title: 't',
+    body: 'b',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+    logger,
+  })
+  assertEquals(result, { sent: 0, deleted: 0 })
+  assertEquals(webpush.calls.sends.length, 0)
+  assert(errors.length > 0, 'expected an error log when loading subscriptions fails')
+})
+
+Deno.test('sendPush — queries push_subscriptions for the given userId', async () => {
+  const supabase = makeSupabase({ subscriptions: [] })
+  const webpush = makeWebPush({})
+  await sendPush({
+    supabase: supabase.client,
+    userId: 'user-xyz',
+    title: 't',
+    body: 'b',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+  })
+  assertEquals(supabase.calls.selects, [
+    { table: 'push_subscriptions', userId: 'user-xyz' },
+  ])
+})
+
+Deno.test('sendPush — failed delete on 410 still counts the row as not sent', async () => {
+  const { errors, logger } = makeLogger()
+  const supabase = makeSupabase({
+    subscriptions: [
+      { id: 'sub-gone', endpoint: 'https://gone', p256dh: 'pk', auth: 'au' },
+    ],
+    deleteError: { message: 'delete failed' },
+  })
+  const webpush = makeWebPush({
+    resultByEndpoint: { 'https://gone': { error: { statusCode: 410 } } },
+  })
+  const result = await sendPush({
+    supabase: supabase.client,
+    userId: 'u',
+    title: 't',
+    body: 'b',
+    deepLink: '/m',
+    ...VAPID,
+    webpushClient: webpush.client,
+    logger,
+  })
+  assertEquals(result.sent, 0)
+  assertEquals(result.deleted, 0)
+  assert(errors.length > 0, 'expected an error log when delete fails')
+})

--- a/supabase/functions/_shared/push.ts
+++ b/supabase/functions/_shared/push.ts
@@ -1,0 +1,195 @@
+// Web Push helper shared by Edge Functions that need to notify users.
+//
+// Loads every push_subscriptions row for the given user, sends a payload to
+// each via the Web Push protocol with VAPID auth, and prunes rows whose
+// endpoint is permanently expired (HTTP 410 Gone or 404 Not Found). Other
+// transport failures are logged and skipped — a single bad subscription must
+// never break the chat stream that triggered the push.
+//
+// Design notes:
+// - Pure deep module: callers pass the Supabase client they already hold and
+//   the function never reads cookies, headers, or hidden state. This keeps
+//   the unit tests trivially mockable.
+// - The actual Web Push transport (`webpushClient`) is dependency-injected.
+//   Tests pass a stub; production uses `npm:web-push@3.6.7` lazy-loaded on
+//   first send so type-checking and `deno test` do not require the npm
+//   module to resolve.
+// - The function never throws. Error signalling is via the `{ sent, deleted }`
+//   counters and the injectable logger. Callers (chat/index.ts in slice 8)
+//   rely on this contract to safely fire-and-forget.
+
+// deno-lint-ignore-file no-explicit-any
+
+export interface PushPayload {
+  title: string
+  body: string
+  deepLink: string
+}
+
+export interface PushSubscriptionLike {
+  endpoint: string
+  keys: { p256dh: string; auth: string }
+}
+
+export interface WebPushClient {
+  setVapidDetails(subject: string, publicKey: string, privateKey: string): void
+  sendNotification(
+    subscription: PushSubscriptionLike,
+    payload: string,
+  ): Promise<{ statusCode?: number } | unknown>
+}
+
+export interface SendPushLogger {
+  error(msg: string, ...args: unknown[]): void
+}
+
+export interface SendPushArgs {
+  supabase: any
+  userId: string
+  title: string
+  body: string
+  deepLink: string
+  vapidSubject?: string
+  vapidPublicKey?: string
+  vapidPrivateKey?: string
+  webpushClient?: WebPushClient
+  logger?: SendPushLogger
+}
+
+export interface SendPushResult {
+  sent: number
+  deleted: number
+}
+
+interface SubscriptionRow {
+  id: string
+  endpoint: string
+  p256dh: string
+  auth: string
+}
+
+const EXPIRED_STATUSES = new Set([404, 410])
+
+export async function sendPush(args: SendPushArgs): Promise<SendPushResult> {
+  const log = args.logger ?? console
+
+  const subject =
+    args.vapidSubject ?? safeEnv('VAPID_SUBJECT')
+  const publicKey =
+    args.vapidPublicKey ?? safeEnv('VITE_VAPID_PUBLIC_KEY')
+  const privateKey =
+    args.vapidPrivateKey ?? safeEnv('VAPID_PRIVATE_KEY')
+
+  if (!subject || !publicKey || !privateKey) {
+    log.error(
+      '[sendPush] missing VAPID configuration — set VAPID_SUBJECT, VITE_VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY',
+    )
+    return { sent: 0, deleted: 0 }
+  }
+
+  const { data, error } = await args.supabase
+    .from('push_subscriptions')
+    .select('id, endpoint, p256dh, auth')
+    .eq('user_id', args.userId)
+
+  if (error) {
+    log.error('[sendPush] failed to load subscriptions', error)
+    return { sent: 0, deleted: 0 }
+  }
+
+  const subscriptions: SubscriptionRow[] = Array.isArray(data) ? data : []
+  if (subscriptions.length === 0) {
+    return { sent: 0, deleted: 0 }
+  }
+
+  let client: WebPushClient
+  try {
+    client = args.webpushClient ?? (await loadDefaultClient())
+  } catch (err) {
+    log.error('[sendPush] failed to load web-push client', err)
+    return { sent: 0, deleted: 0 }
+  }
+
+  try {
+    client.setVapidDetails(subject, publicKey, privateKey)
+  } catch (err) {
+    log.error('[sendPush] invalid VAPID configuration', err)
+    return { sent: 0, deleted: 0 }
+  }
+
+  const payload: PushPayload = {
+    title: args.title,
+    body: args.body,
+    deepLink: args.deepLink,
+  }
+  const payloadJson = JSON.stringify(payload)
+
+  let sent = 0
+  let deleted = 0
+
+  for (const sub of subscriptions) {
+    try {
+      await client.sendNotification(
+        { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+        payloadJson,
+      )
+      sent++
+    } catch (err: any) {
+      const status =
+        typeof err?.statusCode === 'number' ? err.statusCode : undefined
+      if (status !== undefined && EXPIRED_STATUSES.has(status)) {
+        const { error: delErr } = await args.supabase
+          .from('push_subscriptions')
+          .delete()
+          .eq('id', sub.id)
+        if (delErr) {
+          log.error(
+            '[sendPush] failed to delete expired subscription',
+            { id: sub.id, endpoint: sub.endpoint, status },
+            delErr,
+          )
+        } else {
+          deleted++
+        }
+      } else {
+        log.error('[sendPush] send failed', {
+          endpoint: sub.endpoint,
+          status,
+          err,
+        })
+      }
+    }
+  }
+
+  return { sent, deleted }
+}
+
+function safeEnv(name: string): string {
+  try {
+    return Deno.env.get(name) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+let _defaultClientPromise: Promise<WebPushClient> | null = null
+
+async function loadDefaultClient(): Promise<WebPushClient> {
+  if (!_defaultClientPromise) {
+    _defaultClientPromise = (async () => {
+      const mod: any = await import('npm:web-push@3.6.7')
+      const wp = mod?.default ?? mod
+      if (
+        typeof wp?.setVapidDetails !== 'function' ||
+        typeof wp?.sendNotification !== 'function'
+      ) {
+        throw new Error('web-push module did not expose the expected API')
+      }
+      return {
+        setVapidDetails: wp.setVapidDetails.bind(wp),
+        sendNotification: wp.sendNotification.bind(wp),
+      } as WebPushClient
+    })()
+  }
+  return _defaultClientPromise
+}

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -8,7 +8,8 @@
     "npm:@supabase/auth-js@2.105.1": "2.105.1",
     "npm:@supabase/postgrest-js@2.105.1": "2.105.1",
     "npm:@supabase/realtime-js@2.105.1": "2.105.1",
-    "npm:@supabase/storage-js@2.105.1": "2.105.1"
+    "npm:@supabase/storage-js@2.105.1": "2.105.1",
+    "npm:web-push@3.6.7": "3.6.7"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -78,14 +79,98 @@
         "@types/node"
       ]
     },
+    "agent-base@7.1.4": {
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
+    "asn1.js@5.4.1": {
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": [
+        "bn.js",
+        "inherits",
+        "minimalistic-assert",
+        "safer-buffer"
+      ]
+    },
+    "bn.js@4.12.3": {
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+    },
+    "buffer-equal-constant-time@1.0.1": {
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "ecdsa-sig-formatter@1.0.11": {
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "http_ece@1.2.0": {
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="
+    },
+    "https-proxy-agent@7.0.6": {
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": [
+        "agent-base",
+        "debug"
+      ]
+    },
     "iceberg-js@0.8.1": {
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "jwa@2.0.1": {
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": [
+        "buffer-equal-constant-time",
+        "ecdsa-sig-formatter",
+        "safe-buffer"
+      ]
+    },
+    "jws@4.0.1": {
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": [
+        "jwa",
+        "safe-buffer"
+      ]
+    },
+    "minimalistic-assert@1.0.1": {
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimist@1.2.8": {
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "undici-types@7.19.2": {
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+    },
+    "web-push@3.6.7": {
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "dependencies": [
+        "asn1.js",
+        "http_ece",
+        "https-proxy-agent",
+        "jws",
+        "minimist"
+      ],
+      "bin": true
     },
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="


### PR DESCRIPTION
Closes #229

## Summary

Adds the shared backend helper that the chat function (slice 8) will use to fan out Web Push notifications. Loads every `push_subscriptions` row for a user, sends a JSON payload to each endpoint via Web Push + VAPID, prunes rows whose endpoint is permanently expired (HTTP 410 Gone or 404 Not Found), and logs+continues on every other transport failure so a single bad subscription cannot break the chat stream that triggered the push.

- New module: `supabase/functions/_shared/push.ts` exporting `sendPush({ supabase, userId, title, body, deepLink })` returning `{ sent, deleted }`.
- Real Web Push transport is `npm:web-push@3.6.7`, lazy-loaded on first send via dynamic import. The `webpushClient` is injectable so tests never touch the npm module or the network.
- VAPID config read from `VAPID_SUBJECT`, `VITE_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` (or passed in for tests). Missing config is fail-safe: the helper logs and returns `{ sent: 0, deleted: 0 }` rather than throwing.
- README gains a "Push notifications setup" section with the one-time `npx web-push generate-vapid-keys` procedure and a table of where each key goes (Vercel env var vs Supabase secret).
- `.env.local.example` documents `VITE_VAPID_PUBLIC_KEY`.

## TDD

- Tests added: `supabase/functions/_shared/push.test.ts` (14 cases)
- Before implementation (red): `Cannot find module '.../supabase/functions/_shared/push.ts'` — the test file fails to type-check because the helper does not exist.
- After implementation (green): full Edge Function suite passes — `ok | 84 passed | 0 failed (203ms)` (14 new sendPush tests + 70 pre-existing). Frontend `npm test` also stays green at 404 passed.

The 14 cases cover every acceptance bullet: no subscriptions → no-op, single + multiple successes, 410/404 → row deleted, non-410 errors logged + continued, network error (no statusCode) logged + continued, payload includes title+body+deepLink, VAPID details applied with subject + keys, endpoint+keys forwarded to webpush, missing VAPID config returns 0 + logs, supabase load error returns 0 + logs, query targets `push_subscriptions` for the right userId, and a failed delete on 410 still logs without inflating `deleted`.

## Notes

- This slice is the helper only — slice 8 wires it into the chat function's `run.done` / `run.error` / approval-gate trigger points.
- `supabase/functions/deno.lock` updated with `npm:web-push@3.6.7` and its transitive deps so CI resolves the same versions.
- Branch was force-recreated locally to drop orphaned commits from a prior failed Ralph attempt; the remote `issue-229` was deleted (no associated PR existed) and pushed fresh — no force-push to a shared branch.