### PR TITLE
fix(templates): match missing-table errors without public. prefix (#340)

### DIFF
--- a/src/lib/templatesApi.js
+++ b/src/lib/templatesApi.js
@@ -12,13 +12,15 @@ const MISSING_TABLE_CODES = new Set(['42P01', 'PGRST205'])
 
 // Defensive fallback: if Supabase returns an unrecognized error code
 // (e.g. an upstream version bump), fall back to matching the message
-// against task_templates-specific phrasing. Matches the two upstream
-// shapes we know — Postgres ("relation \"public.task_templates\" does
-// not exist") and PostgREST ("Could not find the table
-// 'public.task_templates' in the schema cache"). Restricted to the
-// task_templates table so unrelated failures still surface.
+// against task_templates-specific phrasing. Matches the upstream shapes
+// we know — Postgres ("relation \"task_templates\" does not exist") and
+// PostgREST ("Could not find the table 'task_templates' in the schema
+// cache"), with or without the optional `public.` schema prefix (some
+// servers omit it depending on search_path / upstream version).
+// Restricted to the task_templates table so unrelated failures still
+// surface.
 const MISSING_TABLE_MESSAGE_PATTERN =
-  /(relation\s+"?public\.task_templates"?\s+does\s+not\s+exist|table\s+'?public\.task_templates'?[^']*schema\s+cache)/i
+  /(relation\s+"?(?:public\.)?task_templates"?\s+does\s+not\s+exist|table\s+'?(?:public\.)?task_templates'?[^']*schema\s+cache)/i
 
 // Single user-facing message for every CRUD path that hits a missing-
 // table condition. Keeps the modal/drawer copy consistent so users

--- a/src/lib/templatesApi.test.js
+++ b/src/lib/templatesApi.test.js
@@ -121,6 +121,35 @@ describe('fetchTemplates', () => {
     await expect(fetchTemplates()).resolves.toEqual([])
   })
 
+  it('returns [] when the message omits the public. schema prefix on a relation-does-not-exist error (issue #340)', async () => {
+    // search_path-aware Postgres servers and some PostgREST builds emit the
+    // bare table name in their error string. The fallback must still match
+    // so the templates page degrades to the empty state instead of bubbling
+    // raw Postgres jargon to the user.
+    queryHolder.result = {
+      data: null,
+      error: {
+        code: undefined,
+        message: 'relation "task_templates" does not exist',
+      },
+    }
+    await expect(fetchTemplates()).resolves.toEqual([])
+  })
+
+  it('returns [] when the message omits the public. prefix on a schema-cache miss (issue #340)', async () => {
+    // Some PostgREST versions report the schema-cache miss without the
+    // schema prefix. Mirrors the prefixed PGRST205 case the existing
+    // suite covers.
+    queryHolder.result = {
+      data: null,
+      error: {
+        code: 'PGRST999',
+        message: "Could not find the table 'task_templates' in the schema cache",
+      },
+    }
+    await expect(fetchTemplates()).resolves.toEqual([])
+  })
+
   it('still throws when the message mentions a different table that is missing', async () => {
     // Message-based fallback must not swallow genuinely unrelated errors —
     // a missing-column or missing-other-table error should still surface.


### PR DESCRIPTION
Closes #340

Follow-up to PRs #341 / #374 / #381. The previous fixes already cover
the read path (`fetchTemplates` returns `[]` for known missing-table
codes 42P01 / PGRST205) and CRUD modals (friendly fallback message
for the same codes). The defensive **message-based** fallback for
unknown codes still required the literal `public.task_templates`
substring, so two real-world variants slipped through and surfaced
raw Postgres / PostgREST jargon to the user:

- `relation "task_templates" does not exist` (no `public.` prefix —
  some Postgres builds emit the bare name when search_path resolves
  the table).
- `Could not find the table 'task_templates' in the schema cache`
  (some PostgREST versions omit the prefix on PGRST205-shaped
  payloads with a non-PGRST205 code).

Fix: make `(?:public\.)?` optional in `MISSING_TABLE_MESSAGE_PATTERN`.
The match is still scoped to `task_templates` so unrelated failures
(e.g. permission denied, network errors, missing columns) keep
surfacing verbatim.

## TDD
- Tests added/modified: `src/lib/templatesApi.test.js`
- Before implementation (red): the two new `fetchTemplates` cases
  failed because the API rejected the promise instead of resolving
  to `[]` — the unprefixed messages did not match the regex.
- After implementation (green): full frontend suite **461/461**
  green (was 459/459; +2 new fetchTemplates assertions).

## Notes
- No frontend component change needed — `TemplatesPage`,
  `TemplateSelectorModal`, and the CRUD modals already consume the
  hardened API surface.
- The two existing-prefix cases stay covered: I kept the regex
  matching the `public.task_templates` shape via the optional
  non-capturing group `(?:public\.)?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)