### PR TITLE
feat(chat): wire native Anthropic web_search/web_fetch with Tavily fallback

### DIFF
--- a/supabase/functions/chat/executor.test.ts
+++ b/supabase/functions/chat/executor.test.ts
@@ -59,6 +59,16 @@ function withGithubToken(token: string | null): () => void {
   }
 }
 
+function withEnv(key: string, value: string | null): () => void {
+  const previous = Deno.env.get(key)
+  if (value === null) Deno.env.delete(key)
+  else Deno.env.set(key, value)
+  return () => {
+    if (previous === undefined) Deno.env.delete(key)
+    else Deno.env.set(key, previous)
+  }
+}
+
 function makeCtx() {
   return {
     signal: new AbortController().signal,

--- a/supabase/functions/chat/executor.test.ts
+++ b/supabase/functions/chat/executor.test.ts
@@ -1,9 +1,10 @@
 import {
   assert,
   assertEquals,
+  assertExists,
   assertStringIncludes,
 } from 'jsr:@std/assert@1'
-import { TOOL_HANDLERS } from './executor.ts'
+import { runStep, TOOL_HANDLERS } from './executor.ts'
 
 interface MockCall {
   url: string

--- a/supabase/functions/chat/executor.test.ts
+++ b/supabase/functions/chat/executor.test.ts
@@ -286,3 +286,377 @@ Deno.test('create_github_issue — surfaces upstream 422 validation error', asyn
     restoreToken()
   }
 })
+
+// ─── runStep — native web_search/web_fetch wiring ───────────────────────────
+
+const RESEARCHER_AGENT = {
+  id: 'researcher',
+  name: 'Researcher',
+  content: 'You are a researcher. Use web_search to find information.',
+  tools: ['web_search'],
+  model: 'claude-sonnet-4-6',
+}
+
+const WEB_SEARCH_TOOL_META = {
+  id: 'web_search',
+  name: 'Web search',
+  description: 'Search the web',
+  input_schema: { type: 'object', properties: { query: { type: 'string' } } },
+}
+
+function makeStep(toolsUsed: string[]) {
+  return {
+    id: 1,
+    agent_id: 'researcher',
+    agent_name: 'Researcher',
+    task: 'Find python web frameworks',
+    tools_used: toolsUsed,
+    inputs: ['original_task'],
+  }
+}
+
+function findAnthropicCalls(calls: MockCall[]): MockCall[] {
+  return calls.filter((c) => c.url === 'https://api.anthropic.com/v1/messages')
+}
+
+function getRequestBody(call: MockCall): any {
+  return JSON.parse(call.init?.body as string)
+}
+
+Deno.test('runStep — injects native web_search_20250305 tool def when agent declares web_search', async () => {
+  const restoreAnthropic = withEnv('ANTHROPIC_API_KEY', 'sk-test')
+  const { calls, restore } = installFetchMock(() =>
+    jsonResponse(200, {
+      content: [{ type: 'text', text: 'done' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    }),
+  )
+  try {
+    await runStep(
+      makeStep(['web_search']),
+      [RESEARCHER_AGENT],
+      [WEB_SEARCH_TOOL_META],
+      'context',
+      {},
+      () => {},
+      'sk-test',
+      new AbortController().signal,
+    )
+    const anthropicCalls = findAnthropicCalls(calls)
+    assertEquals(anthropicCalls.length, 1)
+    const body = getRequestBody(anthropicCalls[0])
+    assertExists(body.tools)
+    const native = body.tools.find(
+      (t: { type?: string }) => t.type === 'web_search_20250305',
+    )
+    assertExists(native, 'expected native web_search_20250305 tool def in request body')
+    assertEquals(native.name, 'web_search')
+    // Client-side web_search def must NOT be sent (would collide on `name`).
+    const clientSide = body.tools.find(
+      (t: { type?: string; name?: string }) =>
+        t.name === 'web_search' && t.type !== 'web_search_20250305',
+    )
+    assertEquals(clientSide, undefined)
+  } finally {
+    restore()
+    restoreAnthropic()
+  }
+})
+
+Deno.test('runStep — falls back to Tavily when native web_search returns zero results', async () => {
+  const restoreAnthropic = withEnv('ANTHROPIC_API_KEY', 'sk-test')
+  const restoreTavily = withEnv('TAVILY_API_KEY', 'tv-test')
+  let anthropicCallCount = 0
+  let tavilyCallCount = 0
+  let tavilyQuery = ''
+  const { restore } = installFetchMock((call) => {
+    if (call.url === 'https://api.anthropic.com/v1/messages') {
+      anthropicCallCount++
+      if (anthropicCallCount === 1) {
+        return jsonResponse(200, {
+          content: [
+            {
+              type: 'server_tool_use',
+              id: 'srvtoolu_1',
+              name: 'web_search',
+              input: { query: 'python web frameworks' },
+            },
+            {
+              type: 'web_search_tool_result',
+              tool_use_id: 'srvtoolu_1',
+              content: [],
+            },
+            { type: 'text', text: 'I could not find anything.' },
+          ],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        })
+      }
+      // Second turn after fallback — model emits final text only.
+      return jsonResponse(200, {
+        content: [{ type: 'text', text: 'done with tavily' }],
+        usage: { input_tokens: 5, output_tokens: 5 },
+      })
+    }
+    if (call.url === 'https://api.tavily.com/search') {
+      tavilyCallCount++
+      const body = JSON.parse(call.init?.body as string)
+      tavilyQuery = body.query
+      return jsonResponse(200, {
+        results: [
+          {
+            title: 'Django',
+            url: 'https://www.djangoproject.com/',
+            content: 'High-level Python web framework.',
+          },
+        ],
+      })
+    }
+    return jsonResponse(404, {})
+  })
+  try {
+    await runStep(
+      makeStep(['web_search']),
+      [RESEARCHER_AGENT],
+      [WEB_SEARCH_TOOL_META],
+      'context',
+      {},
+      () => {},
+      'sk-test',
+      new AbortController().signal,
+    )
+    assertEquals(tavilyCallCount, 1)
+    assertEquals(tavilyQuery, 'python web frameworks')
+    assertEquals(anthropicCallCount, 2)
+  } finally {
+    restore()
+    restoreAnthropic()
+    restoreTavily()
+  }
+})
+
+Deno.test('runStep — falls back to Tavily when native web_search errors', async () => {
+  const restoreAnthropic = withEnv('ANTHROPIC_API_KEY', 'sk-test')
+  const restoreTavily = withEnv('TAVILY_API_KEY', 'tv-test')
+  let tavilyCallCount = 0
+  let tavilyQuery = ''
+  let anthropicCallCount = 0
+  const { restore } = installFetchMock((call) => {
+    if (call.url === 'https://api.anthropic.com/v1/messages') {
+      anthropicCallCount++
+      if (anthropicCallCount === 1) {
+        return jsonResponse(200, {
+          content: [
+            {
+              type: 'server_tool_use',
+              id: 'srvtoolu_2',
+              name: 'web_search',
+              input: { query: 'fastapi performance' },
+            },
+            {
+              type: 'web_search_tool_result',
+              tool_use_id: 'srvtoolu_2',
+              content: {
+                type: 'web_search_tool_result_error',
+                error_code: 'max_uses_exceeded',
+              },
+            },
+            { type: 'text', text: 'Search errored.' },
+          ],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        })
+      }
+      return jsonResponse(200, {
+        content: [{ type: 'text', text: 'done' }],
+        usage: { input_tokens: 5, output_tokens: 5 },
+      })
+    }
+    if (call.url === 'https://api.tavily.com/search') {
+      tavilyCallCount++
+      const body = JSON.parse(call.init?.body as string)
+      tavilyQuery = body.query
+      return jsonResponse(200, { results: [] })
+    }
+    return jsonResponse(404, {})
+  })
+  try {
+    await runStep(
+      makeStep(['web_search']),
+      [RESEARCHER_AGENT],
+      [WEB_SEARCH_TOOL_META],
+      'context',
+      {},
+      () => {},
+      'sk-test',
+      new AbortController().signal,
+    )
+    assertEquals(tavilyCallCount, 1)
+    assertEquals(tavilyQuery, 'fastapi performance')
+  } finally {
+    restore()
+    restoreAnthropic()
+    restoreTavily()
+  }
+})
+
+Deno.test('runStep — does NOT add native web tools when agent does not declare them', async () => {
+  const restoreAnthropic = withEnv('ANTHROPIC_API_KEY', 'sk-test')
+  const restoreGithub = withEnv('GITHUB_TOKEN', 'tok')
+  const { calls, restore } = installFetchMock((call) => {
+    if (call.url === 'https://api.anthropic.com/v1/messages') {
+      return jsonResponse(200, {
+        content: [{ type: 'text', text: 'done' }],
+        usage: { input_tokens: 5, output_tokens: 5 },
+      })
+    }
+    return jsonResponse(404, {})
+  })
+  try {
+    const issueAgent = {
+      id: 'issuer',
+      name: 'Issuer',
+      content: 'You file issues.',
+      tools: ['create_github_issue'],
+      model: 'claude-sonnet-4-6',
+    }
+    const issueStep = {
+      id: 1,
+      agent_id: 'issuer',
+      task: 'File an issue',
+      tools_used: ['create_github_issue'],
+      inputs: ['original_task'],
+    }
+    const issueToolMeta = {
+      id: 'create_github_issue',
+      name: 'Create issue',
+      description: 'Create a GitHub issue',
+      input_schema: { type: 'object', properties: {} },
+    }
+    await runStep(
+      issueStep,
+      [issueAgent],
+      [issueToolMeta],
+      'context',
+      {},
+      () => {},
+      'sk-test',
+      new AbortController().signal,
+    )
+    const body = getRequestBody(findAnthropicCalls(calls)[0])
+    const hasNativeWebSearch = (body.tools || []).some(
+      (t: { type?: string }) => t.type === 'web_search_20250305',
+    )
+    const hasNativeWebFetch = (body.tools || []).some(
+      (t: { type?: string }) => t.type === 'web_fetch_20250910',
+    )
+    assertEquals(hasNativeWebSearch, false)
+    assertEquals(hasNativeWebFetch, false)
+  } finally {
+    restore()
+    restoreAnthropic()
+    restoreGithub()
+  }
+})
+
+Deno.test('runStep — successful native web_search does NOT trigger Tavily fallback', async () => {
+  const restoreAnthropic = withEnv('ANTHROPIC_API_KEY', 'sk-test')
+  const restoreTavily = withEnv('TAVILY_API_KEY', 'tv-test')
+  let tavilyCallCount = 0
+  const { restore } = installFetchMock((call) => {
+    if (call.url === 'https://api.anthropic.com/v1/messages') {
+      return jsonResponse(200, {
+        content: [
+          {
+            type: 'server_tool_use',
+            id: 'srvtoolu_ok',
+            name: 'web_search',
+            input: { query: 'q' },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_ok',
+            content: [
+              { type: 'web_search_result', url: 'https://x.com', title: 't' },
+            ],
+          },
+          { type: 'text', text: 'Found something.' },
+        ],
+        usage: { input_tokens: 5, output_tokens: 5 },
+      })
+    }
+    if (call.url === 'https://api.tavily.com/search') {
+      tavilyCallCount++
+      return jsonResponse(200, { results: [] })
+    }
+    return jsonResponse(404, {})
+  })
+  try {
+    await runStep(
+      makeStep(['web_search']),
+      [RESEARCHER_AGENT],
+      [WEB_SEARCH_TOOL_META],
+      'context',
+      {},
+      () => {},
+      'sk-test',
+      new AbortController().signal,
+    )
+    assertEquals(tavilyCallCount, 0)
+  } finally {
+    restore()
+    restoreAnthropic()
+    restoreTavily()
+  }
+})
+
+Deno.test('runStep — adds anthropic-beta header when native web_fetch declared', async () => {
+  const restoreAnthropic = withEnv('ANTHROPIC_API_KEY', 'sk-test')
+  const { calls, restore } = installFetchMock(() =>
+    jsonResponse(200, {
+      content: [{ type: 'text', text: 'done' }],
+      usage: { input_tokens: 5, output_tokens: 5 },
+    }),
+  )
+  try {
+    const fetcherAgent = {
+      id: 'fetcher',
+      name: 'Fetcher',
+      content: 'You fetch URLs.',
+      tools: ['web_fetch'],
+      model: 'claude-sonnet-4-6',
+    }
+    const fetchStep = {
+      id: 1,
+      agent_id: 'fetcher',
+      task: 'Fetch a URL',
+      tools_used: ['web_fetch'],
+      inputs: ['original_task'],
+    }
+    const webFetchToolMeta = {
+      id: 'web_fetch',
+      name: 'Web fetch',
+      description: 'Fetch a URL',
+      input_schema: { type: 'object', properties: {} },
+    }
+    await runStep(
+      fetchStep,
+      [fetcherAgent],
+      [webFetchToolMeta],
+      'context',
+      {},
+      () => {},
+      'sk-test',
+      new AbortController().signal,
+    )
+    const anthropicCall = findAnthropicCalls(calls)[0]
+    const headers = (anthropicCall.init?.headers ?? {}) as Record<string, string>
+    assertEquals(headers['anthropic-beta'], 'web-fetch-2025-09-10')
+    const body = getRequestBody(anthropicCall)
+    const native = body.tools.find(
+      (t: { type?: string }) => t.type === 'web_fetch_20250910',
+    )
+    assertExists(native)
+  } finally {
+    restore()
+    restoreAnthropic()
+  }
+})

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -917,7 +917,52 @@ export async function runStep(
 
     const toolUses = content.filter((b) => b.type === 'tool_use')
     if (toolUses.length === 0) {
-      // Model produced only text — step is done.
+      // Model produced only text — but first check whether the native
+      // server-side web_search returned zero results / errored. If so, run
+      // the Tavily-backed handler once and re-prompt with those results.
+      if (!nativeFallbackUsed) {
+        const failed = findFailedNativeSearches(content)
+        if (failed.length > 0) {
+          nativeFallbackUsed = true
+          const fallbackPayload: any[] = []
+          for (const f of failed) {
+            console.log(
+              JSON.stringify({
+                event: 'web_search.fallback.tavily',
+                step_id: step.id,
+                query: f.query,
+                reason: f.reason,
+              }),
+            )
+            const tavilyResult = await webSearch(
+              { query: f.query },
+              {
+                signal,
+                agentsContext,
+                stepId: step.id,
+                toolCallId: `fallback-${f.tool_use_id}`,
+                userId,
+              },
+            )
+            fallbackPayload.push({
+              query: f.query,
+              ok: tavilyResult.ok,
+              result: tavilyResult.result,
+              error: tavilyResult.error,
+            })
+          }
+          messages.push({ role: 'assistant', content })
+          messages.push({
+            role: 'user',
+            content: `The native web_search returned no usable results (${failed
+              .map((f) => f.reason)
+              .join(', ')}). Tavily fallback results follow — use them to complete the task:\n\n${JSON.stringify(
+              fallbackPayload,
+            ).slice(0, 4000)}`,
+          })
+          continue
+        }
+      }
       return { text: finalText, tokens_in: totalIn, tokens_out: totalOut }
     }
 

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -773,7 +773,9 @@ export async function runStep(
   const skippedIds: string[] = []
   for (const id of declaredIds) {
     if (!agentToolIds.has(id)) continue
-    if (!availableInEnv.has(id)) {
+    // Native web tools (web_search / web_fetch) run server-side on Anthropic
+    // and need no client config — they're always allowed when declared.
+    if (!availableInEnv.has(id) && !NATIVE_WEB_TOOL_IDS.has(id)) {
       skippedIds.push(id)
       continue
     }

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -802,9 +802,18 @@ export async function runStep(
     })
   }
 
-  const anthropicTools = allowedIds
+  // For web_search / web_fetch we inject Anthropic's server-side tool def
+  // (`web_search_20250305` / `web_fetch_20250910`) instead of the client-side
+  // schema, so the model uses the native research path first.
+  const clientToolDefs = allowedIds
+    .filter((id) => !NATIVE_WEB_TOOL_IDS.has(id))
     .map((id) => buildAnthropicTool(id, toolsContext))
     .filter(Boolean) as any[]
+  const nativeToolDefs = buildNativeWebTools(
+    allowedIds.filter((id) => NATIVE_WEB_TOOL_IDS.has(id)),
+  )
+  const anthropicTools = [...clientToolDefs, ...nativeToolDefs] as any[]
+  const usesNativeWebFetch = nativeToolDefs.some((t) => t.type === 'web_fetch_20250910')
 
   const unavailableNotice =
     skippedIds.length > 0

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -17,6 +17,17 @@
 
 import { createIssue, listRepos } from './github.ts'
 import { filterAndSlim } from './githubFilters.ts'
+import {
+  buildNativeWebTools,
+  findFailedNativeSearches,
+} from './webResearchTools.ts'
+
+// Tools whose client-side declaration is replaced with the Anthropic native
+// server-side tool (web_search_20250305 / web_fetch_20250910). The model uses
+// the native tool first; the Tavily-backed `web_search` handler stays as a
+// fallback when the native call returns zero results or errors.
+const NATIVE_WEB_TOOL_IDS = new Set(['web_search', 'web_fetch'])
+const WEB_FETCH_BETA_HEADER = 'web-fetch-2025-09-10'
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const DEFAULT_STEP_MODEL = 'claude-sonnet-4-6'

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -850,6 +850,8 @@ export async function runStep(
   // Tracks repeated tool failures: if the same tool fails twice in a row,
   // abort the step rather than burning iterations on a broken loop.
   const consecutiveFailures = new Map<string, number>()
+  // Tavily fallback for the native web_search runs at most once per step.
+  let nativeFallbackUsed = false
 
   for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
     const reqBody: any = {
@@ -860,17 +862,22 @@ export async function runStep(
     }
     if (anthropicTools.length > 0) reqBody.tools = anthropicTools
 
+    const headers: Record<string, string> = {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    }
+    if (usesNativeWebFetch) {
+      headers['anthropic-beta'] = WEB_FETCH_BETA_HEADER
+    }
+
     // Fetch with a single retry on 429 (rate limit). Waits for the
     // Retry-After header value or 10s, whichever is smaller.
     let res: Response
     const doFetch = () =>
       fetch(ANTHROPIC_API_URL, {
         method: 'POST',
-        headers: {
-          'x-api-key': apiKey,
-          'anthropic-version': '2023-06-01',
-          'content-type': 'application/json',
-        },
+        headers,
         body: JSON.stringify(reqBody),
         signal,
       })

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -738,7 +738,7 @@ function buildStepContext(
 
 type EmitFn = (type: string, payload?: Record<string, unknown>) => void
 
-async function runStep(
+export async function runStep(
   step: any,
   agentsContext: any[],
   toolsContext: any[],

--- a/supabase/functions/chat/webResearchTools.test.ts
+++ b/supabase/functions/chat/webResearchTools.test.ts
@@ -1,0 +1,127 @@
+import { assert, assertEquals } from 'jsr:@std/assert@1'
+import {
+  buildNativeWebTools,
+  findFailedNativeSearches,
+  NATIVE_WEB_FETCH_TOOL_DEF,
+  NATIVE_WEB_SEARCH_TOOL_DEF,
+} from './webResearchTools.ts'
+
+// ─── buildNativeWebTools ────────────────────────────────────────────────────
+
+Deno.test('buildNativeWebTools — returns web_search native def when declared', () => {
+  const tools = buildNativeWebTools(['web_search'])
+  assertEquals(tools, [NATIVE_WEB_SEARCH_TOOL_DEF])
+  assertEquals(tools[0].type, 'web_search_20250305')
+  assertEquals(tools[0].name, 'web_search')
+})
+
+Deno.test('buildNativeWebTools — returns web_fetch native def when declared', () => {
+  const tools = buildNativeWebTools(['web_fetch'])
+  assertEquals(tools, [NATIVE_WEB_FETCH_TOOL_DEF])
+  assertEquals(tools[0].type, 'web_fetch_20250910')
+  assertEquals(tools[0].name, 'web_fetch')
+})
+
+Deno.test('buildNativeWebTools — returns both when both declared', () => {
+  const tools = buildNativeWebTools(['web_search', 'web_fetch'])
+  assertEquals(tools.length, 2)
+  assert(tools.some((t) => t.type === 'web_search_20250305'))
+  assert(tools.some((t) => t.type === 'web_fetch_20250910'))
+})
+
+Deno.test('buildNativeWebTools — returns empty array when neither declared', () => {
+  const tools = buildNativeWebTools(['list_github_repos', 'create_github_issue'])
+  assertEquals(tools, [])
+})
+
+Deno.test('buildNativeWebTools — accepts a Set as input', () => {
+  const tools = buildNativeWebTools(new Set(['web_search']))
+  assertEquals(tools.length, 1)
+  assertEquals(tools[0].type, 'web_search_20250305')
+})
+
+// ─── findFailedNativeSearches ───────────────────────────────────────────────
+
+Deno.test('findFailedNativeSearches — returns empty when no web_search_tool_result blocks', () => {
+  const content = [
+    { type: 'text', text: 'hello' },
+    { type: 'tool_use', id: 't1', name: 'fetch_url', input: { url: 'https://x.com' } },
+  ]
+  assertEquals(findFailedNativeSearches(content), [])
+})
+
+Deno.test('findFailedNativeSearches — flags zero-result web_search_tool_result', () => {
+  const content = [
+    { type: 'server_tool_use', id: 'srv1', name: 'web_search', input: { query: 'foo' } },
+    { type: 'web_search_tool_result', tool_use_id: 'srv1', content: [] },
+  ]
+  const failures = findFailedNativeSearches(content)
+  assertEquals(failures.length, 1)
+  assertEquals(failures[0].tool_use_id, 'srv1')
+  assertEquals(failures[0].query, 'foo')
+  assertEquals(failures[0].reason, 'no_results')
+})
+
+Deno.test('findFailedNativeSearches — flags errored web_search_tool_result', () => {
+  const content = [
+    { type: 'server_tool_use', id: 'srv2', name: 'web_search', input: { query: 'bar' } },
+    {
+      type: 'web_search_tool_result',
+      tool_use_id: 'srv2',
+      content: { type: 'web_search_tool_result_error', error_code: 'max_uses_exceeded' },
+    },
+  ]
+  const failures = findFailedNativeSearches(content)
+  assertEquals(failures.length, 1)
+  assertEquals(failures[0].query, 'bar')
+  assertEquals(failures[0].reason, 'error')
+})
+
+Deno.test('findFailedNativeSearches — does not flag successful results', () => {
+  const content = [
+    { type: 'server_tool_use', id: 'srv3', name: 'web_search', input: { query: 'baz' } },
+    {
+      type: 'web_search_tool_result',
+      tool_use_id: 'srv3',
+      content: [
+        { type: 'web_search_result', url: 'https://example.com', title: 'Example' },
+      ],
+    },
+  ]
+  assertEquals(findFailedNativeSearches(content), [])
+})
+
+Deno.test('findFailedNativeSearches — handles multiple searches mixed', () => {
+  const content = [
+    { type: 'server_tool_use', id: 's1', name: 'web_search', input: { query: 'q1' } },
+    { type: 'server_tool_use', id: 's2', name: 'web_search', input: { query: 'q2' } },
+    {
+      type: 'web_search_tool_result',
+      tool_use_id: 's1',
+      content: [{ type: 'web_search_result', url: 'u', title: 't' }],
+    },
+    { type: 'web_search_tool_result', tool_use_id: 's2', content: [] },
+  ]
+  const failures = findFailedNativeSearches(content)
+  assertEquals(failures.length, 1)
+  assertEquals(failures[0].query, 'q2')
+})
+
+Deno.test('findFailedNativeSearches — tolerates missing query metadata', () => {
+  const content = [
+    { type: 'web_search_tool_result', tool_use_id: 'orphan', content: [] },
+  ]
+  const failures = findFailedNativeSearches(content)
+  assertEquals(failures.length, 1)
+  assertEquals(failures[0].query, '')
+  assertEquals(failures[0].reason, 'no_results')
+})
+
+Deno.test('findFailedNativeSearches — tolerates non-array input', () => {
+  // deno-lint-ignore no-explicit-any
+  assertEquals(findFailedNativeSearches(null as any), [])
+  // deno-lint-ignore no-explicit-any
+  assertEquals(findFailedNativeSearches(undefined as any), [])
+  // deno-lint-ignore no-explicit-any
+  assertEquals(findFailedNativeSearches('not an array' as any), [])
+})

--- a/supabase/functions/chat/webResearchTools.ts
+++ b/supabase/functions/chat/webResearchTools.ts
@@ -1,0 +1,89 @@
+// Pure helpers for Anthropic native server-side web research tools
+// (`web_search_20250305` and `web_fetch_20250910`).
+//
+// The executor and selected-agent branches use `buildNativeWebTools` to inject
+// these tool definitions into the Anthropic request when the agent declares
+// the matching client-side tool ids (`web_search` / `web_fetch`).
+//
+// After receiving a response, `findFailedNativeSearches` scans the content
+// blocks for `web_search_tool_result` blocks that came back empty or with an
+// error code, returning the original query so the caller can fall back to the
+// Tavily client-side handler.
+//
+// deno-lint-ignore-file no-explicit-any
+
+export interface NativeToolDef {
+  type: string
+  name: string
+}
+
+export const NATIVE_WEB_SEARCH_TOOL_DEF: NativeToolDef = {
+  type: 'web_search_20250305',
+  name: 'web_search',
+}
+
+export const NATIVE_WEB_FETCH_TOOL_DEF: NativeToolDef = {
+  type: 'web_fetch_20250910',
+  name: 'web_fetch',
+}
+
+export function buildNativeWebTools(declaredIds: Iterable<string>): NativeToolDef[] {
+  const set = declaredIds instanceof Set
+    ? (declaredIds as Set<string>)
+    : new Set(declaredIds)
+  const tools: NativeToolDef[] = []
+  if (set.has('web_search')) tools.push({ ...NATIVE_WEB_SEARCH_TOOL_DEF })
+  if (set.has('web_fetch')) tools.push({ ...NATIVE_WEB_FETCH_TOOL_DEF })
+  return tools
+}
+
+export type FailureReason = 'no_results' | 'error'
+
+export interface FailedNativeSearch {
+  tool_use_id: string
+  query: string
+  reason: FailureReason
+}
+
+export function findFailedNativeSearches(content: any[]): FailedNativeSearch[] {
+  if (!Array.isArray(content)) return []
+
+  // First pass: index server_tool_use blocks so we can recover the query that
+  // triggered each web_search_tool_result.
+  const queries = new Map<string, string>()
+  for (const b of content) {
+    if (
+      b &&
+      b.type === 'server_tool_use' &&
+      b.name === 'web_search' &&
+      typeof b.id === 'string' &&
+      b.input &&
+      typeof b.input.query === 'string'
+    ) {
+      queries.set(b.id, b.input.query)
+    }
+  }
+
+  const failures: FailedNativeSearch[] = []
+  for (const b of content) {
+    if (!b || b.type !== 'web_search_tool_result' || typeof b.tool_use_id !== 'string') {
+      continue
+    }
+    const query = queries.get(b.tool_use_id) ?? ''
+    const c = b.content
+    if (Array.isArray(c)) {
+      if (c.length === 0) {
+        failures.push({ tool_use_id: b.tool_use_id, query, reason: 'no_results' })
+      }
+      continue
+    }
+    if (
+      c &&
+      typeof c === 'object' &&
+      (c.type === 'web_search_tool_result_error' || typeof c.error_code === 'string')
+    ) {
+      failures.push({ tool_use_id: b.tool_use_id, query, reason: 'error' })
+    }
+  }
+  return failures
+}


### PR DESCRIPTION
Closes #348

## Summary

Wires Anthropic's native server-side `web_search_20250305` and `web_fetch_20250910` as the primary research tools in the chat Edge Function executor. The existing Tavily-backed `web_search` handler stays as a fallback that activates only when the native call returns zero results or errors out.

- New module `supabase/functions/chat/webResearchTools.ts` with two pure helpers:
  - `buildNativeWebTools(declaredIds)` — returns the native tool defs to inject in the Anthropic request.
  - `findFailedNativeSearches(content)` — scans response content blocks for empty / errored `web_search_tool_result` blocks and recovers the original query from the matching `server_tool_use`.
- `runStep` in `executor.ts` now:
  - replaces the client-side `web_search` / `web_fetch` defs with the native server-side defs when declared,
  - allows `web_search` / `web_fetch` even when their client config is absent (native path needs no extra secret),
  - adds the `anthropic-beta: web-fetch-2025-09-10` header when `web_fetch` is declared,
  - after each API turn, when the model produced only text, detects failed native searches, runs the Tavily handler once with the original query, emits a structured `web_search.fallback.tavily` log line, and re-prompts the model with the Tavily payload.
- Per-step fallback fires at most once (`nativeFallbackUsed` flag) so a flaky Tavily call cannot loop.

## TDD

- Tests added/modified:
  - `supabase/functions/chat/webResearchTools.test.ts` (new) — 12 unit tests covering native tool def building and failed-search detection edge cases.
  - `supabase/functions/chat/executor.test.ts` — 6 new integration tests that exercise `runStep` with mocked `fetch` for both Anthropic and Tavily endpoints.
- Before implementation (red): `webResearchTools.test.ts` failed to type-check (`Cannot find module 'webResearchTools.ts'`) and the new `runStep` integration tests didn't exist; the `runStep` symbol wasn't even exported.
- After implementation (green): `npm run test:functions` → 142 tests pass / 0 failed; `npm test` → 427 frontend tests pass; `npm run lint` → 0 errors.

## Acceptance criteria mapping

- Happy-path native call asserted by `runStep — injects native web_search_20250305 tool def when agent declares web_search`.
- Zero-result fallback asserted by `runStep — falls back to Tavily when native web_search returns zero results` (verifies Tavily was called exactly once with the same query).
- Errored-result fallback asserted by `runStep — falls back to Tavily when native web_search errors`.
- No regression on agents without `web_search` asserted by `runStep — does NOT add native web tools when agent does not declare them`.
- Existing executor tests still pass without modification.

## Notes

- The selected-agent branch (`selectedAgentBranch.ts`) is intentionally untouched in this PR — the issue scopes the change to the executor's per-step path. A follow-up can wire the same behavior into the streaming branch if needed.
- No new secrets required; the Tavily fallback continues to depend on the existing `TAVILY_API_KEY` and degrades gracefully (returns "not_configured") when missing.