### PR TITLE
feat(templates): add template_references schema + Storage buckets + signedUrls module (#346)

### DIFF
--- a/supabase/functions/_shared/signedUrls.test.ts
+++ b/supabase/functions/_shared/signedUrls.test.ts
@@ -1,0 +1,182 @@
+// deno-lint-ignore-file no-explicit-any
+import { assert, assertEquals, assertRejects } from 'jsr:@std/assert@1'
+import { signReadUrl } from './signedUrls.ts'
+
+interface CreateSignedUrlCall {
+  bucket: string
+  path: string
+  ttlSeconds: number
+}
+
+function makeSupabase(opts: {
+  signedUrl?: string
+  error?: { message: string }
+}) {
+  const calls: CreateSignedUrlCall[] = []
+  const client = {
+    storage: {
+      from(bucket: string) {
+        return {
+          createSignedUrl(path: string, ttlSeconds: number) {
+            calls.push({ bucket, path, ttlSeconds })
+            if (opts.error) {
+              return Promise.resolve({ data: null, error: opts.error })
+            }
+            return Promise.resolve({
+              data: { signedUrl: opts.signedUrl ?? 'https://signed.example/x' },
+              error: null,
+            })
+          },
+        }
+      },
+    },
+  }
+  return { calls, client }
+}
+
+Deno.test('signReadUrl — returns the signed URL for template-references bucket', async () => {
+  const supabase = makeSupabase({
+    signedUrl: 'https://signed.example/template-references/foo.png',
+  })
+  const url = await signReadUrl(
+    supabase.client,
+    'template-references',
+    'foo.png',
+    60,
+  )
+  assertEquals(url, 'https://signed.example/template-references/foo.png')
+})
+
+Deno.test('signReadUrl — returns the signed URL for task-outputs bucket', async () => {
+  const supabase = makeSupabase({
+    signedUrl: 'https://signed.example/task-outputs/bar.png',
+  })
+  const url = await signReadUrl(
+    supabase.client,
+    'task-outputs',
+    'bar.png',
+    60,
+  )
+  assertEquals(url, 'https://signed.example/task-outputs/bar.png')
+})
+
+Deno.test('signReadUrl — passes bucket, path, ttlSeconds through to storage', async () => {
+  const supabase = makeSupabase({ signedUrl: 'https://x' })
+  await signReadUrl(supabase.client, 'template-references', 'a/b/c.png', 120)
+  assertEquals(supabase.calls.length, 1)
+  assertEquals(supabase.calls[0].bucket, 'template-references')
+  assertEquals(supabase.calls[0].path, 'a/b/c.png')
+  assertEquals(supabase.calls[0].ttlSeconds, 120)
+})
+
+Deno.test('signReadUrl — rejects unknown bucket', async () => {
+  const supabase = makeSupabase({})
+  await assertRejects(
+    () =>
+      signReadUrl(
+        supabase.client,
+        'random-bucket' as unknown as 'template-references',
+        'foo.png',
+        60,
+      ),
+    Error,
+    'unsupported bucket',
+  )
+  assertEquals(supabase.calls.length, 0)
+})
+
+Deno.test('signReadUrl — rejects empty path', async () => {
+  const supabase = makeSupabase({})
+  await assertRejects(
+    () => signReadUrl(supabase.client, 'template-references', '', 60),
+    Error,
+    'path is required',
+  )
+  assertEquals(supabase.calls.length, 0)
+})
+
+Deno.test('signReadUrl — rejects whitespace-only path', async () => {
+  const supabase = makeSupabase({})
+  await assertRejects(
+    () => signReadUrl(supabase.client, 'template-references', '   ', 60),
+    Error,
+    'path is required',
+  )
+})
+
+Deno.test('signReadUrl — rejects zero ttlSeconds', async () => {
+  const supabase = makeSupabase({})
+  await assertRejects(
+    () => signReadUrl(supabase.client, 'template-references', 'x.png', 0),
+    Error,
+    'ttlSeconds must be a positive integer',
+  )
+})
+
+Deno.test('signReadUrl — rejects negative ttlSeconds', async () => {
+  const supabase = makeSupabase({})
+  await assertRejects(
+    () => signReadUrl(supabase.client, 'template-references', 'x.png', -10),
+    Error,
+    'ttlSeconds must be a positive integer',
+  )
+})
+
+Deno.test('signReadUrl — rejects non-integer ttlSeconds', async () => {
+  const supabase = makeSupabase({})
+  await assertRejects(
+    () => signReadUrl(supabase.client, 'template-references', 'x.png', 1.5),
+    Error,
+    'ttlSeconds must be a positive integer',
+  )
+})
+
+Deno.test('signReadUrl — surfaces Supabase storage error message', async () => {
+  const supabase = makeSupabase({ error: { message: 'object not found' } })
+  const err = await assertRejects(
+    () =>
+      signReadUrl(supabase.client, 'template-references', 'missing.png', 60),
+    Error,
+  )
+  assert(err.message.includes('object not found'))
+  assert(err.message.includes('template-references'))
+  assert(err.message.includes('missing.png'))
+})
+
+Deno.test('signReadUrl — rejects when supabase returns no signedUrl', async () => {
+  const client: any = {
+    storage: {
+      from(_bucket: string) {
+        return {
+          createSignedUrl(_path: string, _ttl: number) {
+            return Promise.resolve({ data: {}, error: null })
+          },
+        }
+      },
+    },
+  }
+  await assertRejects(
+    () => signReadUrl(client, 'template-references', 'x.png', 60),
+    Error,
+    'no signed URL',
+  )
+})
+
+Deno.test('signReadUrl — rejects when supabase returns null data', async () => {
+  const client: any = {
+    storage: {
+      from(_bucket: string) {
+        return {
+          createSignedUrl(_path: string, _ttl: number) {
+            return Promise.resolve({ data: null, error: null })
+          },
+        }
+      },
+    },
+  }
+  await assertRejects(
+    () => signReadUrl(client, 'task-outputs', 'x.png', 60),
+    Error,
+    'no signed URL',
+  )
+})

--- a/supabase/functions/_shared/signedUrls.ts
+++ b/supabase/functions/_shared/signedUrls.ts
@@ -1,0 +1,62 @@
+// Mints time-bounded signed URLs for the private Storage buckets owned by the
+// task-templates feature. Deep, narrow module: knows nothing about callers,
+// reads no global state, and accepts the Supabase client as the first argument
+// so unit tests can mock storage and never hit the network.
+//
+// Both buckets are private (Storage RLS rejects anonymous access), so signed
+// URLs are the only safe way to expose objects to the browser without leaking
+// a service-role token.
+
+// deno-lint-ignore-file no-explicit-any
+
+export type SignedUrlBucket = 'template-references' | 'task-outputs'
+
+const SUPPORTED_BUCKETS: ReadonlySet<string> = new Set([
+  'template-references',
+  'task-outputs',
+])
+
+export async function signReadUrl(
+  supabase: any,
+  bucket: SignedUrlBucket,
+  path: string,
+  ttlSeconds: number,
+): Promise<string> {
+  if (!SUPPORTED_BUCKETS.has(bucket as string)) {
+    throw new Error(
+      `signReadUrl: unsupported bucket "${bucket}" (allowed: template-references, task-outputs).`,
+    )
+  }
+  if (typeof path !== 'string' || path.trim().length === 0) {
+    throw new Error('signReadUrl: path is required.')
+  }
+  if (
+    typeof ttlSeconds !== 'number' ||
+    !Number.isInteger(ttlSeconds) ||
+    ttlSeconds <= 0
+  ) {
+    throw new Error('signReadUrl: ttlSeconds must be a positive integer.')
+  }
+
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .createSignedUrl(path, ttlSeconds)
+
+  if (error) {
+    const message =
+      typeof error?.message === 'string' ? error.message : String(error)
+    throw new Error(
+      `signReadUrl failed for ${bucket}/${path}: ${message}`,
+    )
+  }
+  if (
+    !data ||
+    typeof data.signedUrl !== 'string' ||
+    data.signedUrl.length === 0
+  ) {
+    throw new Error(
+      `signReadUrl returned no signed URL for ${bucket}/${path}.`,
+    )
+  }
+  return data.signedUrl
+}

--- a/supabase/migrations/20260505000000_template_references_and_storage.sql
+++ b/supabase/migrations/20260505000000_template_references_and_storage.sql
@@ -1,0 +1,210 @@
+-- Schema scaffolding for the Luiza content-automation template feature
+-- (PRD #344, slice #346). Adds optional columns to task_templates, creates
+-- the new template_references child table, and provisions the two private
+-- Storage buckets that subsequent slices upload to and read from via signed
+-- URLs minted by supabase/functions/_shared/signedUrls.ts.
+--
+-- This migration is purely additive: every change is gated by IF NOT EXISTS
+-- (or ON CONFLICT for storage.buckets) so re-running it on an existing DB is
+-- a no-op.
+
+-- ── task_templates additive columns ────────────────────────────────────────
+-- brand_context: free-form Markdown describing the template's brand voice
+-- params_schema: JSON Schema describing the params an instantiation accepts
+-- title_template / description_template: Mustache templates rendered at
+-- instantiation time using the params + brand_context.
+
+alter table task_templates
+  add column if not exists brand_context text;
+
+alter table task_templates
+  add column if not exists params_schema jsonb;
+
+alter table task_templates
+  add column if not exists title_template text;
+
+alter table task_templates
+  add column if not exists description_template text;
+
+-- ── template_references child table ────────────────────────────────────────
+-- One row per attached reference (text snippet, image, or audio sample) used
+-- to ground the template's prompt. Bucket-backed assets store their object
+-- key in storage_path; pure-text references store the literal payload in
+-- content_text.
+
+create table if not exists template_references (
+  id uuid primary key default gen_random_uuid(),
+  template_id uuid not null references task_templates (id) on delete cascade,
+  key text not null,
+  kind text not null check (kind in ('text', 'image', 'audio')),
+  storage_path text,
+  mime_type text,
+  content_text text,
+  original_filename text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_template_references_template_id
+  on template_references (template_id);
+
+alter table template_references enable row level security;
+
+-- Single-user-friendly policy: the app is allowlist-gated (see CLAUDE.md ›
+-- "Authentication & Authorization"), so any signed-in user can manage
+-- references. Mirrors the public policy used by task_templates today.
+-- Tighten to per-owner once task_templates grows owner_user_id.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'public'
+       and tablename = 'template_references'
+       and policyname = 'Public read access for template_references'
+  ) then
+    create policy "Public read access for template_references"
+      on template_references for select using (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'public'
+       and tablename = 'template_references'
+       and policyname = 'Public insert access for template_references'
+  ) then
+    create policy "Public insert access for template_references"
+      on template_references for insert with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'public'
+       and tablename = 'template_references'
+       and policyname = 'Public update access for template_references'
+  ) then
+    create policy "Public update access for template_references"
+      on template_references for update using (true) with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'public'
+       and tablename = 'template_references'
+       and policyname = 'Public delete access for template_references'
+  ) then
+    create policy "Public delete access for template_references"
+      on template_references for delete using (true);
+  end if;
+end
+$$;
+
+-- ── Private Storage buckets ────────────────────────────────────────────────
+-- Both buckets are private. Browser callers read objects via signed URLs
+-- minted by supabase/functions/_shared/signedUrls.ts; writes go through
+-- authenticated Supabase clients (gated by Storage RLS below).
+
+insert into storage.buckets (id, name, public)
+values ('template-references', 'template-references', false)
+on conflict (id) do nothing;
+
+insert into storage.buckets (id, name, public)
+values ('task-outputs', 'task-outputs', false)
+on conflict (id) do nothing;
+
+-- Storage RLS for both buckets: authenticated users can read/write any
+-- object in either bucket; anonymous clients receive 401/403. The allowlist
+-- gate already restricts who can ever sign in, so per-folder ownership is
+-- not yet enforced here — revisit when the app grows multi-tenant.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'storage'
+       and tablename = 'objects'
+       and policyname = 'Authenticated read template-references'
+  ) then
+    create policy "Authenticated read template-references"
+      on storage.objects for select to authenticated
+      using (bucket_id = 'template-references');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'storage'
+       and tablename = 'objects'
+       and policyname = 'Authenticated write template-references'
+  ) then
+    create policy "Authenticated write template-references"
+      on storage.objects for insert to authenticated
+      with check (bucket_id = 'template-references');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'storage'
+       and tablename = 'objects'
+       and policyname = 'Authenticated update template-references'
+  ) then
+    create policy "Authenticated update template-references"
+      on storage.objects for update to authenticated
+      using (bucket_id = 'template-references')
+      with check (bucket_id = 'template-references');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'storage'
+       and tablename = 'objects'
+       and policyname = 'Authenticated delete template-references'
+  ) then
+    create policy "Authenticated delete template-references"
+      on storage.objects for delete to authenticated
+      using (bucket_id = 'template-references');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'storage'
+       and tablename = 'objects'
+       and policyname = 'Authenticated read task-outputs'
+  ) then
+    create policy "Authenticated read task-outputs"
+      on storage.objects for select to authenticated
+      using (bucket_id = 'task-outputs');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'storage'
+       and tablename = 'objects'
+       and policyname = 'Authenticated write task-outputs'
+  ) then
+    create policy "Authenticated write task-outputs"
+      on storage.objects for insert to authenticated
+      with check (bucket_id = 'task-outputs');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'storage'
+       and tablename = 'objects'
+       and policyname = 'Authenticated update task-outputs'
+  ) then
+    create policy "Authenticated update task-outputs"
+      on storage.objects for update to authenticated
+      using (bucket_id = 'task-outputs')
+      with check (bucket_id = 'task-outputs');
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'storage'
+       and tablename = 'objects'
+       and policyname = 'Authenticated delete task-outputs'
+  ) then
+    create policy "Authenticated delete task-outputs"
+      on storage.objects for delete to authenticated
+      using (bucket_id = 'task-outputs');
+  end if;
+end
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -202,6 +202,21 @@ create policy "Public update access for task_templates" on task_templates
 create policy "Public delete access for task_templates" on task_templates
   for delete using (true);
 
+-- template_references uses the same single-user-friendly public policy as
+-- task_templates. Tighten to per-owner once task_templates grows
+-- owner_user_id (see PRD #344 — slice #346).
+create policy "Public read access for template_references" on template_references
+  for select using (true);
+
+create policy "Public insert access for template_references" on template_references
+  for insert with check (true);
+
+create policy "Public update access for template_references" on template_references
+  for update using (true) with check (true);
+
+create policy "Public delete access for template_references" on template_references
+  for delete using (true);
+
 -- Push subscription policies: a row belongs to its user_id. The Edge
 -- Functions never touch other users' rows, so we don't expose any update or
 -- service-role policy here.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -228,3 +228,10 @@ create policy "Users can insert own push_subscriptions" on push_subscriptions
 
 create policy "Users can delete own push_subscriptions" on push_subscriptions
   for delete using (auth.uid() = user_id);
+
+-- Private Storage buckets owned by the task-templates feature
+-- (template-references and task-outputs). The bucket rows and the
+-- storage.objects RLS policies live in
+-- supabase/migrations/20260505000000_template_references_and_storage.sql so
+-- they can be applied with the rest of the migration history; see that file
+-- for the canonical definitions.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -156,6 +156,7 @@ alter table teams enable row level security;
 alter table tools enable row level security;
 alter table runs enable row level security;
 alter table task_templates enable row level security;
+alter table template_references enable row level security;
 alter table push_subscriptions enable row level security;
 
 -- For now, allow public read access (no auth yet)

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -92,6 +92,10 @@ create index if not exists idx_runs_created_at on runs(created_at desc);
 -- snapshots a ticket's title, description, and the full execution plan
 -- so the planner cost is paid once and the resulting plan can be
 -- instantiated as new tickets. See PRD #246 / issue #247.
+--
+-- The brand_context / params_schema / title_template / description_template
+-- columns plus the template_references child table support the Luiza
+-- content-automation feature (PRD #344, slice #346).
 create table if not exists task_templates (
   id uuid primary key default gen_random_uuid(),
   name text not null,
@@ -99,12 +103,36 @@ create table if not exists task_templates (
   task_title text not null,
   task_description text,
   plan jsonb,
+  brand_context text,
+  params_schema jsonb,
+  title_template text,
+  description_template text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
 
 create index if not exists idx_task_templates_created_at
   on task_templates (created_at desc);
+
+-- Template references (text snippets, images, audio samples) attached to a
+-- task_templates row to ground its prompt at instantiation time. Bucket-
+-- backed assets live under storage_path; pure-text references inline the
+-- payload in content_text.
+create table if not exists template_references (
+  id uuid primary key default gen_random_uuid(),
+  template_id uuid not null references task_templates (id) on delete cascade,
+  key text not null,
+  kind text not null check (kind in ('text', 'image', 'audio')),
+  storage_path text,
+  mime_type text,
+  content_text text,
+  original_filename text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_template_references_template_id
+  on template_references (template_id);
 
 -- Web Push subscriptions for the mobile shell at /mobile. Owned by the
 -- push-subscribe / push-unsubscribe Edge Functions. RLS scopes every


### PR DESCRIPTION
Closes #346

Slice #346 of PRD #344. Pure additive scaffolding for the Luiza template feature — no UI, no callers wired in yet.

## What this adds

- **Migration** `supabase/migrations/20260505000000_template_references_and_storage.sql`:
  - Adds `brand_context text`, `params_schema jsonb`, `title_template text`, `description_template text` to `task_templates` (all `IF NOT EXISTS`, defaults to NULL — existing rows untouched).
  - Creates `template_references` (FK to `task_templates` with `on delete cascade`, `kind in ('text','image','audio')`, `storage_path`, `mime_type`, `content_text`, `original_filename`, timestamps), with an index on `template_id` and RLS enabled.
  - Provisions the two private Storage buckets `template-references` and `task-outputs` via `storage.buckets` upserts with `on conflict (id) do nothing`.
  - Adds `storage.objects` policies for both buckets that grant read/insert/update/delete to `authenticated`. Anonymous clients receive 401/403 by default since RLS is enabled and no `to anon` policy is defined.
- **`supabase/functions/_shared/signedUrls.ts`** — pure deep module exposing `signReadUrl(supabase, bucket, path, ttlSeconds): Promise<string>`. Validates inputs (allowed buckets, non-empty path, positive integer TTL) and surfaces Supabase storage errors with the bucket/path interpolated for debuggability. Mirrors the dependency-injection style of `_shared/push.ts`.
- **`schema.sql`** updated to keep the source-of-truth doc in sync with the migration (new columns, new table + RLS, pointer to the migration for the storage bucket policies).

The `template_references` policies use the same single-user-friendly `using (true)` pattern as `task_templates` because the app is allowlist-gated (see `CLAUDE.md › Authentication & Authorization`) and `task_templates` has no `owner_user_id` column to scope against. The migration comment notes this should tighten to per-owner once the parent grows ownership.

## TDD

- Tests added: `supabase/functions/_shared/signedUrls.test.ts` (12 cases — happy path for both buckets, argument validation, supabase error surfacing, missing-`signedUrl` and null-data handling).
- Before implementation (red): `npm run test:functions` failed at type-check time with `TS2307: Cannot find module 'file:///.../supabase/functions/_shared/signedUrls.ts'` — the test importer pointed at a non-existent module, exactly the failure mode expected.
- After implementation (green): `npm run test:functions` → **96 passed | 0 failed (238ms)**. The 12 new `signReadUrl` tests are in the suite.
- Frontend regression check: `npm test` → **427 passed | 0 failed**, no React code was touched.
- Lint: `npm run lint` → 0 errors, 26 pre-existing warnings (no new warnings introduced — the diff is SQL + TS in `supabase/`).

The migration itself is verified by inspection (`IF NOT EXISTS` / `ON CONFLICT` / `pg_policies` guards make every block idempotent) plus the policy enforcement model — anonymous Storage access fails because RLS is on and no anonymous policy is defined; authenticated CRUD is granted explicitly.

## Notes

- `signedUrls.ts` is intentionally consumed nowhere in v1 — slice #347 / #350+ will wire it into the chat function and the templates UI.
- The auto-commit hook split the diff across 7 small `auto:` commits. The squash-merge strategy collapses them into one commit on `dev` titled by this PR.