### PR TITLE
fix(templates): treat missing task_templates table as empty (#340)

### DIFF
--- a/src/lib/templatesApi.js
+++ b/src/lib/templatesApi.js
@@ -1,10 +1,14 @@
 // Thin Supabase CRUD wrapper for the `task_templates` table.
 //
-// Mirrors the inline helpers BoardPage.jsx uses for `tasks`. Trivial
-// pass-through — there is no isolated unit test, only transitive
-// coverage from the page-level component tests.
+// Mirrors the inline helpers BoardPage.jsx uses for `tasks`.
 
 import { supabase } from './supabase'
+
+// Postgres 42P01 ("relation does not exist") and Postgrest PGRST205
+// ("schema cache miss") both mean the table is unreachable. From the
+// user's perspective the page should render the empty state instead
+// of a confusing schema error — see issue #340.
+const MISSING_TABLE_CODES = new Set(['42P01', 'PGRST205'])
 
 export async function fetchTemplates() {
   if (!supabase) return []
@@ -13,6 +17,10 @@ export async function fetchTemplates() {
     .select('*')
     .order('created_at', { ascending: true })
   if (error) {
+    if (MISSING_TABLE_CODES.has(error.code)) {
+      console.warn('[templates] task_templates table not reachable, treating as empty', error)
+      return []
+    }
     console.error('[templates] fetch', error)
     throw error
   }

--- a/src/lib/templatesApi.test.js
+++ b/src/lib/templatesApi.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Holder for the result the next `from('task_templates').select(...).order(...)` call resolves to.
+const queryHolder = { result: { data: [], error: null } }
+
+vi.mock('./supabase', () => {
+  const chain = {
+    select: vi.fn(() => chain),
+    order: vi.fn(() => Promise.resolve(queryHolder.result)),
+  }
+  return {
+    supabase: {
+      from: vi.fn(() => chain),
+    },
+  }
+})
+
+import { fetchTemplates } from './templatesApi'
+
+describe('fetchTemplates', () => {
+  let consoleErrorSpy
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    queryHolder.result = { data: [], error: null }
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('returns the rows from Supabase on a successful query', async () => {
+    queryHolder.result = {
+      data: [{ id: 'tpl-1', name: 'A' }],
+      error: null,
+    }
+    await expect(fetchTemplates()).resolves.toEqual([{ id: 'tpl-1', name: 'A' }])
+  })
+
+  it('returns [] when the task_templates table does not exist (Postgres 42P01)', async () => {
+    queryHolder.result = {
+      data: null,
+      error: {
+        code: '42P01',
+        message: 'relation "public.task_templates" does not exist',
+      },
+    }
+    await expect(fetchTemplates()).resolves.toEqual([])
+  })
+
+  it('returns [] when Supabase responds with PGRST205 (schema cache miss)', async () => {
+    // Postgrest returns PGRST205 when its schema cache has not yet picked up
+    // a freshly created table. From the user's perspective this is the same
+    // condition as 42P01: the data is not reachable yet, but the page should
+    // still render the empty state instead of an error.
+    queryHolder.result = {
+      data: null,
+      error: {
+        code: 'PGRST205',
+        message: "Could not find the table 'public.task_templates' in the schema cache",
+      },
+    }
+    await expect(fetchTemplates()).resolves.toEqual([])
+  })
+
+  it('throws on other Supabase errors so genuine failures stay visible', async () => {
+    queryHolder.result = {
+      data: null,
+      error: { code: '42501', message: 'permission denied' },
+    }
+    await expect(fetchTemplates()).rejects.toMatchObject({ code: '42501' })
+  })
+})

--- a/src/lib/templatesApi.test.js
+++ b/src/lib/templatesApi.test.js
@@ -18,15 +18,14 @@ vi.mock('./supabase', () => {
 import { fetchTemplates } from './templatesApi'
 
 describe('fetchTemplates', () => {
-  let consoleErrorSpy
-
   beforeEach(() => {
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
     queryHolder.result = { data: [], error: null }
   })
 
   afterEach(() => {
-    consoleErrorSpy.mockRestore()
+    vi.restoreAllMocks()
   })
 
   it('returns the rows from Supabase on a successful query', async () => {


### PR DESCRIPTION
Closes #340

## Root cause

The local migration file `supabase/migrations/20260430000000_task_templates.sql` was never applied to the production Supabase database. With the table missing, `fetchTemplates()` rethrew the Postgres `42P01 / PGRST205` error (relation does not exist / schema cache miss), and `TemplatesPage` rendered the raw error to users.

## Fix

Two-part fix:

1. **Migration applied to Supabase production** (one-shot, via the Supabase MCP). `task_templates` now exists with the same shape and RLS policies as the migration file. `list_tables` confirms 11 tables in `public` including `public.task_templates`.
2. **Defensive fallback in `src/lib/templatesApi.js`** — `fetchTemplates()` now treats `42P01` and `PGRST205` errors as "empty list", so any future environment (preview branch, fresh local dev DB, schema-cache lag right after a migration) renders the friendly empty state instead of leaking a database error to the UI. Other error codes still throw, so genuine failures (RLS denial, network, etc.) stay visible.

## TDD

- Tests added/modified: `src/lib/templatesApi.test.js` (new file, 4 tests)
- Before implementation (red): `returns [] when the task_templates table does not exist (Postgres 42P01)` and `returns [] when Supabase responds with PGRST205 (schema cache miss)` — both rejected the promise instead of resolving to `[]`.
- After implementation (green): all 4 tests in the file pass; full Vitest suite green at 408 tests.

## Notes

- `insertTemplate`, `updateTemplate`, and `deleteTemplate` keep throwing on missing-table errors — silently swallowing a write failure would hide data loss. Only the read path falls back to empty.
- `console.warn` (not `error`) is used for the fallback path so logs distinguish "expected dev/preview gap" from "unexpected fetch failure".