### PR TITLE
fix(templates): friendly message for CRUD missing-table errors (#340)

### DIFF
--- a/src/lib/templatesApi.js
+++ b/src/lib/templatesApi.js
@@ -20,6 +20,12 @@ const MISSING_TABLE_CODES = new Set(['42P01', 'PGRST205'])
 const MISSING_TABLE_MESSAGE_PATTERN =
   /(relation\s+"?public\.task_templates"?\s+does\s+not\s+exist|table\s+'?public\.task_templates'?[^']*schema\s+cache)/i
 
+// Single user-facing message for every CRUD path that hits a missing-
+// table condition. Keeps the modal/drawer copy consistent so users
+// reading the alert never see raw Postgres/PostgREST jargon.
+const FRIENDLY_MISSING_TABLE_MESSAGE =
+  'Templates table is not ready yet. Please try again in a moment, or contact your administrator if the problem persists.'
+
 function isMissingTableError(error) {
   if (!error) return false
   if (MISSING_TABLE_CODES.has(error.code)) return true
@@ -27,6 +33,16 @@ function isMissingTableError(error) {
     return true
   }
   return false
+}
+
+// Wrap a missing-table Supabase error in a user-readable Error so the
+// CreateTemplateModal / TemplateEditDrawer / TaskDetailPanel surfaces
+// surface a sensible message via their existing err.message rendering.
+// The original Supabase error is preserved on `.cause` for debugging.
+function asFriendlyMissingTableError(error) {
+  const friendly = new Error(FRIENDLY_MISSING_TABLE_MESSAGE)
+  friendly.cause = error
+  return friendly
 }
 
 export async function fetchTemplates() {
@@ -55,6 +71,7 @@ export async function insertTemplate(template) {
     .single()
   if (error) {
     console.error('[templates] insert', error)
+    if (isMissingTableError(error)) throw asFriendlyMissingTableError(error)
     throw error
   }
   return data
@@ -71,6 +88,7 @@ export async function updateTemplate(id, updates) {
     .single()
   if (error) {
     console.error('[templates] update', error)
+    if (isMissingTableError(error)) throw asFriendlyMissingTableError(error)
     throw error
   }
   return data
@@ -81,6 +99,7 @@ export async function deleteTemplate(id) {
   const { error } = await supabase.from('task_templates').delete().eq('id', id)
   if (error) {
     console.error('[templates] delete', error)
+    if (isMissingTableError(error)) throw asFriendlyMissingTableError(error)
     throw error
   }
 }

--- a/src/lib/templatesApi.test.js
+++ b/src/lib/templatesApi.test.js
@@ -1,12 +1,32 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// Holder for the result the next `from('task_templates').select(...).order(...)` call resolves to.
+// Holder for the result the next terminal Supabase call resolves to.
+// "Terminal" means the leaf call in each query chain — `.order()` for
+// fetch, `.single()` for insert/update, the `.eq()` after `.delete()`.
+// All four CRUD paths share the same holder so each test can stage one
+// outcome.
 const queryHolder = { result: { data: [], error: null } }
 
 vi.mock('./supabase', () => {
+  const resolveTerminal = () => Promise.resolve(queryHolder.result)
   const chain = {
     select: vi.fn(() => chain),
-    order: vi.fn(() => Promise.resolve(queryHolder.result)),
+    order: vi.fn(resolveTerminal),
+    insert: vi.fn(() => chain),
+    update: vi.fn(() => chain),
+    delete: vi.fn(() => chain),
+    eq: vi.fn(() => {
+      // After delete().eq(...) the chain resolves; after update().eq(...)
+      // the caller still appends .select().single(). Returning a thenable
+      // chain object that ALSO resolves keeps both call shapes happy.
+      const settled = resolveTerminal()
+      return Object.assign(chain, {
+        then: settled.then.bind(settled),
+        catch: settled.catch.bind(settled),
+        finally: settled.finally.bind(settled),
+      })
+    }),
+    single: vi.fn(resolveTerminal),
   }
   return {
     supabase: {
@@ -15,7 +35,12 @@ vi.mock('./supabase', () => {
   }
 })
 
-import { fetchTemplates } from './templatesApi'
+import {
+  fetchTemplates,
+  insertTemplate,
+  updateTemplate,
+  deleteTemplate,
+} from './templatesApi'
 
 describe('fetchTemplates', () => {
   beforeEach(() => {
@@ -121,5 +146,156 @@ describe('fetchTemplates', () => {
       },
     }
     await expect(fetchTemplates()).rejects.toMatchObject({ code: 'PGRST999' })
+  })
+})
+
+// Issue #340 follow-up: the original fix only hardened the read path
+// (fetchTemplates → empty state). When a user actually clicks "+ New
+// template", "Save", or "Delete template" while the schema is still
+// catching up, the modals surfaced the raw Postgres / PostgREST jargon
+// ("Could not find the table 'public.task_templates' in the schema
+// cache") via the err.message rendering path in CreateTemplateModal,
+// TemplateEditDrawer, and TaskDetailPanel. These tests pin down the
+// new behavior: missing-table errors get translated to a single
+// user-readable message so every CRUD surface stays consistent with
+// the read path's recovery story.
+
+describe('CRUD missing-table handling (issue #340)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    queryHolder.result = { data: null, error: null }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const FRIENDLY_MATCH = /templates table is not ready yet/i
+
+  describe('insertTemplate', () => {
+    it('throws a friendly error with a code-based missing-table failure (42P01)', async () => {
+      queryHolder.result = {
+        data: null,
+        error: {
+          code: '42P01',
+          message: 'relation "public.task_templates" does not exist',
+        },
+      }
+      await expect(
+        insertTemplate({ name: 'X', task_title: 'Y', plan: null }),
+      ).rejects.toThrow(FRIENDLY_MATCH)
+    })
+
+    it('throws a friendly error with a code-based missing-table failure (PGRST205)', async () => {
+      queryHolder.result = {
+        data: null,
+        error: {
+          code: 'PGRST205',
+          message: "Could not find the table 'public.task_templates' in the schema cache",
+        },
+      }
+      await expect(
+        insertTemplate({ name: 'X', task_title: 'Y', plan: null }),
+      ).rejects.toThrow(FRIENDLY_MATCH)
+    })
+
+    it('throws a friendly error with a message-based missing-table failure (unknown code)', async () => {
+      queryHolder.result = {
+        data: null,
+        error: {
+          code: 'PGRST999',
+          message: "Could not find the table 'public.task_templates' in the schema cache",
+        },
+      }
+      await expect(
+        insertTemplate({ name: 'X', task_title: 'Y', plan: null }),
+      ).rejects.toThrow(FRIENDLY_MATCH)
+    })
+
+    it('preserves the original Supabase error on the thrown error\'s `cause`', async () => {
+      const original = {
+        code: '42P01',
+        message: 'relation "public.task_templates" does not exist',
+      }
+      queryHolder.result = { data: null, error: original }
+      try {
+        await insertTemplate({ name: 'X', task_title: 'Y', plan: null })
+        throw new Error('expected to throw')
+      } catch (err) {
+        expect(err.cause).toBe(original)
+      }
+    })
+
+    it('still surfaces unrelated Supabase errors verbatim', async () => {
+      queryHolder.result = {
+        data: null,
+        error: { code: '42501', message: 'permission denied' },
+      }
+      await expect(
+        insertTemplate({ name: 'X', task_title: 'Y', plan: null }),
+      ).rejects.toMatchObject({ code: '42501' })
+    })
+  })
+
+  describe('updateTemplate', () => {
+    it('throws a friendly error on a missing-table failure (42P01)', async () => {
+      queryHolder.result = {
+        data: null,
+        error: {
+          code: '42P01',
+          message: 'relation "public.task_templates" does not exist',
+        },
+      }
+      await expect(
+        updateTemplate('tpl-1', { name: 'X' }),
+      ).rejects.toThrow(FRIENDLY_MATCH)
+    })
+
+    it('throws a friendly error on a missing-table failure (message-based, unknown code)', async () => {
+      queryHolder.result = {
+        data: null,
+        error: {
+          code: 'PGRST999',
+          message: "Could not find the table 'public.task_templates' in the schema cache",
+        },
+      }
+      await expect(
+        updateTemplate('tpl-1', { name: 'X' }),
+      ).rejects.toThrow(FRIENDLY_MATCH)
+    })
+
+    it('still surfaces unrelated Supabase errors verbatim', async () => {
+      queryHolder.result = {
+        data: null,
+        error: { code: '42501', message: 'permission denied' },
+      }
+      await expect(
+        updateTemplate('tpl-1', { name: 'X' }),
+      ).rejects.toMatchObject({ code: '42501' })
+    })
+  })
+
+  describe('deleteTemplate', () => {
+    it('throws a friendly error on a missing-table failure (PGRST205)', async () => {
+      queryHolder.result = {
+        data: null,
+        error: {
+          code: 'PGRST205',
+          message: "Could not find the table 'public.task_templates' in the schema cache",
+        },
+      }
+      await expect(deleteTemplate('tpl-1')).rejects.toThrow(FRIENDLY_MATCH)
+    })
+
+    it('still surfaces unrelated Supabase errors verbatim', async () => {
+      queryHolder.result = {
+        data: null,
+        error: { code: '42501', message: 'permission denied' },
+      }
+      await expect(deleteTemplate('tpl-1')).rejects.toMatchObject({
+        code: '42501',
+      })
+    })
   })
 })


### PR DESCRIPTION
Closes #340

The original fixes (#341, #374) hardened only the read path
(`fetchTemplates`) — when the `task_templates` schema is missing or
PostgREST's schema cache is cold, the page renders the empty state.
But the modals for **+ New template**, **Save** edits, and **Delete
template** still surfaced the raw Postgres / PostgREST jargon
("`Could not find the table 'public.task_templates' in the schema
cache`") via their existing `err.message` rendering, leaving users
back at the same confusing string the original bug report named.

This PR closes that surface gap: `insertTemplate`, `updateTemplate`,
and `deleteTemplate` now translate any missing-table error (42P01,
PGRST205, or message-match for an unknown code) into a single
user-readable Error — `"Templates table is not ready yet. Please try
again in a moment, or contact your administrator if the problem
persists."` The original Supabase error is preserved on the thrown
error's `.cause` so debugging is unaffected. Unrelated errors
(e.g. `42501 permission denied`) still surface verbatim.

## TDD
- Tests added/modified: `src/lib/templatesApi.test.js`
- Before implementation (red): 7 new assertions failed for the right
  reason — the API still threw raw Postgres/PostgREST messages
  ("`Could not find the table 'public.task_templates' in the schema
  cache`") instead of matching `/templates table is not ready yet/i`.
- After implementation (green): all 18 templatesApi tests pass; full
  suite is **459/459 green** (was 449/449; +10 new tests covering
  insert/update/delete missing-table handling, unrelated-error
  pass-through, and `.cause` preservation).

## Notes
- No frontend component change needed: the `CreateTemplateModal`,
  `TemplateEditDrawer`, and `TaskDetailPanel` all already render
  `err.message` via their own alert paths, so swapping the message at
  the API layer cascades correctly.
- The `task_templates` migration is applied in the live Supabase
  project (verified via `mcp__supabase__list_migrations` and
  `list_tables` — table exists with 1 row, RLS enabled), so the
  practical user-facing trigger today would be a transient PostgREST
  cache miss, not a permanently missing schema. The fix still matters
  because that transient state is exactly what the original bug
  report described.