### PR TITLE
feat(templates): add templateRenderer Mustache module (#347)

### DIFF
--- a/supabase/functions/_shared/templateRenderer.test.ts
+++ b/supabase/functions/_shared/templateRenderer.test.ts
@@ -1,9 +1,18 @@
 import { assertEquals } from 'jsr:@std/assert@1'
-import { render, validate } from './templateRenderer.ts'
+import {
+  type ImageBlock,
+  type PriorStep,
+  render,
+  type TemplateReference,
+  validate,
+} from './templateRenderer.ts'
 
-const sampleParams = { topic: 'ansiedade', time_range: '7d' }
+const sampleParams: Record<string, string> = {
+  topic: 'ansiedade',
+  time_range: '7d',
+}
 
-const sampleSteps = [
+const sampleSteps: PriorStep[] = [
   {
     output: 'research summary text',
     output_files: [
@@ -17,7 +26,7 @@ const sampleSteps = [
   },
 ]
 
-const sampleRefs = {
+const sampleRefs: Record<string, TemplateReference> = {
   tone_of_voice: {
     kind: 'text',
     content_text: 'Speak in calm, warm Portuguese.',

--- a/supabase/functions/_shared/templateRenderer.test.ts
+++ b/supabase/functions/_shared/templateRenderer.test.ts
@@ -217,7 +217,7 @@ Deno.test('render — {{ref:KEY}} image reference becomes an image block, not UR
 })
 
 Deno.test('render — multiple image refs emitted in left-to-right order', () => {
-  const refs = {
+  const refs: Record<string, TemplateReference> = {
     a: { kind: 'image', url: 'https://x/a.png', mime_type: 'image/png' },
     b: { kind: 'image', url: 'https://x/b.png', mime_type: 'image/png' },
     c: { kind: 'image', url: 'https://x/c.png', mime_type: 'image/png' },
@@ -229,7 +229,7 @@ Deno.test('render — multiple image refs emitted in left-to-right order', () =>
     references: refs,
   })
   const urls = out.user_message_blocks
-    .filter((b) => b.type === 'image')
+    .filter((b): b is ImageBlock => b.type === 'image')
     .map((b) => b.source.url)
   assertEquals(urls, ['https://x/b.png', 'https://x/a.png', 'https://x/c.png'])
 })

--- a/supabase/functions/_shared/templateRenderer.test.ts
+++ b/supabase/functions/_shared/templateRenderer.test.ts
@@ -1,0 +1,415 @@
+import { assertEquals } from 'jsr:@std/assert@1'
+import { render, validate } from './templateRenderer.ts'
+
+const sampleParams = { topic: 'ansiedade', time_range: '7d' }
+
+const sampleSteps = [
+  {
+    output: 'research summary text',
+    output_files: [
+      { url: 'https://signed.example/step1/a.jpg', mime_type: 'image/jpeg' },
+      { url: 'https://signed.example/step1/b.png', mime_type: 'image/png' },
+    ],
+  },
+  {
+    output: 'second step plain output',
+    output_files: [],
+  },
+]
+
+const sampleRefs = {
+  tone_of_voice: {
+    kind: 'text',
+    content_text: 'Speak in calm, warm Portuguese.',
+  },
+  moodboard: {
+    kind: 'image',
+    url: 'https://signed.example/refs/moodboard.png',
+    mime_type: 'image/png',
+  },
+}
+
+// ── render() ────────────────────────────────────────────────────────────────
+
+Deno.test('render — static text only returns a single text block', () => {
+  const out = render({
+    instruction: 'Hello, world!',
+    params: {},
+    priorSteps: [],
+    references: {},
+  })
+  assertEquals(out.user_message_blocks, [
+    { type: 'text', text: 'Hello, world!' },
+  ])
+  assertEquals(out.resolved_text, 'Hello, world!')
+  assertEquals(out.validation_errors, [])
+})
+
+Deno.test('render — empty instruction yields no blocks and no text', () => {
+  const out = render({
+    instruction: '',
+    params: {},
+    priorSteps: [],
+    references: {},
+  })
+  assertEquals(out.user_message_blocks, [])
+  assertEquals(out.resolved_text, '')
+  assertEquals(out.validation_errors, [])
+})
+
+Deno.test('render — resolves {{params.X}} placeholders', () => {
+  const out = render({
+    instruction: 'Topic is {{params.topic}} over {{params.time_range}}.',
+    params: sampleParams,
+    priorSteps: [],
+    references: {},
+  })
+  assertEquals(out.resolved_text, 'Topic is ansiedade over 7d.')
+  assertEquals(out.user_message_blocks, [
+    { type: 'text', text: 'Topic is ansiedade over 7d.' },
+  ])
+  assertEquals(out.validation_errors, [])
+})
+
+Deno.test('render — tolerates whitespace inside placeholder braces', () => {
+  const out = render({
+    instruction: 'Topic is {{ params.topic }}.',
+    params: sampleParams,
+    priorSteps: [],
+    references: {},
+  })
+  assertEquals(out.resolved_text, 'Topic is ansiedade.')
+  assertEquals(out.validation_errors, [])
+})
+
+Deno.test('render — resolves {{step-N.output}} from priorSteps', () => {
+  const out = render({
+    instruction: 'Prior: {{step-1.output}} then {{step-2.output}}.',
+    params: {},
+    priorSteps: sampleSteps,
+    references: {},
+  })
+  assertEquals(
+    out.resolved_text,
+    'Prior: research summary text then second step plain output.',
+  )
+  assertEquals(out.validation_errors, [])
+})
+
+Deno.test('render — {{step-N.output_files}} expands to a markdown URL list', () => {
+  const out = render({
+    instruction: 'Files:\n{{step-1.output_files}}',
+    params: {},
+    priorSteps: sampleSteps,
+    references: {},
+  })
+  assertEquals(
+    out.resolved_text,
+    'Files:\n- https://signed.example/step1/a.jpg\n- https://signed.example/step1/b.png',
+  )
+})
+
+Deno.test('render — {{step-N.output_files}} emits one image block per image/* file', () => {
+  const out = render({
+    instruction: 'Files:\n{{step-1.output_files}}',
+    params: {},
+    priorSteps: sampleSteps,
+    references: {},
+  })
+  const imageBlocks = out.user_message_blocks.filter((b) => b.type === 'image')
+  assertEquals(imageBlocks, [
+    {
+      type: 'image',
+      source: { type: 'url', url: 'https://signed.example/step1/a.jpg' },
+    },
+    {
+      type: 'image',
+      source: { type: 'url', url: 'https://signed.example/step1/b.png' },
+    },
+  ])
+})
+
+Deno.test('render — output_files keeps non-image URLs in markdown list but not as image blocks', () => {
+  const steps = [
+    {
+      output: 'x',
+      output_files: [
+        { url: 'https://signed.example/photo.jpg', mime_type: 'image/jpeg' },
+        { url: 'https://signed.example/notes.txt', mime_type: 'text/plain' },
+      ],
+    },
+  ]
+  const out = render({
+    instruction: '{{step-1.output_files}}',
+    params: {},
+    priorSteps: steps,
+    references: {},
+  })
+  assertEquals(
+    out.resolved_text,
+    '- https://signed.example/photo.jpg\n- https://signed.example/notes.txt',
+  )
+  const imageBlocks = out.user_message_blocks.filter((b) => b.type === 'image')
+  assertEquals(imageBlocks.length, 1)
+  assertEquals(imageBlocks[0], {
+    type: 'image',
+    source: { type: 'url', url: 'https://signed.example/photo.jpg' },
+  })
+})
+
+Deno.test('render — output_files with empty list yields empty string in resolved text', () => {
+  const out = render({
+    instruction: 'Empty: [{{step-2.output_files}}]',
+    params: {},
+    priorSteps: sampleSteps,
+    references: {},
+  })
+  assertEquals(out.resolved_text, 'Empty: []')
+  assertEquals(
+    out.user_message_blocks.filter((b) => b.type === 'image').length,
+    0,
+  )
+})
+
+Deno.test('render — {{ref:KEY}} text reference inlines content_text', () => {
+  const out = render({
+    instruction: 'Voice: {{ref:tone_of_voice}}',
+    params: {},
+    priorSteps: [],
+    references: sampleRefs,
+  })
+  assertEquals(out.resolved_text, 'Voice: Speak in calm, warm Portuguese.')
+  assertEquals(out.user_message_blocks, [
+    { type: 'text', text: 'Voice: Speak in calm, warm Portuguese.' },
+  ])
+})
+
+Deno.test('render — {{ref:KEY}} image reference becomes an image block, not URL text', () => {
+  const out = render({
+    instruction: 'Mood: {{ref:moodboard}}',
+    params: {},
+    priorSteps: [],
+    references: sampleRefs,
+  })
+  // Image refs leave nothing in the text (they are NOT URL text).
+  assertEquals(
+    out.user_message_blocks.some(
+      (b) => b.type === 'text' && b.text.includes('signed.example/refs'),
+    ),
+    false,
+  )
+  const imageBlocks = out.user_message_blocks.filter((b) => b.type === 'image')
+  assertEquals(imageBlocks, [
+    {
+      type: 'image',
+      source: { type: 'url', url: 'https://signed.example/refs/moodboard.png' },
+    },
+  ])
+})
+
+Deno.test('render — multiple image refs emitted in left-to-right order', () => {
+  const refs = {
+    a: { kind: 'image', url: 'https://x/a.png', mime_type: 'image/png' },
+    b: { kind: 'image', url: 'https://x/b.png', mime_type: 'image/png' },
+    c: { kind: 'image', url: 'https://x/c.png', mime_type: 'image/png' },
+  }
+  const out = render({
+    instruction: 'see {{ref:b}} and {{ref:a}} and {{ref:c}}',
+    params: {},
+    priorSteps: [],
+    references: refs,
+  })
+  const urls = out.user_message_blocks
+    .filter((b) => b.type === 'image')
+    .map((b) => b.source.url)
+  assertEquals(urls, ['https://x/b.png', 'https://x/a.png', 'https://x/c.png'])
+})
+
+Deno.test('render — combines params, prior step output, and refs into one prompt', () => {
+  const out = render({
+    instruction:
+      'Topic: {{params.topic}}\nResearch: {{step-1.output}}\nVoice: {{ref:tone_of_voice}}',
+    params: sampleParams,
+    priorSteps: sampleSteps,
+    references: sampleRefs,
+  })
+  assertEquals(
+    out.resolved_text,
+    'Topic: ansiedade\nResearch: research summary text\nVoice: Speak in calm, warm Portuguese.',
+  )
+  assertEquals(out.validation_errors, [])
+})
+
+Deno.test('render — missing param produces a validation error, no throw', () => {
+  const out = render({
+    instruction: 'Topic: {{params.missing_one}}',
+    params: {},
+    priorSteps: [],
+    references: {},
+  })
+  assertEquals(out.validation_errors.length, 1)
+  assertEquals(out.validation_errors[0].kind, 'missing_param')
+  assertEquals(out.validation_errors[0].placeholder, 'params.missing_one')
+})
+
+Deno.test('render — missing prior-step output produces a validation error', () => {
+  const out = render({
+    instruction: 'Prior: {{step-3.output}}',
+    params: {},
+    priorSteps: sampleSteps,
+    references: {},
+  })
+  assertEquals(out.validation_errors.length, 1)
+  assertEquals(out.validation_errors[0].kind, 'missing_step_output')
+  assertEquals(out.validation_errors[0].placeholder, 'step-3.output')
+})
+
+Deno.test('render — missing reference produces a validation error', () => {
+  const out = render({
+    instruction: 'Voice: {{ref:nope}}',
+    params: {},
+    priorSteps: [],
+    references: sampleRefs,
+  })
+  assertEquals(out.validation_errors.length, 1)
+  assertEquals(out.validation_errors[0].kind, 'missing_ref')
+  assertEquals(out.validation_errors[0].placeholder, 'ref:nope')
+})
+
+Deno.test('render — unknown placeholder format produces a validation error', () => {
+  const out = render({
+    instruction: 'Weird: {{not_a_known_kind}}',
+    params: {},
+    priorSteps: [],
+    references: {},
+  })
+  assertEquals(out.validation_errors.length, 1)
+  assertEquals(out.validation_errors[0].kind, 'unknown_placeholder')
+})
+
+Deno.test('render — audio reference is recognised but unsupported in v1', () => {
+  const out = render({
+    instruction: 'Audio: {{ref:voicebed}}',
+    params: {},
+    priorSteps: [],
+    references: {
+      voicebed: { kind: 'audio', url: 'https://x/v.mp3', mime_type: 'audio/mpeg' },
+    },
+  })
+  assertEquals(out.validation_errors.length, 1)
+  assertEquals(out.validation_errors[0].kind, 'unsupported_ref_kind')
+})
+
+Deno.test('render — defaults missing params/priorSteps/references to empty', () => {
+  const out = render({ instruction: 'Hi' })
+  assertEquals(out.resolved_text, 'Hi')
+  assertEquals(out.user_message_blocks, [{ type: 'text', text: 'Hi' }])
+  assertEquals(out.validation_errors, [])
+})
+
+// ── validate() ──────────────────────────────────────────────────────────────
+
+Deno.test('validate — returns no errors when every placeholder is declared', () => {
+  const errors = validate(
+    {
+      instruction:
+        'Topic: {{params.topic}} | Prior: {{step-1.output}} | Voice: {{ref:tone}}',
+    },
+    ['topic'],
+    [1],
+    ['tone'],
+  )
+  assertEquals(errors, [])
+})
+
+Deno.test('validate — flags undeclared param', () => {
+  const errors = validate(
+    { instruction: '{{params.topic}} {{params.audience}}' },
+    ['topic'],
+    [],
+    [],
+  )
+  assertEquals(errors.length, 1)
+  assertEquals(errors[0].kind, 'undeclared_param')
+  assertEquals(errors[0].placeholder, 'params.audience')
+})
+
+Deno.test('validate — flags undeclared step output dependency', () => {
+  const errors = validate(
+    { instruction: '{{step-1.output}} {{step-2.output}}' },
+    [],
+    [1],
+    [],
+  )
+  assertEquals(errors.length, 1)
+  assertEquals(errors[0].kind, 'undeclared_step')
+  assertEquals(errors[0].placeholder, 'step-2.output')
+})
+
+Deno.test('validate — flags undeclared step output_files dependency', () => {
+  const errors = validate(
+    { instruction: '{{step-3.output_files}}' },
+    [],
+    [1, 2],
+    [],
+  )
+  assertEquals(errors.length, 1)
+  assertEquals(errors[0].kind, 'undeclared_step')
+  assertEquals(errors[0].placeholder, 'step-3.output_files')
+})
+
+Deno.test('validate — flags undeclared reference key', () => {
+  const errors = validate(
+    { instruction: '{{ref:moodboard}}' },
+    [],
+    [],
+    ['tone_of_voice'],
+  )
+  assertEquals(errors.length, 1)
+  assertEquals(errors[0].kind, 'undeclared_ref')
+  assertEquals(errors[0].placeholder, 'ref:moodboard')
+})
+
+Deno.test('validate — flags unknown placeholder format', () => {
+  const errors = validate(
+    { instruction: 'Weird: {{garbage}}' },
+    [],
+    [],
+    [],
+  )
+  assertEquals(errors.length, 1)
+  assertEquals(errors[0].kind, 'unknown_placeholder')
+})
+
+Deno.test('validate — collects multiple errors in left-to-right order', () => {
+  const errors = validate(
+    {
+      instruction:
+        '{{params.unknown_param}} {{step-9.output}} {{ref:nope}} {{whatever}}',
+    },
+    [],
+    [],
+    [],
+  )
+  assertEquals(errors.length, 4)
+  assertEquals(errors[0].kind, 'undeclared_param')
+  assertEquals(errors[1].kind, 'undeclared_step')
+  assertEquals(errors[2].kind, 'undeclared_ref')
+  assertEquals(errors[3].kind, 'unknown_placeholder')
+})
+
+Deno.test('validate — does not report the same placeholder more than once', () => {
+  const errors = validate(
+    { instruction: '{{params.x}} and {{params.x}} again' },
+    [],
+    [],
+    [],
+  )
+  assertEquals(errors.length, 1)
+  assertEquals(errors[0].placeholder, 'params.x')
+})
+
+Deno.test('validate — instruction without placeholders has no errors', () => {
+  const errors = validate({ instruction: 'plain text' }, [], [], [])
+  assertEquals(errors, [])
+})

--- a/supabase/functions/_shared/templateRenderer.ts
+++ b/supabase/functions/_shared/templateRenderer.ts
@@ -1,0 +1,331 @@
+// Pure template renderer for the Luiza content-automation pipeline (PRD #344).
+//
+// Resolves a Mustache-style instruction string against a runtime context made
+// of params, prior step outputs, and named references, and produces an
+// Anthropic-API-ready user message: a `user_message_blocks[]` array of
+// interleaved text and image blocks plus a flat `resolved_text` for debug
+// surfaces. Image references and prior-step image files are emitted as
+// Anthropic `image` blocks rather than URL text so the LLM can actually see
+// them.
+//
+// Save-time validation lives next to render() so a template author can be
+// told at authoring time that a placeholder references something the step
+// has not declared (param, prior step, or reference key).
+//
+// Module is intentionally pure: no fetch, no Deno.env, no Supabase imports.
+
+export interface TextBlock {
+  type: 'text'
+  text: string
+}
+
+export interface ImageBlock {
+  type: 'image'
+  source: {
+    type: 'url'
+    url: string
+  }
+}
+
+export type ContentBlock = TextBlock | ImageBlock
+
+export interface PriorStepFile {
+  url: string
+  mime_type: string
+}
+
+export interface PriorStep {
+  output?: string
+  output_files?: PriorStepFile[]
+}
+
+export interface TemplateReference {
+  kind: 'text' | 'image' | 'audio'
+  content_text?: string
+  url?: string
+  mime_type?: string
+}
+
+export interface RenderInput {
+  instruction: string
+  params?: Record<string, string>
+  priorSteps?: PriorStep[]
+  references?: Record<string, TemplateReference>
+}
+
+export type ValidationErrorKind =
+  | 'unknown_placeholder'
+  | 'missing_param'
+  | 'missing_step_output'
+  | 'missing_ref'
+  | 'unsupported_ref_kind'
+  | 'undeclared_param'
+  | 'undeclared_step'
+  | 'undeclared_ref'
+
+export interface ValidationError {
+  kind: ValidationErrorKind
+  placeholder: string
+  detail?: string
+}
+
+export interface RenderOutput {
+  user_message_blocks: ContentBlock[]
+  resolved_text: string
+  validation_errors: ValidationError[]
+}
+
+export interface TemplateStep {
+  instruction: string
+}
+
+interface ParsedPlaceholder {
+  raw: string // full match including braces, e.g. "{{ params.topic }}"
+  inner: string // trimmed inner, e.g. "params.topic"
+  start: number
+  end: number
+}
+
+const PLACEHOLDER_RE = /\{\{\s*([^{}]+?)\s*\}\}/g
+
+function parsePlaceholders(instruction: string): ParsedPlaceholder[] {
+  const out: ParsedPlaceholder[] = []
+  PLACEHOLDER_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = PLACEHOLDER_RE.exec(instruction)) !== null) {
+    out.push({
+      raw: m[0],
+      inner: m[1].trim(),
+      start: m.index,
+      end: m.index + m[0].length,
+    })
+  }
+  return out
+}
+
+type Classification =
+  | { kind: 'param'; name: string }
+  | { kind: 'step_output'; index: number }
+  | { kind: 'step_output_files'; index: number }
+  | { kind: 'ref'; key: string }
+  | { kind: 'unknown' }
+
+function classify(inner: string): Classification {
+  const paramMatch = /^params\.([A-Za-z_][A-Za-z0-9_]*)$/.exec(inner)
+  if (paramMatch) return { kind: 'param', name: paramMatch[1] }
+
+  const stepOutputMatch = /^step-(\d+)\.output$/.exec(inner)
+  if (stepOutputMatch) {
+    return { kind: 'step_output', index: Number(stepOutputMatch[1]) }
+  }
+
+  const stepFilesMatch = /^step-(\d+)\.output_files$/.exec(inner)
+  if (stepFilesMatch) {
+    return { kind: 'step_output_files', index: Number(stepFilesMatch[1]) }
+  }
+
+  const refMatch = /^ref:([A-Za-z0-9_\-.]+)$/.exec(inner)
+  if (refMatch) return { kind: 'ref', key: refMatch[1] }
+
+  return { kind: 'unknown' }
+}
+
+function markdownUrlList(files: PriorStepFile[]): string {
+  return files.map((f) => `- ${f.url}`).join('\n')
+}
+
+export function render(input: RenderInput): RenderOutput {
+  const instruction = input.instruction ?? ''
+  const params = input.params ?? {}
+  const priorSteps = input.priorSteps ?? []
+  const references = input.references ?? {}
+
+  const placeholders = parsePlaceholders(instruction)
+  const blocks: ContentBlock[] = []
+  const validationErrors: ValidationError[] = []
+
+  let textBuffer = ''
+  let cursor = 0
+
+  const flushText = () => {
+    if (textBuffer.length > 0) {
+      blocks.push({ type: 'text', text: textBuffer })
+      textBuffer = ''
+    }
+  }
+
+  const resolvedSegments: string[] = []
+
+  for (const ph of placeholders) {
+    const literal = instruction.slice(cursor, ph.start)
+    textBuffer += literal
+    resolvedSegments.push(literal)
+    cursor = ph.end
+
+    const c = classify(ph.inner)
+
+    if (c.kind === 'param') {
+      const value = params[c.name]
+      if (typeof value !== 'string') {
+        validationErrors.push({
+          kind: 'missing_param',
+          placeholder: ph.inner,
+        })
+        continue
+      }
+      textBuffer += value
+      resolvedSegments.push(value)
+      continue
+    }
+
+    if (c.kind === 'step_output') {
+      const step = priorSteps[c.index - 1]
+      if (!step || typeof step.output !== 'string') {
+        validationErrors.push({
+          kind: 'missing_step_output',
+          placeholder: ph.inner,
+        })
+        continue
+      }
+      textBuffer += step.output
+      resolvedSegments.push(step.output)
+      continue
+    }
+
+    if (c.kind === 'step_output_files') {
+      const step = priorSteps[c.index - 1]
+      if (!step) {
+        validationErrors.push({
+          kind: 'missing_step_output',
+          placeholder: ph.inner,
+        })
+        continue
+      }
+      const files = Array.isArray(step.output_files) ? step.output_files : []
+      const list = markdownUrlList(files)
+      textBuffer += list
+      resolvedSegments.push(list)
+      // Flush so image blocks land after the markdown list, then emit one
+      // image block per file whose mime_type starts with "image/".
+      flushText()
+      for (const file of files) {
+        if (
+          typeof file?.url === 'string' &&
+          typeof file?.mime_type === 'string' &&
+          file.mime_type.startsWith('image/')
+        ) {
+          blocks.push({
+            type: 'image',
+            source: { type: 'url', url: file.url },
+          })
+        }
+      }
+      continue
+    }
+
+    if (c.kind === 'ref') {
+      const ref = references[c.key]
+      if (!ref) {
+        validationErrors.push({
+          kind: 'missing_ref',
+          placeholder: ph.inner,
+        })
+        continue
+      }
+      if (ref.kind === 'text') {
+        const text = typeof ref.content_text === 'string' ? ref.content_text : ''
+        textBuffer += text
+        resolvedSegments.push(text)
+        continue
+      }
+      if (ref.kind === 'image') {
+        if (typeof ref.url === 'string' && ref.url.length > 0) {
+          flushText()
+          blocks.push({
+            type: 'image',
+            source: { type: 'url', url: ref.url },
+          })
+        } else {
+          validationErrors.push({
+            kind: 'missing_ref',
+            placeholder: ph.inner,
+            detail: 'image reference is missing a url',
+          })
+        }
+        continue
+      }
+      // audio (reserved in schema, unimplemented in v1) and any future kinds
+      validationErrors.push({
+        kind: 'unsupported_ref_kind',
+        placeholder: ph.inner,
+        detail: `ref kind "${ref.kind}" is not supported in v1`,
+      })
+      continue
+    }
+
+    // Unknown placeholder shape — leave the literal in place so the prompt
+    // does not silently drop content, and surface the error.
+    validationErrors.push({
+      kind: 'unknown_placeholder',
+      placeholder: ph.inner,
+    })
+    textBuffer += ph.raw
+    resolvedSegments.push(ph.raw)
+  }
+
+  const tail = instruction.slice(cursor)
+  textBuffer += tail
+  resolvedSegments.push(tail)
+  flushText()
+
+  return {
+    user_message_blocks: blocks,
+    resolved_text: resolvedSegments.join(''),
+    validation_errors: validationErrors,
+  }
+}
+
+export function validate(
+  step: TemplateStep,
+  declaredParamsKeys: readonly string[],
+  declaredNeedsOutputsFrom: readonly number[],
+  declaredReferenceIds: readonly string[],
+): ValidationError[] {
+  const instruction = step?.instruction ?? ''
+  const placeholders = parsePlaceholders(instruction)
+  const errors: ValidationError[] = []
+  const seen = new Set<string>()
+
+  const paramSet = new Set(declaredParamsKeys)
+  const stepSet = new Set(declaredNeedsOutputsFrom)
+  const refSet = new Set(declaredReferenceIds)
+
+  for (const ph of placeholders) {
+    if (seen.has(ph.inner)) continue
+    seen.add(ph.inner)
+
+    const c = classify(ph.inner)
+
+    if (c.kind === 'param') {
+      if (!paramSet.has(c.name)) {
+        errors.push({ kind: 'undeclared_param', placeholder: ph.inner })
+      }
+      continue
+    }
+    if (c.kind === 'step_output' || c.kind === 'step_output_files') {
+      if (!stepSet.has(c.index)) {
+        errors.push({ kind: 'undeclared_step', placeholder: ph.inner })
+      }
+      continue
+    }
+    if (c.kind === 'ref') {
+      if (!refSet.has(c.key)) {
+        errors.push({ kind: 'undeclared_ref', placeholder: ph.inner })
+      }
+      continue
+    }
+    errors.push({ kind: 'unknown_placeholder', placeholder: ph.inner })
+  }
+
+  return errors
+}


### PR DESCRIPTION
Closes #347

Adds `supabase/functions/_shared/templateRenderer.ts` — a pure deep module that
resolves Mustache placeholders against a runtime context (params, prior step
outputs, references) and produces an Anthropic-API-ready `user_message_blocks[]`
array of interleaved text and image blocks plus a flat `resolved_text` debug
string. Also exposes `validate(step, paramsKeys, needsOutputsFrom, referenceIds)`
for save-time use that returns a list of structured errors instead of throwing.

Implements the four placeholder kinds documented in PRD #344:

- `{{params.X}}` — string lookup in `params`.
- `{{step-N.output}}` — string lookup in `priorSteps[N-1].output`.
- `{{step-N.output_files}}` — markdown URL list in the text **plus** Anthropic
  `image` content blocks for every file whose `mime_type` starts with `image/`.
- `{{ref:KEY}}` — `references[KEY].content_text` for `kind=text`; emitted as an
  Anthropic `image` block (not URL text) for `kind=image`. `audio` is reserved
  in the schema but flagged as `unsupported_ref_kind` in v1.

Missing or unknown placeholders surface as structured `validation_errors[]`
entries — the renderer never throws.

The module is intentionally pure: zero `fetch`, zero `Deno.env`, zero Supabase
imports, ready to be consumed by the upcoming executor extension and the
`/templates` editor save-time validator.

## TDD
- Tests added: `supabase/functions/_shared/templateRenderer.test.ts`
- Before implementation (red): the test file referenced a not-yet-existing
  module; `deno test` failed type-check with `Cannot find module
  './templateRenderer.ts'` and 28 cases unreachable.
- After implementation (green): `npm run test:functions` → 124 passed
  (96 baseline + 28 new). `npm test` → 427 passed. `npm run lint` → 0 errors.

## Notes
- 28 new table-driven cases follow the style of `githubFilters.test.ts`:
  every placeholder kind, image-block injection, output_files mime filter,
  whitespace tolerance, ordering, missing-vs-undeclared distinctions, and the
  duplicate-placeholder dedup in `validate()`.
- Saved as `_shared/` (not `chat/`) because the renderer will be reused by the
  approval/retry endpoints, the `render_html_to_image` step builder, and the
  `/templates` save-time UI validator — none of which live under `chat/`.