### PR TITLE
feat: render_html_to_image Edge Function tool

### DIFF
--- a/supabase/functions/_shared/htmlScreenshotter.test.ts
+++ b/supabase/functions/_shared/htmlScreenshotter.test.ts
@@ -1,0 +1,516 @@
+// deno-lint-ignore-file no-explicit-any
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from 'jsr:@std/assert@1'
+import {
+  captureHtmlToTaskOutput,
+  fetchBrowserlessPng,
+} from './htmlScreenshotter.ts'
+
+interface MockCall {
+  url: string
+  init?: RequestInit
+}
+
+function installFetchMock(
+  responder: (call: MockCall) => Response | Promise<Response>,
+): { calls: MockCall[]; restore: () => void } {
+  const calls: MockCall[] = []
+  const original = globalThis.fetch
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url
+    const call: MockCall = { url, init }
+    calls.push(call)
+    return await responder(call)
+  }) as typeof fetch
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original
+    },
+  }
+}
+
+function pngResponse(status: number, bytes: Uint8Array): Response {
+  return new Response(bytes, {
+    status,
+    headers: { 'Content-Type': 'image/png' },
+  })
+}
+
+const FAKE_PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+const FAKE_JPEG = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10])
+
+interface CapturedUpload {
+  bucket: string
+  path: string
+  body: unknown
+  options?: { contentType?: string; upsert?: boolean }
+}
+
+interface CapturedSignedUrl {
+  bucket: string
+  path: string
+  ttlSeconds: number
+}
+
+function makeSupabase(opts: {
+  uploadError?: { message: string }
+  signedUrl?: string
+  signedUrlError?: { message: string }
+} = {}): {
+  client: any
+  uploads: CapturedUpload[]
+  signedUrls: CapturedSignedUrl[]
+} {
+  const uploads: CapturedUpload[] = []
+  const signedUrls: CapturedSignedUrl[] = []
+  const client = {
+    storage: {
+      from(bucket: string) {
+        return {
+          upload(path: string, body: unknown, options?: any) {
+            uploads.push({ bucket, path, body, options })
+            if (opts.uploadError) {
+              return Promise.resolve({
+                data: null,
+                error: opts.uploadError,
+              })
+            }
+            return Promise.resolve({
+              data: { path },
+              error: null,
+            })
+          },
+          createSignedUrl(path: string, ttlSeconds: number) {
+            signedUrls.push({ bucket, path, ttlSeconds })
+            if (opts.signedUrlError) {
+              return Promise.resolve({
+                data: null,
+                error: opts.signedUrlError,
+              })
+            }
+            return Promise.resolve({
+              data: {
+                signedUrl:
+                  opts.signedUrl ??
+                  `https://signed.example/${bucket}/${path}?token=abc`,
+              },
+              error: null,
+            })
+          },
+        }
+      },
+    },
+  }
+  return { client, uploads, signedUrls }
+}
+
+// ─── fetchBrowserlessPng ─────────────────────────────────────────────────────
+
+Deno.test('fetchBrowserlessPng — POSTs to chrome.browserless.io/screenshot with token', async () => {
+  const { calls, restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  try {
+    await fetchBrowserlessPng('TOK', {
+      html: '<h1>hi</h1>',
+      width: 1080,
+      height: 1080,
+    })
+  } finally {
+    restore()
+  }
+  assertEquals(calls.length, 1)
+  const url = new URL(calls[0].url)
+  assertEquals(url.origin + url.pathname, 'https://chrome.browserless.io/screenshot')
+  assertEquals(url.searchParams.get('token'), 'TOK')
+  assertEquals(calls[0].init?.method, 'POST')
+})
+
+Deno.test('fetchBrowserlessPng — sends html + viewport + png type in JSON body', async () => {
+  const { calls, restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  try {
+    await fetchBrowserlessPng('TOK', {
+      html: '<h1>hi</h1>',
+      width: 1080,
+      height: 1350,
+    })
+  } finally {
+    restore()
+  }
+  const body = JSON.parse(String(calls[0].init?.body ?? '{}'))
+  assertEquals(body.html, '<h1>hi</h1>')
+  assertEquals(body.viewport, { width: 1080, height: 1350 })
+  assertEquals(body.options?.type, 'png')
+})
+
+Deno.test('fetchBrowserlessPng — sets Content-Type: application/json', async () => {
+  const { calls, restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  try {
+    await fetchBrowserlessPng('TOK', {
+      html: '<h1>hi</h1>',
+      width: 800,
+      height: 600,
+    })
+  } finally {
+    restore()
+  }
+  const headers = new Headers(calls[0].init?.headers)
+  assertEquals(headers.get('Content-Type'), 'application/json')
+})
+
+Deno.test('fetchBrowserlessPng — returns the response bytes as Uint8Array', async () => {
+  const { restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  try {
+    const out = await fetchBrowserlessPng('TOK', {
+      html: '<h1>hi</h1>',
+      width: 800,
+      height: 600,
+    })
+    assert(out instanceof Uint8Array)
+    assertEquals(Array.from(out), Array.from(FAKE_PNG))
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('fetchBrowserlessPng — retries once on 5xx then returns the retry payload', async () => {
+  let attempt = 0
+  const { calls, restore } = installFetchMock(() => {
+    attempt += 1
+    if (attempt === 1) {
+      return new Response('upstream boom', { status: 503 })
+    }
+    return pngResponse(200, FAKE_PNG)
+  })
+  try {
+    const out = await fetchBrowserlessPng('TOK', {
+      html: '<h1>hi</h1>',
+      width: 800,
+      height: 600,
+    })
+    assertEquals(Array.from(out), Array.from(FAKE_PNG))
+    assertEquals(calls.length, 2)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('fetchBrowserlessPng — surfaces 5xx error after the retry also fails', async () => {
+  const { calls, restore } = installFetchMock(
+    () => new Response('still down', { status: 502 }),
+  )
+  try {
+    const err = await assertRejects(
+      () =>
+        fetchBrowserlessPng('TOK', {
+          html: '<h1>hi</h1>',
+          width: 800,
+          height: 600,
+        }),
+      Error,
+    )
+    assertStringIncludes(err.message, '502')
+    assertEquals(calls.length, 2)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('fetchBrowserlessPng — does NOT retry on 4xx', async () => {
+  const { calls, restore } = installFetchMock(
+    () => new Response('bad token', { status: 401 }),
+  )
+  try {
+    const err = await assertRejects(
+      () =>
+        fetchBrowserlessPng('TOK', {
+          html: '<h1>hi</h1>',
+          width: 800,
+          height: 600,
+        }),
+      Error,
+    )
+    assertStringIncludes(err.message, '401')
+    assertEquals(calls.length, 1)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('fetchBrowserlessPng — rejects empty token at the boundary', async () => {
+  await assertRejects(
+    () =>
+      fetchBrowserlessPng('', {
+        html: '<h1>hi</h1>',
+        width: 800,
+        height: 600,
+      }),
+    Error,
+    'Browserless token is required',
+  )
+})
+
+Deno.test('fetchBrowserlessPng — rejects empty html at the boundary', async () => {
+  await assertRejects(
+    () =>
+      fetchBrowserlessPng('TOK', {
+        html: '',
+        width: 800,
+        height: 600,
+      }),
+    Error,
+    'html is required',
+  )
+})
+
+Deno.test('fetchBrowserlessPng — rejects non-positive viewport dimensions', async () => {
+  await assertRejects(
+    () =>
+      fetchBrowserlessPng('TOK', {
+        html: '<h1>hi</h1>',
+        width: 0,
+        height: 600,
+      }),
+    Error,
+    'width',
+  )
+  await assertRejects(
+    () =>
+      fetchBrowserlessPng('TOK', {
+        html: '<h1>hi</h1>',
+        width: 800,
+        height: -10,
+      }),
+    Error,
+    'height',
+  )
+})
+
+// ─── captureHtmlToTaskOutput ─────────────────────────────────────────────────
+
+Deno.test('captureHtmlToTaskOutput — happy path: fetches PNG, converts JPEG, uploads, signs URL', async () => {
+  const { calls, restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  const supabase = makeSupabase()
+  let convertCalled = false
+  let convertedQuality = 0
+  try {
+    const result = await captureHtmlToTaskOutput(
+      {
+        token: 'TOK',
+        supabase: supabase.client,
+        pngToJpeg: async (png, quality) => {
+          convertCalled = true
+          convertedQuality = quality
+          assertEquals(Array.from(png), Array.from(FAKE_PNG))
+          return FAKE_JPEG
+        },
+      },
+      {
+        html: '<h1>hi</h1>',
+        width: 1080,
+        height: 1080,
+        filenamePrefix: 'cover',
+      },
+      {
+        userId: 'user-1',
+        taskId: 'task-2',
+        stepOrder: 3,
+      },
+    )
+    assertEquals(calls.length, 1, 'one Browserless call')
+    assert(convertCalled, 'pngToJpeg called')
+    assertEquals(convertedQuality, 95)
+
+    assertEquals(supabase.uploads.length, 1)
+    assertEquals(supabase.uploads[0].bucket, 'task-outputs')
+    assert(
+      supabase.uploads[0].path.startsWith('user-1/task-2/step-3/cover-'),
+      `expected path to start with user-1/task-2/step-3/cover-, got ${supabase.uploads[0].path}`,
+    )
+    assert(
+      supabase.uploads[0].path.endsWith('.jpg'),
+      `expected path to end with .jpg, got ${supabase.uploads[0].path}`,
+    )
+    assertEquals(supabase.uploads[0].options?.contentType, 'image/jpeg')
+
+    assertEquals(supabase.signedUrls.length, 1)
+    assertEquals(supabase.signedUrls[0].bucket, 'task-outputs')
+    assertEquals(supabase.signedUrls[0].path, supabase.uploads[0].path)
+    assertEquals(supabase.signedUrls[0].ttlSeconds, 86400)
+
+    assertEquals(result.storage_path, supabase.uploads[0].path)
+    assertEquals(result.mime_type, 'image/jpeg')
+    assertEquals(result.width, 1080)
+    assertEquals(result.height, 1080)
+    assert(result.signed_url.startsWith('https://'))
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('captureHtmlToTaskOutput — uses default filename prefix when none provided', async () => {
+  const { restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  const supabase = makeSupabase()
+  try {
+    await captureHtmlToTaskOutput(
+      {
+        token: 'TOK',
+        supabase: supabase.client,
+        pngToJpeg: async () => FAKE_JPEG,
+      },
+      { html: '<p>x</p>', width: 800, height: 600 },
+      { userId: 'u', taskId: 't', stepOrder: 1 },
+    )
+    assertEquals(supabase.uploads.length, 1)
+    const path = supabase.uploads[0].path
+    assert(
+      path.startsWith('u/t/step-1/screenshot-'),
+      `expected default prefix, got ${path}`,
+    )
+    assert(path.endsWith('.jpg'))
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('captureHtmlToTaskOutput — uploads JPEG bytes (not PNG) to Storage', async () => {
+  const { restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  const supabase = makeSupabase()
+  try {
+    await captureHtmlToTaskOutput(
+      {
+        token: 'TOK',
+        supabase: supabase.client,
+        pngToJpeg: async () => FAKE_JPEG,
+      },
+      { html: '<p>x</p>', width: 800, height: 600 },
+      { userId: 'u', taskId: 't', stepOrder: 1 },
+    )
+    const body = supabase.uploads[0].body as Uint8Array
+    assertEquals(Array.from(body), Array.from(FAKE_JPEG))
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('captureHtmlToTaskOutput — surfaces upload error', async () => {
+  const { restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  const supabase = makeSupabase({
+    uploadError: { message: 'bucket disabled' },
+  })
+  try {
+    const err = await assertRejects(
+      () =>
+        captureHtmlToTaskOutput(
+          {
+            token: 'TOK',
+            supabase: supabase.client,
+            pngToJpeg: async () => FAKE_JPEG,
+          },
+          { html: '<p>x</p>', width: 800, height: 600 },
+          { userId: 'u', taskId: 't', stepOrder: 1 },
+        ),
+      Error,
+    )
+    assertStringIncludes(err.message, 'bucket disabled')
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('captureHtmlToTaskOutput — surfaces signedUrl error', async () => {
+  const { restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  const supabase = makeSupabase({
+    signedUrlError: { message: 'object missing' },
+  })
+  try {
+    const err = await assertRejects(
+      () =>
+        captureHtmlToTaskOutput(
+          {
+            token: 'TOK',
+            supabase: supabase.client,
+            pngToJpeg: async () => FAKE_JPEG,
+          },
+          { html: '<p>x</p>', width: 800, height: 600 },
+          { userId: 'u', taskId: 't', stepOrder: 1 },
+        ),
+      Error,
+    )
+    assertStringIncludes(err.message, 'object missing')
+  } finally {
+    restore()
+  }
+})
+
+Deno.test('captureHtmlToTaskOutput — rejects empty userId / taskId', async () => {
+  const supabase = makeSupabase()
+  await assertRejects(
+    () =>
+      captureHtmlToTaskOutput(
+        {
+          token: 'TOK',
+          supabase: supabase.client,
+          pngToJpeg: async () => FAKE_JPEG,
+        },
+        { html: '<p>x</p>', width: 800, height: 600 },
+        { userId: '', taskId: 't', stepOrder: 1 },
+      ),
+    Error,
+    'userId',
+  )
+  await assertRejects(
+    () =>
+      captureHtmlToTaskOutput(
+        {
+          token: 'TOK',
+          supabase: supabase.client,
+          pngToJpeg: async () => FAKE_JPEG,
+        },
+        { html: '<p>x</p>', width: 800, height: 600 },
+        { userId: 'u', taskId: '', stepOrder: 1 },
+      ),
+    Error,
+    'taskId',
+  )
+})
+
+Deno.test('captureHtmlToTaskOutput — sanitises filenamePrefix to safe chars', async () => {
+  const { restore } = installFetchMock(() => pngResponse(200, FAKE_PNG))
+  const supabase = makeSupabase()
+  try {
+    await captureHtmlToTaskOutput(
+      {
+        token: 'TOK',
+        supabase: supabase.client,
+        pngToJpeg: async () => FAKE_JPEG,
+      },
+      {
+        html: '<p>x</p>',
+        width: 800,
+        height: 600,
+        filenamePrefix: '../etc/passwd weird name!',
+      },
+      { userId: 'u', taskId: 't', stepOrder: 1 },
+    )
+    const path = supabase.uploads[0].path
+    assert(
+      !path.includes('..'),
+      `path must not contain "..", got ${path}`,
+    )
+    assert(
+      !path.includes(' '),
+      `path must not contain spaces, got ${path}`,
+    )
+  } finally {
+    restore()
+  }
+})

--- a/supabase/functions/_shared/htmlScreenshotter.test.ts
+++ b/supabase/functions/_shared/htmlScreenshotter.test.ts
@@ -40,7 +40,9 @@ function installFetchMock(
 }
 
 function pngResponse(status: number, bytes: Uint8Array): Response {
-  return new Response(bytes, {
+  // Pass a Blob to dodge the Uint8Array<ArrayBufferLike> generic mismatch
+  // that current TS lib types complain about for Response's BodyInit.
+  return new Response(new Blob([new Uint8Array(bytes)]), {
     status,
     headers: { 'Content-Type': 'image/png' },
   })

--- a/supabase/functions/_shared/htmlScreenshotter.test.ts
+++ b/supabase/functions/_shared/htmlScreenshotter.test.ts
@@ -308,7 +308,7 @@ Deno.test('captureHtmlToTaskOutput — happy path: fetches PNG, converts JPEG, u
       {
         token: 'TOK',
         supabase: supabase.client,
-        pngToJpeg: async (png, quality) => {
+        pngToJpeg: async (png: Uint8Array, quality: number) => {
           convertCalled = true
           convertedQuality = quality
           assertEquals(Array.from(png), Array.from(FAKE_PNG))

--- a/supabase/functions/_shared/htmlScreenshotter.ts
+++ b/supabase/functions/_shared/htmlScreenshotter.ts
@@ -1,0 +1,207 @@
+// HTML → JPEG screenshot pipeline backed by Browserless.
+//
+// Deep, narrow module: knows everything about driving Browserless, converting
+// the resulting PNG to a JPEG (default q95 via sharp), uploading it to the
+// `task-outputs` private Storage bucket, and minting a 24h signed URL. Reads
+// no global state — both the Browserless token and the Supabase client are
+// passed in by the caller, and the JPEG converter is dependency-injected so
+// unit tests never trigger sharp's native binary install.
+//
+// Two seams the consumer / tests can override:
+//   - pngToJpeg(png, quality)  — defaults to a lazy `npm:sharp` import
+//   - fetchImpl                — defaults to global `fetch`
+//
+// Storage layout:
+//   task-outputs/{userId}/{taskId}/step-{stepOrder}/{filenamePrefix}-{uuid}.jpg
+//
+// Browserless API: `POST https://chrome.browserless.io/screenshot?token=<TOK>`
+// with JSON body `{ html, viewport: { width, height }, options: { type: 'png' } }`.
+// 5xx responses are retried once before bubbling up; 4xx surfaces immediately.
+
+// deno-lint-ignore-file no-explicit-any
+
+import { signReadUrl } from './signedUrls.ts'
+
+const BROWSERLESS_URL = 'https://chrome.browserless.io/screenshot'
+const DEFAULT_JPEG_QUALITY = 95
+const DEFAULT_SIGNED_URL_TTL_SECONDS = 24 * 60 * 60
+const TASK_OUTPUTS_BUCKET = 'task-outputs'
+const DEFAULT_FILENAME_PREFIX = 'screenshot'
+const FILENAME_SAFE_PATTERN = /[^a-zA-Z0-9_-]+/g
+
+export interface ScreenshotRequest {
+  html: string
+  width: number
+  height: number
+  filenamePrefix?: string
+}
+
+export interface ScreenshotPath {
+  userId: string
+  taskId: string
+  stepOrder: number
+}
+
+export interface ScreenshotResult {
+  storage_path: string
+  signed_url: string
+  mime_type: 'image/jpeg'
+  width: number
+  height: number
+}
+
+export type PngToJpegFn = (
+  png: Uint8Array,
+  quality: number,
+) => Promise<Uint8Array>
+
+export interface CaptureDeps {
+  token: string
+  supabase: any
+  pngToJpeg?: PngToJpegFn
+  fetchImpl?: typeof fetch
+  signedUrlTtlSeconds?: number
+  jpegQuality?: number
+}
+
+function assertNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} is required.`)
+  }
+}
+
+function assertPositiveInteger(value: unknown, label: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a positive number.`)
+  }
+}
+
+function sanitizeFilename(prefix: string): string {
+  const trimmed = prefix.trim()
+  const cleaned = trimmed.replace(FILENAME_SAFE_PATTERN, '-').replace(/^-+|-+$/g, '')
+  return cleaned.length > 0 ? cleaned.slice(0, 64) : DEFAULT_FILENAME_PREFIX
+}
+
+export async function fetchBrowserlessPng(
+  token: string,
+  request: ScreenshotRequest,
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<Uint8Array> {
+  if (typeof token !== 'string' || token.trim().length === 0) {
+    throw new Error('Browserless token is required.')
+  }
+  assertNonEmptyString(request.html, 'html')
+  assertPositiveInteger(request.width, 'width')
+  assertPositiveInteger(request.height, 'height')
+
+  const url = `${BROWSERLESS_URL}?token=${encodeURIComponent(token)}`
+  const body = JSON.stringify({
+    html: request.html,
+    viewport: { width: request.width, height: request.height },
+    options: { type: 'png' },
+  })
+
+  const init: RequestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    signal,
+  }
+
+  let res = await fetchImpl(url, init)
+  if (res.status >= 500 && res.status < 600) {
+    // One retry on transient upstream failures. We deliberately do not delay —
+    // the Edge Function wall-clock budget is tight and Browserless cold-start
+    // recovery is well under a second in practice.
+    res = await fetchImpl(url, init)
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(
+      `Browserless screenshot failed (${res.status}): ${text.slice(0, 200)}`,
+    )
+  }
+  const buf = await res.arrayBuffer()
+  return new Uint8Array(buf)
+}
+
+// Lazy default JPEG converter. Imported only when no override is supplied so
+// unit tests never resolve `npm:sharp` (whose native binaries are slow / can
+// fail to install in stripped-down sandboxes).
+async function defaultPngToJpeg(
+  png: Uint8Array,
+  quality: number,
+): Promise<Uint8Array> {
+  const mod: any = await import('npm:sharp@0.33.5')
+  const sharp = (mod && (mod.default ?? mod)) as (
+    input: Uint8Array,
+  ) => { jpeg(opts: { quality: number; mozjpeg?: boolean }): { toBuffer(): Promise<Uint8Array> } }
+  const out = await sharp(png).jpeg({ quality, mozjpeg: true }).toBuffer()
+  return out instanceof Uint8Array ? out : new Uint8Array(out)
+}
+
+export async function captureHtmlToTaskOutput(
+  deps: CaptureDeps,
+  request: ScreenshotRequest,
+  path: ScreenshotPath,
+  signal?: AbortSignal,
+): Promise<ScreenshotResult> {
+  assertNonEmptyString(path.userId, 'userId')
+  assertNonEmptyString(path.taskId, 'taskId')
+  if (
+    typeof path.stepOrder !== 'number' ||
+    !Number.isInteger(path.stepOrder) ||
+    path.stepOrder < 0
+  ) {
+    throw new Error('stepOrder must be a non-negative integer.')
+  }
+
+  const png = await fetchBrowserlessPng(
+    deps.token,
+    request,
+    deps.fetchImpl ?? fetch,
+    signal,
+  )
+
+  const quality = deps.jpegQuality ?? DEFAULT_JPEG_QUALITY
+  const convert = deps.pngToJpeg ?? defaultPngToJpeg
+  const jpeg = await convert(png, quality)
+
+  const safePrefix = sanitizeFilename(request.filenamePrefix ?? DEFAULT_FILENAME_PREFIX)
+  const uniqueSuffix = crypto.randomUUID()
+  const storagePath =
+    `${path.userId}/${path.taskId}/step-${path.stepOrder}/${safePrefix}-${uniqueSuffix}.jpg`
+
+  const { error: uploadError } = await deps.supabase.storage
+    .from(TASK_OUTPUTS_BUCKET)
+    .upload(storagePath, jpeg, {
+      contentType: 'image/jpeg',
+      upsert: false,
+    })
+  if (uploadError) {
+    const message =
+      typeof uploadError?.message === 'string'
+        ? uploadError.message
+        : String(uploadError)
+    throw new Error(
+      `Storage upload failed for ${TASK_OUTPUTS_BUCKET}/${storagePath}: ${message}`,
+    )
+  }
+
+  const ttl = deps.signedUrlTtlSeconds ?? DEFAULT_SIGNED_URL_TTL_SECONDS
+  const signedUrl = await signReadUrl(
+    deps.supabase,
+    TASK_OUTPUTS_BUCKET,
+    storagePath,
+    ttl,
+  )
+
+  return {
+    storage_path: storagePath,
+    signed_url: signedUrl,
+    mime_type: 'image/jpeg',
+    width: request.width,
+    height: request.height,
+  }
+}

--- a/supabase/functions/chat/executor.test.ts
+++ b/supabase/functions/chat/executor.test.ts
@@ -4,7 +4,14 @@ import {
   assertExists,
   assertStringIncludes,
 } from 'jsr:@std/assert@1'
-import { runStep, TOOL_HANDLERS } from './executor.ts'
+import {
+  _renderHtmlInternals,
+  describeUnavailableReason,
+  getAvailableTools,
+  runStep,
+  setCreateAdminClientForTests,
+  TOOL_HANDLERS,
+} from './executor.ts'
 
 interface MockCall {
   url: string
@@ -659,4 +666,223 @@ Deno.test('runStep — adds anthropic-beta header when native web_fetch declared
     restore()
     restoreAnthropic()
   }
+})
+
+// ─── render_html_to_image ───────────────────────────────────────────────────
+
+Deno.test('render_html_to_image — registered in TOOL_HANDLERS', () => {
+  assert(typeof TOOL_HANDLERS.render_html_to_image === 'function')
+})
+
+Deno.test('render_html_to_image — returns not_configured when BROWSERLESS_TOKEN is missing', async () => {
+  const restoreEnv = withEnv('BROWSERLESS_TOKEN', null)
+  try {
+    const result = await TOOL_HANDLERS.render_html_to_image(
+      { html: '<h1>hi</h1>', width: 800, height: 600 },
+      { ...makeCtx(), userId: 'user-1' },
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'BROWSERLESS_TOKEN')
+    assertEquals(
+      (result.result as { error?: string } | undefined)?.error,
+      'not_configured',
+    )
+  } finally {
+    restoreEnv()
+  }
+})
+
+Deno.test('render_html_to_image — rejects empty html before hitting Browserless', async () => {
+  const restoreToken = withEnv('BROWSERLESS_TOKEN', 'TOK')
+  let fetchCalled = false
+  const { restore } = installFetchMock(() => {
+    fetchCalled = true
+    return new Response(new Uint8Array([1, 2, 3]).buffer)
+  })
+  try {
+    const result = await TOOL_HANDLERS.render_html_to_image(
+      { html: '   ', width: 800, height: 600 },
+      { ...makeCtx(), userId: 'user-1' },
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'html')
+    assertEquals(fetchCalled, false)
+  } finally {
+    restore()
+    restoreToken()
+  }
+})
+
+Deno.test('render_html_to_image — rejects non-positive viewport dimensions', async () => {
+  const restoreToken = withEnv('BROWSERLESS_TOKEN', 'TOK')
+  try {
+    const result = await TOOL_HANDLERS.render_html_to_image(
+      { html: '<h1>hi</h1>', width: 0, height: 600 },
+      { ...makeCtx(), userId: 'user-1' },
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'width')
+  } finally {
+    restoreToken()
+  }
+})
+
+Deno.test('render_html_to_image — refuses to run without ctx.userId', async () => {
+  const restoreToken = withEnv('BROWSERLESS_TOKEN', 'TOK')
+  try {
+    const result = await TOOL_HANDLERS.render_html_to_image(
+      { html: '<h1>hi</h1>', width: 800, height: 600 },
+      makeCtx(),
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'userId')
+  } finally {
+    restoreToken()
+  }
+})
+
+Deno.test('render_html_to_image — returns not_configured when SUPABASE_SERVICE_ROLE_KEY is missing', async () => {
+  const restoreToken = withEnv('BROWSERLESS_TOKEN', 'TOK')
+  const restoreUrl = withEnv('SUPABASE_URL', 'https://x.supabase.co')
+  const restoreKey = withEnv('SUPABASE_SERVICE_ROLE_KEY', null)
+  try {
+    const result = await TOOL_HANDLERS.render_html_to_image(
+      { html: '<h1>hi</h1>', width: 800, height: 600 },
+      { ...makeCtx(), userId: 'user-1' },
+    )
+    assertEquals(result.ok, false)
+    assertStringIncludes(result.error ?? '', 'SUPABASE_SERVICE_ROLE_KEY')
+    assertEquals(
+      (result.result as { error?: string } | undefined)?.error,
+      'not_configured',
+    )
+  } finally {
+    restoreKey()
+    restoreUrl()
+    restoreToken()
+  }
+})
+
+Deno.test('render_html_to_image — happy path returns storage_path + signed_url', async () => {
+  const restoreToken = withEnv('BROWSERLESS_TOKEN', 'TOK')
+  const restoreUrl = withEnv('SUPABASE_URL', 'https://x.supabase.co')
+  const restoreKey = withEnv('SUPABASE_SERVICE_ROLE_KEY', 'svc')
+
+  let captureCalls = 0
+  let capturedPath: { userId: string; taskId: string; stepOrder: number } | null = null
+  const previousCapture = _renderHtmlInternals.capture
+  _renderHtmlInternals.capture = async (_deps, request, path) => {
+    captureCalls += 1
+    capturedPath = path
+    return {
+      storage_path: `${path.userId}/${path.taskId}/step-${path.stepOrder}/x.jpg`,
+      signed_url: 'https://signed.example/x.jpg?token=abc',
+      mime_type: 'image/jpeg',
+      width: request.width,
+      height: request.height,
+    }
+  }
+  const restoreClient = setCreateAdminClientForTests(((..._args: unknown[]) =>
+    ({}) as never) as never)
+  try {
+    const result = await TOOL_HANDLERS.render_html_to_image(
+      { html: '<h1>hi</h1>', width: 1080, height: 1080, filename_prefix: 'cover' },
+      {
+        ...makeCtx(),
+        userId: 'user-1',
+        taskId: 'task-2',
+        stepOrder: 3,
+      },
+    )
+    assert(result.ok, `expected ok, got ${result.error}`)
+    assertEquals(captureCalls, 1)
+    assertEquals(capturedPath, { userId: 'user-1', taskId: 'task-2', stepOrder: 3 })
+    const r = result.result as {
+      storage_path: string
+      signed_url: string
+      mime_type: string
+      width: number
+      height: number
+    }
+    assertEquals(r.storage_path, 'user-1/task-2/step-3/x.jpg')
+    assertEquals(r.mime_type, 'image/jpeg')
+    assertEquals(r.width, 1080)
+    assertEquals(r.height, 1080)
+    assertStringIncludes(r.signed_url, 'signed.example')
+  } finally {
+    _renderHtmlInternals.capture = previousCapture
+    restoreClient()
+    restoreKey()
+    restoreUrl()
+    restoreToken()
+  }
+})
+
+Deno.test('render_html_to_image — falls back to chat-toolCallId / stepId when no template ctx', async () => {
+  const restoreToken = withEnv('BROWSERLESS_TOKEN', 'TOK')
+  const restoreUrl = withEnv('SUPABASE_URL', 'https://x.supabase.co')
+  const restoreKey = withEnv('SUPABASE_SERVICE_ROLE_KEY', 'svc')
+
+  let capturedPath: { userId: string; taskId: string; stepOrder: number } | null = null
+  const previousCapture = _renderHtmlInternals.capture
+  _renderHtmlInternals.capture = async (_deps, request, path) => {
+    capturedPath = path
+    return {
+      storage_path: `${path.userId}/${path.taskId}/step-${path.stepOrder}/x.jpg`,
+      signed_url: 'https://signed.example/x.jpg',
+      mime_type: 'image/jpeg',
+      width: request.width,
+      height: request.height,
+    }
+  }
+  const restoreClient = setCreateAdminClientForTests(((..._args: unknown[]) =>
+    ({}) as never) as never)
+  try {
+    const ctx = makeCtx()
+    ctx.stepId = 7
+    ctx.toolCallId = 'tool-call-xyz'
+    const result = await TOOL_HANDLERS.render_html_to_image(
+      { html: '<h1>hi</h1>', width: 800, height: 600 },
+      { ...ctx, userId: 'user-1' },
+    )
+    assert(result.ok, `expected ok, got ${result.error}`)
+    assertEquals(capturedPath?.userId, 'user-1')
+    assertEquals(capturedPath?.taskId, 'chat-tool-call-xyz')
+    assertEquals(capturedPath?.stepOrder, 7)
+  } finally {
+    _renderHtmlInternals.capture = previousCapture
+    restoreClient()
+    restoreKey()
+    restoreUrl()
+    restoreToken()
+  }
+})
+
+// ─── available tool gating ──────────────────────────────────────────────────
+
+Deno.test('getAvailableTools — drops render_html_to_image when BROWSERLESS_TOKEN missing', () => {
+  const restoreEnv = withEnv('BROWSERLESS_TOKEN', null)
+  try {
+    const available = getAvailableTools()
+    assertEquals(available.has('render_html_to_image'), false)
+  } finally {
+    restoreEnv()
+  }
+})
+
+Deno.test('getAvailableTools — keeps render_html_to_image when BROWSERLESS_TOKEN present', () => {
+  const restoreEnv = withEnv('BROWSERLESS_TOKEN', 'TOK')
+  try {
+    const available = getAvailableTools()
+    assertEquals(available.has('render_html_to_image'), true)
+  } finally {
+    restoreEnv()
+  }
+})
+
+Deno.test('describeUnavailableReason — names BROWSERLESS_TOKEN for render_html_to_image', () => {
+  assertStringIncludes(
+    describeUnavailableReason('render_html_to_image'),
+    'BROWSERLESS_TOKEN',
+  )
 })

--- a/supabase/functions/chat/executor.test.ts
+++ b/supabase/functions/chat/executor.test.ts
@@ -769,7 +769,8 @@ Deno.test('render_html_to_image — happy path returns storage_path + signed_url
   const restoreKey = withEnv('SUPABASE_SERVICE_ROLE_KEY', 'svc')
 
   let captureCalls = 0
-  let capturedPath: { userId: string; taskId: string; stepOrder: number } | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let capturedPath: any = null
   const previousCapture = _renderHtmlInternals.capture
   _renderHtmlInternals.capture = async (_deps, request, path) => {
     captureCalls += 1
@@ -823,7 +824,8 @@ Deno.test('render_html_to_image — falls back to chat-toolCallId / stepId when 
   const restoreUrl = withEnv('SUPABASE_URL', 'https://x.supabase.co')
   const restoreKey = withEnv('SUPABASE_SERVICE_ROLE_KEY', 'svc')
 
-  let capturedPath: { userId: string; taskId: string; stepOrder: number } | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let capturedPath: any = null
   const previousCapture = _renderHtmlInternals.capture
   _renderHtmlInternals.capture = async (_deps, request, path) => {
     capturedPath = path

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -15,12 +15,22 @@
 //
 // deno-lint-ignore-file no-explicit-any
 
+import {
+  createClient as defaultCreateAdminClient,
+  type SupabaseClient,
+} from 'jsr:@supabase/supabase-js@2'
 import { createIssue, listRepos } from './github.ts'
 import { filterAndSlim } from './githubFilters.ts'
 import {
   buildNativeWebTools,
   findFailedNativeSearches,
 } from './webResearchTools.ts'
+import {
+  captureHtmlToTaskOutput,
+  type CaptureDeps,
+  type ScreenshotPath,
+  type ScreenshotRequest,
+} from '../_shared/htmlScreenshotter.ts'
 
 // Tools whose client-side declaration is replaced with the Anthropic native
 // server-side tool (web_search_20250305 / web_fetch_20250910). The model uses

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -820,6 +820,9 @@ export function getAvailableTools(): Set<string> {
     available.delete('list_github_repos')
     available.delete('create_github_issue')
   }
+  if (!Deno.env.get('BROWSERLESS_TOKEN')) {
+    available.delete('render_html_to_image')
+  }
   return available
 }
 
@@ -829,6 +832,9 @@ export function describeUnavailableReason(toolId: string): string {
   }
   if (toolId === 'list_github_repos' || toolId === 'create_github_issue') {
     return 'GITHUB_TOKEN is not configured in the Edge Function secrets.'
+  }
+  if (toolId === 'render_html_to_image') {
+    return 'BROWSERLESS_TOKEN is not configured in the Edge Function secrets.'
   }
   return 'Tool is not available in this environment.'
 }

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -58,6 +58,14 @@ export interface ToolContext {
   stepId: number
   toolCallId: string
   userId?: string
+  // Optional template-mode context. When the executor is instantiated against
+  // a template-mode task (issue #354), it threads the real `task.id` and the
+  // 0-based step order through here so tools that emit artifacts (e.g.
+  // `render_html_to_image`) can build a deterministic Storage path. Chat-mode
+  // and free-form tasks leave them undefined and the tool falls back to
+  // ctx.toolCallId / ctx.stepId.
+  taskId?: string
+  stepOrder?: number
 }
 
 export interface ToolArtifact {

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -662,6 +662,139 @@ async function createGithubIssue(
   }
 }
 
+// ─── Render HTML to image (Browserless) ─────────────────────────────────────
+
+const MISSING_BROWSERLESS_TOKEN_ERROR =
+  'Browserless is not configured. Set BROWSERLESS_TOKEN in the Edge Function secrets to enable this tool.'
+const MISSING_SUPABASE_ADMIN_ERROR =
+  'render_html_to_image cannot reach Supabase Storage (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing).'
+
+// Indirection so unit tests can swap in a mock Supabase client without
+// pulling jsr:@supabase/supabase-js into the test sandbox.
+let _createAdminClient: (url: string, key: string) => SupabaseClient =
+  defaultCreateAdminClient as unknown as (
+    url: string,
+    key: string,
+  ) => SupabaseClient
+
+export function setCreateAdminClientForTests(
+  factory: ((url: string, key: string) => SupabaseClient) | null,
+): () => void {
+  const previous = _createAdminClient
+  _createAdminClient =
+    factory ??
+    (defaultCreateAdminClient as unknown as (
+      url: string,
+      key: string,
+    ) => SupabaseClient)
+  return () => {
+    _createAdminClient = previous
+  }
+}
+
+// Exported only so the executor.test.ts can override the conversion step
+// without resolving `npm:sharp` inside the test sandbox.
+export const _renderHtmlInternals = {
+  capture: captureHtmlToTaskOutput as (
+    deps: CaptureDeps,
+    request: ScreenshotRequest,
+    path: ScreenshotPath,
+    signal?: AbortSignal,
+  ) => Promise<{
+    storage_path: string
+    signed_url: string
+    mime_type: 'image/jpeg'
+    width: number
+    height: number
+  }>,
+}
+
+async function renderHtmlToImage(
+  input: {
+    html?: unknown
+    width?: unknown
+    height?: unknown
+    filename_prefix?: unknown
+  },
+  ctx: ToolContext,
+): Promise<ToolResult> {
+  const html = typeof input.html === 'string' ? input.html : ''
+  const width = typeof input.width === 'number' ? input.width : 0
+  const height = typeof input.height === 'number' ? input.height : 0
+  const filenamePrefix =
+    typeof input.filename_prefix === 'string' && input.filename_prefix.trim()
+      ? input.filename_prefix.trim()
+      : undefined
+
+  if (!html.trim()) {
+    return {
+      ok: false,
+      error: 'render_html_to_image requires a non-empty `html` string.',
+    }
+  }
+  if (width <= 0 || height <= 0) {
+    return {
+      ok: false,
+      error:
+        'render_html_to_image requires positive `width` and `height` viewport dimensions.',
+    }
+  }
+
+  const token = Deno.env.get('BROWSERLESS_TOKEN')
+  if (!token) {
+    return {
+      ok: false,
+      error: MISSING_BROWSERLESS_TOKEN_ERROR,
+      result: { error: 'not_configured' },
+    }
+  }
+
+  if (!ctx.userId) {
+    return {
+      ok: false,
+      error:
+        'render_html_to_image requires an authenticated user (ctx.userId is missing).',
+    }
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+  if (!supabaseUrl || !serviceKey) {
+    return {
+      ok: false,
+      error: MISSING_SUPABASE_ADMIN_ERROR,
+      result: { error: 'not_configured' },
+    }
+  }
+
+  const taskId = ctx.taskId ?? `chat-${ctx.toolCallId}`
+  const stepOrder =
+    typeof ctx.stepOrder === 'number' ? ctx.stepOrder : ctx.stepId
+
+  try {
+    const supabase = _createAdminClient(supabaseUrl, serviceKey)
+    const result = await _renderHtmlInternals.capture(
+      { token, supabase },
+      { html, width, height, filenamePrefix },
+      { userId: ctx.userId, taskId, stepOrder },
+      ctx.signal,
+    )
+    return {
+      ok: true,
+      result,
+      summary: `Rendered ${width}×${height} screenshot → ${result.storage_path}`,
+      artifact: {
+        type: 'file',
+        name: result.storage_path.split('/').pop() || 'screenshot.jpg',
+        format: 'jpg',
+        content: result.signed_url,
+      },
+    }
+  } catch (err) {
+    return { ok: false, error: (err as Error).message }
+  }
+}
+
 export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   web_search: webSearch,
   fetch_url: fetchUrl,
@@ -672,6 +805,7 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   create_google_slides: createGoogleSlides,
   list_github_repos: listGithubRepos,
   create_github_issue: createGithubIssue,
+  render_html_to_image: renderHtmlToImage,
 }
 
 // Which tools are functional in the current environment. Some tools depend on

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -9,6 +9,7 @@
     "npm:@supabase/postgrest-js@2.105.1": "2.105.1",
     "npm:@supabase/realtime-js@2.105.1": "2.105.1",
     "npm:@supabase/storage-js@2.105.1": "2.105.1",
+    "npm:sharp@0.33.5": "0.33.5",
     "npm:web-push@3.6.7": "3.6.7"
   },
   "jsr": {
@@ -36,6 +37,133 @@
     }
   },
   "npm": {
+    "@emnapi/runtime@1.10.0": {
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@img/sharp-darwin-arm64@0.33.5": {
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "optionalDependencies": [
+        "@img/sharp-libvips-darwin-arm64"
+      ],
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@img/sharp-darwin-x64@0.33.5": {
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "optionalDependencies": [
+        "@img/sharp-libvips-darwin-x64"
+      ],
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@img/sharp-libvips-darwin-arm64@1.0.4": {
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@img/sharp-libvips-darwin-x64@1.0.4": {
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@img/sharp-libvips-linux-arm64@1.0.4": {
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@img/sharp-libvips-linux-arm@1.0.5": {
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@img/sharp-libvips-linux-s390x@1.0.4": {
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@img/sharp-libvips-linux-x64@1.0.4": {
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@img/sharp-libvips-linuxmusl-arm64@1.0.4": {
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@img/sharp-libvips-linuxmusl-x64@1.0.4": {
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@img/sharp-linux-arm64@0.33.5": {
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "optionalDependencies": [
+        "@img/sharp-libvips-linux-arm64"
+      ],
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@img/sharp-linux-arm@0.33.5": {
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "optionalDependencies": [
+        "@img/sharp-libvips-linux-arm"
+      ],
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@img/sharp-linux-s390x@0.33.5": {
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "optionalDependencies": [
+        "@img/sharp-libvips-linux-s390x"
+      ],
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@img/sharp-linux-x64@0.33.5": {
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "optionalDependencies": [
+        "@img/sharp-libvips-linux-x64"
+      ],
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@img/sharp-linuxmusl-arm64@0.33.5": {
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "optionalDependencies": [
+        "@img/sharp-libvips-linuxmusl-arm64"
+      ],
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@img/sharp-linuxmusl-x64@0.33.5": {
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "optionalDependencies": [
+        "@img/sharp-libvips-linuxmusl-x64"
+      ],
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@img/sharp-wasm32@0.33.5": {
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "dependencies": [
+        "@emnapi/runtime"
+      ],
+      "cpu": ["wasm32"]
+    },
+    "@img/sharp-win32-ia32@0.33.5": {
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@img/sharp-win32-x64@0.33.5": {
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
     "@supabase/auth-js@2.105.1": {
       "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
       "dependencies": [
@@ -97,11 +225,37 @@
     "buffer-equal-constant-time@1.0.1": {
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "color-convert@2.0.1": {
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": [
+        "color-name"
+      ]
+    },
+    "color-name@1.1.4": {
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "color-string@1.9.1": {
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": [
+        "color-name",
+        "simple-swizzle"
+      ]
+    },
+    "color@4.2.3": {
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": [
+        "color-convert",
+        "color-string"
+      ]
+    },
     "debug@4.4.3": {
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
         "ms"
       ]
+    },
+    "detect-libc@2.1.2": {
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
     },
     "ecdsa-sig-formatter@1.0.11": {
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
@@ -124,6 +278,9 @@
     },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-arrayish@0.3.4": {
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="
     },
     "jwa@2.0.1": {
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
@@ -154,6 +311,46 @@
     },
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver@7.7.4": {
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": true
+    },
+    "sharp@0.33.5": {
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dependencies": [
+        "color",
+        "detect-libc",
+        "semver"
+      ],
+      "optionalDependencies": [
+        "@img/sharp-darwin-arm64",
+        "@img/sharp-darwin-x64",
+        "@img/sharp-libvips-darwin-arm64",
+        "@img/sharp-libvips-darwin-x64",
+        "@img/sharp-libvips-linux-arm",
+        "@img/sharp-libvips-linux-arm64",
+        "@img/sharp-libvips-linux-s390x",
+        "@img/sharp-libvips-linux-x64",
+        "@img/sharp-libvips-linuxmusl-arm64",
+        "@img/sharp-libvips-linuxmusl-x64",
+        "@img/sharp-linux-arm",
+        "@img/sharp-linux-arm64",
+        "@img/sharp-linux-s390x",
+        "@img/sharp-linux-x64",
+        "@img/sharp-linuxmusl-arm64",
+        "@img/sharp-linuxmusl-x64",
+        "@img/sharp-wasm32",
+        "@img/sharp-win32-ia32",
+        "@img/sharp-win32-x64"
+      ],
+      "scripts": true
+    },
+    "simple-swizzle@0.2.4": {
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dependencies": [
+        "is-arrayish"
+      ]
     },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="

--- a/supabase/integration/htmlScreenshotter.integration.test.ts
+++ b/supabase/integration/htmlScreenshotter.integration.test.ts
@@ -1,0 +1,53 @@
+// Real-API integration test for the HTML screenshot pipeline.
+//
+// Hits the real Browserless `/screenshot` endpoint when `BROWSERLESS_TEST_TOKEN`
+// is set. Auto-skips otherwise so unit-test-only environments stay green.
+//
+// Required env vars:
+//   BROWSERLESS_TEST_TOKEN — token with screenshot quota on chrome.browserless.io.
+//                            Separate from BROWSERLESS_TOKEN (the runtime
+//                            Edge Function secret) so a CI failure cannot
+//                            exhaust the production quota.
+//
+// Scope: this test verifies that fetchBrowserlessPng can talk to the real
+// upstream and gets back a PNG payload. It deliberately does NOT exercise
+// the full captureHtmlToTaskOutput path because Storage RLS would require a
+// real Supabase project; the local-only deep-module unit tests cover that
+// branch end-to-end with a mocked client. Adding storage integration here
+// is a separate slice (track via a follow-up issue).
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+import { fetchBrowserlessPng } from '../functions/_shared/htmlScreenshotter.ts'
+
+const TOKEN = Deno.env.get('BROWSERLESS_TEST_TOKEN')
+const SKIP = !TOKEN
+
+const skipReason =
+  'BROWSERLESS_TEST_TOKEN not set — skipping real Browserless integration tests.'
+if (SKIP) console.warn(`[integration] ${skipReason}`)
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+Deno.test({
+  name: 'integration · fetchBrowserlessPng renders <h1> at 800x600 (real Browserless)',
+  ignore: SKIP,
+  async fn() {
+    const png = await fetchBrowserlessPng(TOKEN!, {
+      html: '<!doctype html><html><body style="font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><h1>integration test</h1></body></html>',
+      width: 800,
+      height: 600,
+    })
+    assert(png instanceof Uint8Array, 'response must be Uint8Array')
+    assert(png.byteLength > 1000, `expected non-trivial PNG, got ${png.byteLength} bytes`)
+
+    // Verify the PNG magic header (Browserless ignored our `type: 'png'`
+    // request if this fails).
+    for (let i = 0; i < PNG_MAGIC.length; i++) {
+      assertEquals(
+        png[i],
+        PNG_MAGIC[i],
+        `byte ${i}: expected 0x${PNG_MAGIC[i].toString(16)} (PNG magic), got 0x${png[i].toString(16)}`,
+      )
+    }
+  },
+})

--- a/supabase/seed-tools.sql
+++ b/supabase/seed-tools.sql
@@ -55,6 +55,43 @@ ON CONFLICT (id) DO UPDATE SET
   enabled = EXCLUDED.enabled;
 
 -- =============================================================================
+-- TOOL: render_html_to_image (issue #351)
+-- =============================================================================
+--
+-- Drives Browserless headlessly to render arbitrary HTML at a fixed viewport,
+-- post-processes the PNG to a JPEG @ q95 via sharp, uploads to the private
+-- `task-outputs` bucket at `{user_id}/{task_id}/step-{order}/{filename}.jpg`,
+-- and returns the storage path + 24h signed URL.
+--
+-- Configuration: requires `BROWSERLESS_TOKEN` Edge Function secret. When
+-- absent, the handler returns a structured `not_configured` error instead of
+-- attempting the call.
+--
+-- requires_approval is intentionally false: rendering is a read-only
+-- operation that produces a private artifact in the task-outputs bucket.
+-- Public publishing is gated by separate write tools (e.g. zernio_publish).
+
+INSERT INTO tools (id, name, description, icon, category, input_schema, requires_approval, enabled)
+VALUES (
+  'render_html_to_image',
+  'Render HTML to image',
+  'Renders the supplied HTML at the requested viewport via Browserless and returns a private signed URL to the resulting JPEG. Use for previewing visual layouts, social-card mockups, and template artifacts.',
+  'Image',
+  'media',
+  '{"type":"object","required":["html","width","height"],"properties":{"html":{"type":"string","description":"Full HTML document to render. Inline any CSS / fonts you need — the page is rendered in a sandboxed Chromium with no network access guarantees."},"width":{"type":"integer","minimum":1,"description":"Viewport width in pixels (e.g. 1080 for an Instagram feed asset)."},"height":{"type":"integer","minimum":1,"description":"Viewport height in pixels (e.g. 1080 for square, 1350 for portrait, 1920 for story)."},"filename_prefix":{"type":"string","description":"Optional prefix used to name the resulting file. Sanitised to [a-zA-Z0-9_-] before storage. Defaults to \"screenshot\"."}},"additionalProperties":false}'::jsonb,
+  false,
+  true
+)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  icon = EXCLUDED.icon,
+  category = EXCLUDED.category,
+  input_schema = EXCLUDED.input_schema,
+  requires_approval = EXCLUDED.requires_approval,
+  enabled = EXCLUDED.enabled;
+
+-- =============================================================================
 -- AGENT
 -- =============================================================================
 --


### PR DESCRIPTION
Closes #351

## Summary

Implements the `render_html_to_image` Edge Function tool: drives Browserless headlessly to produce a PNG, post-processes to JPEG @ q95 via `sharp` (lazy-loaded `npm:` import), uploads to the private `task-outputs` bucket at `{user_id}/{task_id}/step-{order}/{filename}.jpg`, and returns the storage path + 24h signed URL.

## TDD
- Tests added/modified:
  - `supabase/functions/_shared/htmlScreenshotter.test.ts` (new) — 17 unit tests covering happy path, retry, error surfacing, path layout, filename sanitisation
  - `supabase/functions/chat/executor.test.ts` — 10 new tests covering registration, missing-secret branches, validation, ctx fallback, gating helpers
  - `supabase/integration/htmlScreenshotter.integration.test.ts` (new) — auto-skips without `BROWSERLESS_TEST_TOKEN`
- Before implementation (red): `htmlScreenshotter.test.ts` failed to compile (`Cannot find module 'htmlScreenshotter.ts'`); executor tests for `render_html_to_image` were absent.
- After implementation (green): `npm run test:functions` → 170 passed (was 143 before this slice); `npm test` → 449 passed; `npm run lint` → 0 errors. The auto-skipped integration test wires the real Browserless contract for follow-up validation.

## Notes
- `htmlScreenshotter.ts` lives in `_shared/` because the seam (Browserless ↔ Storage ↔ signedUrls) is reusable across tools, mirroring `signedUrls.ts` and `templateRenderer.ts`.
- The default JPEG converter is a lazy `await import('npm:sharp@0.33.5')` so unit tests inject a mock and never touch sharp's native binary; integration tests would exercise the real path once a sandbox bucket is provisioned (out of scope for this slice).
- `ToolContext` gained optional `taskId` / `stepOrder` fields. The executor's chat path leaves them undefined and the handler falls back to `chat-{toolCallId}` / `ctx.stepId`. Issue #354 (template-mode executor) will populate them with real task IDs.
- Tool gating extended: `getAvailableTools()` drops `render_html_to_image` when `BROWSERLESS_TOKEN` is absent and `describeUnavailableReason` names the missing secret.
- Seed row in `supabase/seed-tools.sql` is idempotent (`ON CONFLICT DO UPDATE`), category `media`, `requires_approval: false` (rendering produces a private artifact; public publishing is gated by separate write tools like `zernio_publish`).
- A new Edge Function secret `BROWSERLESS_TOKEN` must be provisioned before the tool can run end-to-end. Until then it returns the structured `not_configured` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)