### PR TITLE
feat(templates): /templates/[id] detail + partial editor (#353)

### DIFF
--- a/src/components/TemplateDetailPage.jsx
+++ b/src/components/TemplateDetailPage.jsx
@@ -479,7 +479,12 @@ export default function TemplateDetailPage() {
         <div className="px-8 pb-12 space-y-8">
           <section className="rounded-2xl border border-border-subtle bg-bg-card p-5 space-y-3">
             <div>
-              <h2 className="text-sm font-semibold text-text-primary">Brand context</h2>
+              <label
+                htmlFor="template-brand-context"
+                className="text-sm font-semibold text-text-primary block"
+              >
+                Brand context
+              </label>
               <p className="text-xs text-text-muted">
                 Free-form Markdown describing voice, anti-patterns, and grounding
                 content for every step in this template.
@@ -487,7 +492,6 @@ export default function TemplateDetailPage() {
             </div>
             <textarea
               id="template-brand-context"
-              aria-label="Brand context"
               value={brandContext}
               onChange={(e) => setBrandContext(e.target.value)}
               rows={6}

--- a/src/components/TemplateDetailPage.jsx
+++ b/src/components/TemplateDetailPage.jsx
@@ -1,9 +1,438 @@
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router'
-import { ArrowLeft, LayoutTemplate } from 'lucide-react'
+import {
+  ArrowLeft,
+  Image as ImageIcon,
+  LayoutTemplate,
+  Loader2,
+  Lock,
+  FileText,
+  Plus,
+  Trash2,
+} from 'lucide-react'
 import Header from './Header'
+import { updateTemplate } from '../lib/templatesApi'
+import {
+  fetchTemplateById,
+  fetchReferences,
+  createTextReference,
+  createImageReference,
+  deleteReference,
+  getReferenceSignedUrl,
+} from '../lib/templateReferencesApi'
+import { validateTemplateStep } from '../lib/templateValidate'
+
+function deepCopy(value) {
+  if (value == null) return value
+  if (typeof structuredClone === 'function') return structuredClone(value)
+  return JSON.parse(JSON.stringify(value))
+}
+
+async function readFileAsText(file) {
+  if (typeof file.text === 'function') return file.text()
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '')
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(file)
+  })
+}
+
+function isImageFile(file) {
+  if (!file) return false
+  return typeof file.type === 'string' && file.type.startsWith('image/')
+}
+
+function paramsKeysFromSchema(schema) {
+  if (!schema || typeof schema !== 'object') return []
+  // Accept either a JSON-Schema-ish shape ({ properties: { x: {...} } }) or a
+  // flat map of keys to descriptors.
+  if (schema.properties && typeof schema.properties === 'object') {
+    return Object.keys(schema.properties)
+  }
+  return Object.keys(schema)
+}
+
+function ReadOnlyField({ label, value }) {
+  return (
+    <div>
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1">
+        {label}
+      </span>
+      <div className="flex items-center gap-1.5 text-xs text-text-secondary bg-bg-input/40 border border-border-subtle/60 rounded-lg px-2.5 py-1.5">
+        <Lock size={11} className="text-text-muted shrink-0" />
+        <span className="font-mono">{value}</span>
+      </div>
+    </div>
+  )
+}
+
+function ReferenceListItem({ reference, signedUrl, onDelete, deleting }) {
+  const [confirming, setConfirming] = useState(false)
+
+  return (
+    <li className="flex items-center gap-3 p-3 rounded-xl border border-border-subtle bg-bg-card">
+      <div className="w-10 h-10 rounded-lg bg-bg-input flex items-center justify-center text-text-muted shrink-0">
+        {reference.kind === 'image' ? <ImageIcon size={18} /> : <FileText size={18} />}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-text-primary truncate">{reference.key}</p>
+        <p className="text-xs text-text-muted">
+          {reference.kind === 'image' ? 'image' : 'text'}
+          {reference.original_filename ? ` · ${reference.original_filename}` : ''}
+        </p>
+        {reference.kind === 'image' && signedUrl ? (
+          <img
+            src={signedUrl}
+            alt={`${reference.key} preview`}
+            className="mt-2 max-h-24 rounded-md border border-border-subtle"
+          />
+        ) : null}
+      </div>
+      {confirming ? (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onDelete(reference.id)}
+            disabled={deleting}
+            className="text-xs px-2 py-1 rounded-md bg-rose-500 text-white hover:bg-rose-600 transition-colors disabled:opacity-50"
+            aria-label={`Confirm delete reference ${reference.key}`}
+          >
+            Confirm delete reference
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            disabled={deleting}
+            className="text-xs px-2 py-1 rounded-md text-text-secondary hover:text-text-primary"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="p-1.5 rounded-md text-rose-400 hover:bg-rose-500/10 transition-colors"
+          aria-label={`Delete reference ${reference.key}`}
+        >
+          <Trash2 size={14} />
+        </button>
+      )}
+    </li>
+  )
+}
+
+function StepEditor({ step, references, paramsKeys, onSave }) {
+  const [instruction, setInstruction] = useState(step.instruction ?? '')
+  const [requiresApproval, setRequiresApproval] = useState(Boolean(step.requires_approval))
+  const [errors, setErrors] = useState([])
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState(null)
+
+  const referenceKeysForStep = useMemo(() => {
+    const ids = Array.isArray(step.reference_ids) ? step.reference_ids : []
+    const idSet = new Set(ids)
+    return references.filter((r) => idSet.has(r.id)).map((r) => r.key)
+  }, [references, step.reference_ids])
+
+  const handleSave = async () => {
+    const validationErrors = validateTemplateStep(
+      { instruction },
+      paramsKeys,
+      Array.isArray(step.needs_outputs_from) ? step.needs_outputs_from : [],
+      referenceKeysForStep,
+    )
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors)
+      setSaveError(null)
+      return
+    }
+    setErrors([])
+    setSaveError(null)
+    setSaving(true)
+    try {
+      await onSave({
+        ...step,
+        instruction,
+        requires_approval: requiresApproval,
+      })
+    } catch (err) {
+      setSaveError(err?.message || 'Failed to save step')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const stepLabel = step.agent_name || step.agent_id || 'Agent'
+  const orderLabel = `Step ${step.order ?? step.id}`
+  const instructionId = `step-${step.id}-instruction`
+  const approvalId = `step-${step.id}-requires-approval`
+
+  return (
+    <div className="rounded-2xl border border-border-subtle bg-bg-card p-5 space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+            {orderLabel}
+          </p>
+          <h3 className="text-base font-semibold text-text-primary">{stepLabel}</h3>
+        </div>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50"
+          aria-label={`Save step ${step.order ?? step.id}`}
+        >
+          {saving && <Loader2 size={12} className="animate-spin" />}
+          Save step {step.order ?? step.id}
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <ReadOnlyField label="Agent ID" value={step.agent_id || '—'} />
+        <ReadOnlyField
+          label="Tool Keys"
+          value={
+            Array.isArray(step.tool_keys) && step.tool_keys.length > 0
+              ? step.tool_keys.join(', ')
+              : '—'
+          }
+        />
+        <ReadOnlyField
+          label="Needs Outputs From"
+          value={
+            Array.isArray(step.needs_outputs_from) && step.needs_outputs_from.length > 0
+              ? step.needs_outputs_from.join(', ')
+              : '—'
+          }
+        />
+        <ReadOnlyField
+          label="Params Keys"
+          value={
+            Array.isArray(step.params_keys) && step.params_keys.length > 0
+              ? step.params_keys.join(', ')
+              : '—'
+          }
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor={instructionId}
+          className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+        >
+          Step {step.order ?? step.id} instruction
+        </label>
+        <textarea
+          id={instructionId}
+          value={instruction}
+          onChange={(e) => setInstruction(e.target.value)}
+          rows={4}
+          className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary outline-none focus:border-border-hover resize-y transition-colors font-mono"
+        />
+      </div>
+
+      <div>
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5">
+          Reference IDs (read-only — edit via references panel)
+        </span>
+        <p className="text-xs text-text-secondary font-mono">
+          {Array.isArray(step.reference_ids) && step.reference_ids.length > 0
+            ? step.reference_ids.join(', ')
+            : '—'}
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id={approvalId}
+          type="checkbox"
+          checked={requiresApproval}
+          onChange={(e) => setRequiresApproval(e.target.checked)}
+          aria-label={`Step ${step.order ?? step.id} requires approval`}
+        />
+        <label htmlFor={approvalId} className="text-sm text-text-secondary">
+          Requires approval before advancing
+        </label>
+      </div>
+
+      {errors.length > 0 && (
+        <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2" role="alert">
+          <p className="text-xs font-semibold text-rose-300 mb-1">
+            Validation failed — fix before saving:
+          </p>
+          <ul className="text-xs text-rose-200 space-y-0.5">
+            {errors.map((err, idx) => (
+              <li key={idx}>
+                <span className="font-mono">{err.placeholder}</span> — {err.kind.replace(/_/g, ' ')}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {saveError && (
+        <p className="text-xs text-rose-300" role="alert">{saveError}</p>
+      )}
+    </div>
+  )
+}
 
 export default function TemplateDetailPage() {
   const { id } = useParams()
+  const [template, setTemplate] = useState(null)
+  const [references, setReferences] = useState([])
+  const [signedUrls, setSignedUrls] = useState({})
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(null)
+  const [notFound, setNotFound] = useState(false)
+
+  const [brandContext, setBrandContext] = useState('')
+  const [savingBrand, setSavingBrand] = useState(false)
+  const [brandError, setBrandError] = useState(null)
+
+  const [newKey, setNewKey] = useState('')
+  const [newFile, setNewFile] = useState(null)
+  const [adding, setAdding] = useState(false)
+  const [addError, setAddError] = useState(null)
+  const [deletingId, setDeletingId] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setLoadError(null)
+    setNotFound(false)
+    Promise.all([fetchTemplateById(id), fetchReferences(id)])
+      .then(([tpl, refs]) => {
+        if (cancelled) return
+        if (!tpl) {
+          setNotFound(true)
+          return
+        }
+        setTemplate(tpl)
+        setBrandContext(tpl.brand_context ?? '')
+        setReferences(Array.isArray(refs) ? refs : [])
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setLoadError(err?.message || 'Failed to load template')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  useEffect(() => {
+    let cancelled = false
+    const imageRefs = references.filter(
+      (r) => r.kind === 'image' && typeof r.storage_path === 'string',
+    )
+    Promise.all(
+      imageRefs.map(async (r) => {
+        try {
+          const url = await getReferenceSignedUrl(r.storage_path, 3600)
+          return [r.id, url]
+        } catch {
+          return [r.id, null]
+        }
+      }),
+    ).then((entries) => {
+      if (cancelled) return
+      const map = {}
+      for (const [refId, url] of entries) {
+        if (url) map[refId] = url
+      }
+      setSignedUrls(map)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [references])
+
+  const paramsKeys = useMemo(
+    () => paramsKeysFromSchema(template?.params_schema),
+    [template?.params_schema],
+  )
+
+  const handleSaveBrand = async () => {
+    if (!template) return
+    setSavingBrand(true)
+    setBrandError(null)
+    try {
+      const updated = await updateTemplate(template.id, { brand_context: brandContext })
+      if (updated) setTemplate(updated)
+      else setTemplate({ ...template, brand_context: brandContext })
+    } catch (err) {
+      setBrandError(err?.message || 'Failed to save brand context')
+    } finally {
+      setSavingBrand(false)
+    }
+  }
+
+  const handleAddReference = async () => {
+    if (!template) return
+    if (!newKey.trim() || !newFile) return
+    setAdding(true)
+    setAddError(null)
+    try {
+      let inserted
+      if (isImageFile(newFile)) {
+        inserted = await createImageReference(template.id, {
+          key: newKey.trim(),
+          file: newFile,
+          mime_type: newFile.type,
+          original_filename: newFile.name,
+        })
+      } else {
+        const text = await readFileAsText(newFile)
+        inserted = await createTextReference(template.id, {
+          key: newKey.trim(),
+          content_text: text,
+          mime_type: newFile.type || 'text/markdown',
+          original_filename: newFile.name,
+        })
+      }
+      if (inserted) {
+        setReferences((prev) => [...prev, inserted])
+      }
+      setNewKey('')
+      setNewFile(null)
+    } catch (err) {
+      setAddError(err?.message || 'Failed to add reference')
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const handleDeleteReference = async (referenceId) => {
+    setDeletingId(referenceId)
+    try {
+      await deleteReference(referenceId)
+      setReferences((prev) => prev.filter((r) => r.id !== referenceId))
+    } catch (err) {
+      setAddError(err?.message || 'Failed to delete reference')
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  const handleSaveStep = async (updatedStep) => {
+    if (!template) return
+    const planClone = deepCopy(template.plan) ?? { steps: [] }
+    if (!Array.isArray(planClone.steps)) planClone.steps = []
+    planClone.steps = planClone.steps.map((s) =>
+      s.id === updatedStep.id ? updatedStep : s,
+    )
+    const updated = await updateTemplate(template.id, { plan: planClone })
+    if (updated) setTemplate(updated)
+    else setTemplate({ ...template, plan: planClone })
+  }
+
+  const planSteps = Array.isArray(template?.plan?.steps) ? template.plan.steps : []
 
   return (
     <>
@@ -16,29 +445,161 @@ export default function TemplateDetailPage() {
           <ArrowLeft size={16} />
           Back to templates
         </Link>
-        <div className="flex items-center gap-5">
-          <div className="hero-icon w-16 h-16 rounded-2xl bg-gradient-to-br from-purple-500/20 to-purple-500/5 border border-purple-500/20 flex items-center justify-center">
-            <LayoutTemplate size={32} className="text-purple-400" />
+
+        {loading ? (
+          <p className="text-text-muted text-base" role="status">
+            Loading template...
+          </p>
+        ) : notFound ? (
+          <p className="text-text-muted text-base" role="alert">
+            Template not found.
+          </p>
+        ) : loadError ? (
+          <p className="text-rose-300 text-base" role="alert">
+            Failed to load template: {loadError}
+          </p>
+        ) : template ? (
+          <div className="flex items-center gap-5">
+            <div className="hero-icon w-16 h-16 rounded-2xl bg-gradient-to-br from-purple-500/20 to-purple-500/5 border border-purple-500/20 flex items-center justify-center">
+              <LayoutTemplate size={32} className="text-purple-400" />
+            </div>
+            <div className="flex-1">
+              <h1 className="text-3xl font-bold text-text-primary tracking-tight">
+                {template.name}
+              </h1>
+              <p className="text-text-secondary text-base mt-0.5">
+                {template.description || 'No description'}
+              </p>
+            </div>
           </div>
-          <div className="flex-1">
-            <h1 className="text-3xl font-bold text-text-primary tracking-tight">Template details</h1>
-            <p className="text-text-secondary text-base mt-0.5">
-              ID: <code className="font-mono text-sm text-text-muted">{id}</code>
-            </p>
-          </div>
-        </div>
+        ) : null}
       </section>
 
-      <div className="px-8 pb-12">
-        <div className="rounded-2xl border border-border-subtle bg-bg-card p-8 text-center">
-          <p className="text-text-muted text-base">
-            The full template detail view is coming soon.
-          </p>
-          <p className="text-text-muted/60 text-sm mt-2">
-            For now this page exists so the &quot;Usar template&quot; CTA has a destination.
-          </p>
+      {template && !notFound && !loading ? (
+        <div className="px-8 pb-12 space-y-8">
+          <section className="rounded-2xl border border-border-subtle bg-bg-card p-5 space-y-3">
+            <div>
+              <h2 className="text-sm font-semibold text-text-primary">Brand context</h2>
+              <p className="text-xs text-text-muted">
+                Free-form Markdown describing voice, anti-patterns, and grounding
+                content for every step in this template.
+              </p>
+            </div>
+            <textarea
+              id="template-brand-context"
+              aria-label="Brand context"
+              value={brandContext}
+              onChange={(e) => setBrandContext(e.target.value)}
+              rows={6}
+              className="w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary outline-none focus:border-border-hover resize-y font-mono"
+            />
+            <div className="flex items-center justify-end gap-2">
+              {brandError && (
+                <span className="text-xs text-rose-300" role="alert">{brandError}</span>
+              )}
+              <button
+                type="button"
+                onClick={handleSaveBrand}
+                disabled={savingBrand}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50"
+                aria-label="Save brand context"
+              >
+                {savingBrand && <Loader2 size={12} className="animate-spin" />}
+                Save brand context
+              </button>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-border-subtle bg-bg-card p-5 space-y-4">
+            <div>
+              <h2 className="text-sm font-semibold text-text-primary">References</h2>
+              <p className="text-xs text-text-muted">
+                Brand grounding (text or image). Each step picks the references it
+                consumes; placeholders use <code className="font-mono">{`{{ref:KEY}}`}</code>.
+              </p>
+            </div>
+
+            {references.length === 0 ? (
+              <p className="text-xs text-text-muted italic">No references attached yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {references.map((ref) => (
+                  <ReferenceListItem
+                    key={ref.id}
+                    reference={ref}
+                    signedUrl={signedUrls[ref.id]}
+                    onDelete={handleDeleteReference}
+                    deleting={deletingId === ref.id}
+                  />
+                ))}
+              </ul>
+            )}
+
+            <div className="border-t border-border-subtle/60 pt-4 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                Add reference
+              </p>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <input
+                  id="new-reference-key"
+                  aria-label="New reference key"
+                  type="text"
+                  value={newKey}
+                  onChange={(e) => setNewKey(e.target.value)}
+                  placeholder="e.g. tone_of_voice"
+                  className="flex-1 bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2 text-sm text-text-primary outline-none focus:border-border-hover transition-colors"
+                />
+                <input
+                  id="new-reference-file"
+                  aria-label="Upload reference file"
+                  type="file"
+                  onChange={(e) => setNewFile(e.target.files?.[0] ?? null)}
+                  className="text-sm text-text-secondary file:mr-3 file:px-3 file:py-1.5 file:text-xs file:font-medium file:rounded-lg file:bg-bg-input file:text-text-primary file:border-0 hover:file:bg-bg-input-hover transition-colors"
+                />
+                <button
+                  type="button"
+                  onClick={handleAddReference}
+                  disabled={adding || !newKey.trim() || !newFile}
+                  className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50"
+                  aria-label="Add reference"
+                >
+                  {adding ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+                  Add reference
+                </button>
+              </div>
+              {addError && (
+                <p className="text-xs text-rose-300" role="alert">{addError}</p>
+              )}
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div>
+              <h2 className="text-sm font-semibold text-text-primary">Plan steps</h2>
+              <p className="text-xs text-text-muted">
+                Structural fields (agent, tools, needs_outputs_from, params_keys) are
+                read-only. Edit instruction text and approval gates here.
+              </p>
+            </div>
+
+            {planSteps.length === 0 ? (
+              <p className="text-xs text-text-muted italic">No steps in this template's plan.</p>
+            ) : (
+              <div className="space-y-4">
+                {planSteps.map((step) => (
+                  <StepEditor
+                    key={step.id}
+                    step={step}
+                    references={references}
+                    paramsKeys={paramsKeys}
+                    onSave={handleSaveStep}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
         </div>
-      </div>
+      ) : null}
     </>
   )
 }

--- a/src/components/TemplateDetailPage.test.jsx
+++ b/src/components/TemplateDetailPage.test.jsx
@@ -274,10 +274,12 @@ describe('TemplateDetailPage — references CRUD', () => {
     renderAtRoute()
     await screen.findByText(/^tone$/i)
 
-    const deleteButtons = screen.getAllByRole('button', { name: /delete reference/i })
+    const deleteButtons = screen.getAllByRole('button', { name: /^delete reference tone$/i })
     await user.click(deleteButtons[0])
     // Confirmation step
-    await user.click(await screen.findByRole('button', { name: /^confirm delete reference$/i }))
+    await user.click(
+      await screen.findByRole('button', { name: /^confirm delete reference tone$/i }),
+    )
 
     await waitFor(() => expect(deleteReference).toHaveBeenCalledWith('ref-tone-id'))
     await waitFor(() => expect(screen.queryByText(/^tone$/i)).not.toBeInTheDocument())

--- a/src/components/TemplateDetailPage.test.jsx
+++ b/src/components/TemplateDetailPage.test.jsx
@@ -171,7 +171,7 @@ describe('TemplateDetailPage — loading, not-found, and basic header', () => {
 describe('TemplateDetailPage — brand_context editor', () => {
   it('pre-fills the brand context textarea with the current value', async () => {
     renderAtRoute()
-    const textarea = await screen.findByLabelText(/brand context/i)
+    const textarea = await screen.findByLabelText(/^brand context$/i)
     expect(textarea).toHaveValue('Speak warmly in Portuguese.')
   })
 
@@ -182,7 +182,7 @@ describe('TemplateDetailPage — brand_context editor', () => {
     const user = userEvent.setup()
     renderAtRoute()
 
-    const textarea = await screen.findByLabelText(/brand context/i)
+    const textarea = await screen.findByLabelText(/^brand context$/i)
     await user.clear(textarea)
     await user.type(textarea, 'Updated brand voice')
     await user.click(screen.getByRole('button', { name: /save brand context/i }))

--- a/src/components/TemplateDetailPage.test.jsx
+++ b/src/components/TemplateDetailPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Routes, Route, MemoryRouter } from 'react-router'
 import { render } from '@testing-library/react'

--- a/src/components/TemplateDetailPage.test.jsx
+++ b/src/components/TemplateDetailPage.test.jsx
@@ -321,8 +321,7 @@ describe('TemplateDetailPage — steps editor', () => {
     await screen.findByLabelText(/step 1 instruction/i)
 
     const instruction = screen.getByLabelText(/step 1 instruction/i)
-    await user.clear(instruction)
-    await user.type(instruction, 'Pesquise sobre {{params.topic}}')
+    fireEvent.change(instruction, { target: { value: 'Pesquise sobre {{params.topic}}' } })
 
     const approvalToggle = screen.getByLabelText(/step 1 requires approval/i)
     await user.click(approvalToggle) // toggle off (was true)
@@ -347,8 +346,7 @@ describe('TemplateDetailPage — steps editor', () => {
     await screen.findByLabelText(/step 1 instruction/i)
 
     const instruction = screen.getByLabelText(/step 1 instruction/i)
-    await user.clear(instruction)
-    await user.type(instruction, 'Bad: {{params.unknown_one}}')
+    fireEvent.change(instruction, { target: { value: 'Bad: {{params.unknown_one}}' } })
 
     await user.click(screen.getByRole('button', { name: /^save step 1$/i }))
 
@@ -363,8 +361,7 @@ describe('TemplateDetailPage — steps editor', () => {
     await screen.findByLabelText(/step 1 instruction/i)
 
     const instruction = screen.getByLabelText(/step 1 instruction/i)
-    await user.clear(instruction)
-    await user.type(instruction, 'Voice: {{ref:nonexistent}}')
+    fireEvent.change(instruction, { target: { value: 'Voice: {{ref:nonexistent}}' } })
 
     await user.click(screen.getByRole('button', { name: /^save step 1$/i }))
 

--- a/src/components/TemplateDetailPage.test.jsx
+++ b/src/components/TemplateDetailPage.test.jsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
-import { screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Routes, Route, MemoryRouter } from 'react-router'
 import { render } from '@testing-library/react'
 import TemplateDetailPage from './TemplateDetailPage'
@@ -29,7 +30,34 @@ vi.mock('../context/AuthContext', () => ({
   AuthProvider: ({ children }) => children,
 }))
 
-function renderAtRoute(path) {
+vi.mock('../lib/templatesApi', () => ({
+  fetchTemplates: vi.fn().mockResolvedValue([]),
+  insertTemplate: vi.fn(),
+  updateTemplate: vi.fn(),
+  deleteTemplate: vi.fn(),
+}))
+
+vi.mock('../lib/templateReferencesApi', () => ({
+  fetchReferences: vi.fn(),
+  createTextReference: vi.fn(),
+  createImageReference: vi.fn(),
+  updateReference: vi.fn(),
+  deleteReference: vi.fn(),
+  getReferenceSignedUrl: vi.fn(),
+  fetchTemplateById: vi.fn(),
+}))
+
+import { updateTemplate } from '../lib/templatesApi'
+import {
+  fetchReferences,
+  createTextReference,
+  createImageReference,
+  deleteReference,
+  getReferenceSignedUrl,
+  fetchTemplateById,
+} from '../lib/templateReferencesApi'
+
+function renderAtRoute(path = '/templates/tpl-1') {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <DataProvider>
@@ -43,15 +71,303 @@ function renderAtRoute(path) {
   )
 }
 
-describe('TemplateDetailPage', () => {
-  it('renders the template id pulled from the URL', () => {
-    renderAtRoute('/templates/tpl-123')
-    expect(screen.getByText('tpl-123')).toBeInTheDocument()
+const sampleTemplate = {
+  id: 'tpl-1',
+  name: 'Luiza pipeline',
+  description: 'Content automation pipeline',
+  brand_context: 'Speak warmly in Portuguese.',
+  params_schema: {
+    topic: { type: 'string', required: true },
+    time_range: { type: 'string', required: true },
+  },
+  title_template: 'Conteúdo: {{params.topic}}',
+  description_template: 'Tópico {{params.topic}}',
+  plan: {
+    steps: [
+      {
+        id: 1,
+        order: 1,
+        agent_id: 'pedro-pesquisa',
+        agent_name: 'Pedro Pesquisa',
+        tool_keys: ['web_search'],
+        params_keys: ['topic', 'time_range'],
+        needs_outputs_from: [],
+        reference_ids: [],
+        instruction: 'Pesquise sobre {{params.topic}} nos últimos {{params.time_range}}.',
+        requires_approval: true,
+      },
+      {
+        id: 2,
+        order: 2,
+        agent_id: 'iago-instagram',
+        agent_name: 'Iago Instagram',
+        tool_keys: [],
+        params_keys: [],
+        needs_outputs_from: [1],
+        reference_ids: ['ref-tone-id'],
+        instruction: 'Use {{step-1.output}} no tom {{ref:tone}}.',
+        requires_approval: false,
+      },
+    ],
+  },
+}
+
+const sampleReferences = [
+  {
+    id: 'ref-tone-id',
+    template_id: 'tpl-1',
+    key: 'tone',
+    kind: 'text',
+    content_text: 'Speak warmly.',
+    mime_type: 'text/markdown',
+    original_filename: 'tone.md',
+    created_at: '2026-05-01T00:00:00Z',
+  },
+  {
+    id: 'ref-mood-id',
+    template_id: 'tpl-1',
+    key: 'mood',
+    kind: 'image',
+    storage_path: 'tpl-1/mood.png',
+    mime_type: 'image/png',
+    original_filename: 'mood.png',
+    created_at: '2026-05-02T00:00:00Z',
+  },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchTemplateById.mockResolvedValue(sampleTemplate)
+  fetchReferences.mockResolvedValue(sampleReferences)
+  getReferenceSignedUrl.mockResolvedValue('https://signed.example/preview.png')
+})
+
+describe('TemplateDetailPage — loading, not-found, and basic header', () => {
+  it('shows a loading indicator before the fetch resolves', () => {
+    fetchTemplateById.mockReturnValue(new Promise(() => {}))
+    renderAtRoute()
+    expect(screen.getByText(/loading template/i)).toBeInTheDocument()
   })
 
-  it('renders a back link to /templates', () => {
-    renderAtRoute('/templates/tpl-456')
-    const back = screen.getByRole('link', { name: /back to templates/i })
+  it('shows a not-found message when fetchTemplateById returns null', async () => {
+    fetchTemplateById.mockResolvedValue(null)
+    renderAtRoute('/templates/missing')
+    expect(await screen.findByText(/template not found/i)).toBeInTheDocument()
+  })
+
+  it('renders the template name and description', async () => {
+    renderAtRoute()
+    expect(await screen.findByRole('heading', { name: /luiza pipeline/i })).toBeInTheDocument()
+    expect(screen.getByText(/content automation pipeline/i)).toBeInTheDocument()
+  })
+
+  it('renders a back link to /templates', async () => {
+    renderAtRoute()
+    const back = await screen.findByRole('link', { name: /back to templates/i })
     expect(back).toHaveAttribute('href', '/templates')
+  })
+})
+
+describe('TemplateDetailPage — brand_context editor', () => {
+  it('pre-fills the brand context textarea with the current value', async () => {
+    renderAtRoute()
+    const textarea = await screen.findByLabelText(/brand context/i)
+    expect(textarea).toHaveValue('Speak warmly in Portuguese.')
+  })
+
+  it('saving brand_context calls updateTemplate with the new value', async () => {
+    updateTemplate.mockImplementation((id, updates) =>
+      Promise.resolve({ ...sampleTemplate, ...updates }),
+    )
+    const user = userEvent.setup()
+    renderAtRoute()
+
+    const textarea = await screen.findByLabelText(/brand context/i)
+    await user.clear(textarea)
+    await user.type(textarea, 'Updated brand voice')
+    await user.click(screen.getByRole('button', { name: /save brand context/i }))
+
+    await waitFor(() => expect(updateTemplate).toHaveBeenCalledTimes(1))
+    expect(updateTemplate).toHaveBeenCalledWith(
+      'tpl-1',
+      expect.objectContaining({ brand_context: 'Updated brand voice' }),
+    )
+  })
+})
+
+describe('TemplateDetailPage — references CRUD', () => {
+  it('lists existing references with name and kind', async () => {
+    renderAtRoute()
+    expect(await screen.findByText(/^tone$/i)).toBeInTheDocument()
+    expect(screen.getByText(/^mood$/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/text/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/image/i).length).toBeGreaterThan(0)
+  })
+
+  it('uploading a .md file creates a kind=text reference', async () => {
+    createTextReference.mockResolvedValue({
+      id: 'ref-new',
+      template_id: 'tpl-1',
+      key: 'instructions',
+      kind: 'text',
+      content_text: '# hello world',
+      original_filename: 'instructions.md',
+    })
+    const user = userEvent.setup()
+    renderAtRoute()
+    await screen.findByText(/^tone$/i)
+
+    await user.type(screen.getByLabelText(/new reference key/i), 'instructions')
+
+    const file = new File(['# hello world'], 'instructions.md', { type: 'text/markdown' })
+    const input = screen.getByLabelText(/upload reference file/i)
+    await user.upload(input, file)
+
+    await user.click(screen.getByRole('button', { name: /add reference/i }))
+
+    await waitFor(() => expect(createTextReference).toHaveBeenCalledTimes(1))
+    expect(createTextReference).toHaveBeenCalledWith(
+      'tpl-1',
+      expect.objectContaining({
+        key: 'instructions',
+        original_filename: 'instructions.md',
+      }),
+    )
+  })
+
+  it('uploading a .png file creates a kind=image reference', async () => {
+    createImageReference.mockResolvedValue({
+      id: 'ref-img-new',
+      template_id: 'tpl-1',
+      key: 'cover',
+      kind: 'image',
+      storage_path: 'tpl-1/cover.png',
+      mime_type: 'image/png',
+      original_filename: 'cover.png',
+    })
+    const user = userEvent.setup()
+    renderAtRoute()
+    await screen.findByText(/^tone$/i)
+
+    await user.type(screen.getByLabelText(/new reference key/i), 'cover')
+
+    const file = new File(['fake-bytes'], 'cover.png', { type: 'image/png' })
+    const input = screen.getByLabelText(/upload reference file/i)
+    await user.upload(input, file)
+
+    await user.click(screen.getByRole('button', { name: /add reference/i }))
+
+    await waitFor(() => expect(createImageReference).toHaveBeenCalledTimes(1))
+    expect(createImageReference).toHaveBeenCalledWith(
+      'tpl-1',
+      expect.objectContaining({
+        key: 'cover',
+        mime_type: 'image/png',
+        original_filename: 'cover.png',
+      }),
+    )
+  })
+
+  it('deleting a reference calls deleteReference and removes it from the list', async () => {
+    deleteReference.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    renderAtRoute()
+    await screen.findByText(/^tone$/i)
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete reference/i })
+    await user.click(deleteButtons[0])
+    // Confirmation step
+    await user.click(await screen.findByRole('button', { name: /^confirm delete reference$/i }))
+
+    await waitFor(() => expect(deleteReference).toHaveBeenCalledWith('ref-tone-id'))
+    await waitFor(() => expect(screen.queryByText(/^tone$/i)).not.toBeInTheDocument())
+  })
+})
+
+describe('TemplateDetailPage — steps editor', () => {
+  it('renders one step block per step, labeled with order and agent', async () => {
+    renderAtRoute()
+    expect(await screen.findByText(/step 1/i)).toBeInTheDocument()
+    expect(screen.getByText(/pedro pesquisa/i)).toBeInTheDocument()
+    expect(screen.getByText(/step 2/i)).toBeInTheDocument()
+    expect(screen.getByText(/iago instagram/i)).toBeInTheDocument()
+  })
+
+  it('renders structural fields read-only and instruction as a textarea', async () => {
+    renderAtRoute()
+    await screen.findByText(/step 1/i)
+
+    // Read-only display: agent_id should appear as text, not in an editable input.
+    const agentIdReadonly = screen.getAllByText(/pedro-pesquisa/i)
+    expect(agentIdReadonly.length).toBeGreaterThan(0)
+    expect(screen.queryByRole('textbox', { name: /agent id/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: /tool keys/i })).not.toBeInTheDocument()
+
+    // Instruction is an editable textarea.
+    const instruction1 = screen.getByLabelText(/step 1 instruction/i)
+    expect(instruction1.tagName.toLowerCase()).toBe('textarea')
+    expect(instruction1).toHaveValue(
+      'Pesquise sobre {{params.topic}} nos últimos {{params.time_range}}.',
+    )
+  })
+
+  it('saving a step persists instruction and requires_approval changes via updateTemplate', async () => {
+    updateTemplate.mockImplementation((id, updates) =>
+      Promise.resolve({ ...sampleTemplate, ...updates }),
+    )
+    const user = userEvent.setup()
+    renderAtRoute()
+    await screen.findByText(/step 1/i)
+
+    const instruction = screen.getByLabelText(/step 1 instruction/i)
+    await user.clear(instruction)
+    await user.type(instruction, 'Pesquise sobre {{params.topic}}')
+
+    const approvalToggle = screen.getByLabelText(/step 1 requires approval/i)
+    await user.click(approvalToggle) // toggle off (was true)
+
+    await user.click(screen.getByRole('button', { name: /^save step 1$/i }))
+
+    await waitFor(() => expect(updateTemplate).toHaveBeenCalledTimes(1))
+    const [id, payload] = updateTemplate.mock.calls[0]
+    expect(id).toBe('tpl-1')
+    const updatedStep = payload.plan.steps.find((s) => s.id === 1)
+    expect(updatedStep.instruction).toBe('Pesquise sobre {{params.topic}}')
+    expect(updatedStep.requires_approval).toBe(false)
+    // Other structural fields preserved unchanged.
+    expect(updatedStep.agent_id).toBe('pedro-pesquisa')
+    expect(updatedStep.tool_keys).toEqual(['web_search'])
+    expect(updatedStep.params_keys).toEqual(['topic', 'time_range'])
+  })
+
+  it('blocks save when instruction has an undeclared placeholder, surfacing inline error', async () => {
+    const user = userEvent.setup()
+    renderAtRoute()
+    await screen.findByText(/step 1/i)
+
+    const instruction = screen.getByLabelText(/step 1 instruction/i)
+    await user.clear(instruction)
+    await user.type(instruction, 'Bad: {{params.unknown_one}}')
+
+    await user.click(screen.getByRole('button', { name: /^save step 1$/i }))
+
+    expect(updateTemplate).not.toHaveBeenCalled()
+    expect(await screen.findByText(/params\.unknown_one/i)).toBeInTheDocument()
+    expect(screen.getByText(/undeclared/i)).toBeInTheDocument()
+  })
+
+  it('blocks save when instruction references an unknown reference key', async () => {
+    const user = userEvent.setup()
+    renderAtRoute()
+    await screen.findByText(/step 1/i)
+
+    const instruction = screen.getByLabelText(/step 1 instruction/i)
+    await user.clear(instruction)
+    await user.type(instruction, 'Voice: {{ref:nonexistent}}')
+
+    await user.click(screen.getByRole('button', { name: /^save step 1$/i }))
+
+    expect(updateTemplate).not.toHaveBeenCalled()
+    expect(await screen.findByText(/ref:nonexistent/i)).toBeInTheDocument()
   })
 })

--- a/src/components/TemplateDetailPage.test.jsx
+++ b/src/components/TemplateDetailPage.test.jsx
@@ -353,8 +353,9 @@ describe('TemplateDetailPage — steps editor', () => {
     await user.click(screen.getByRole('button', { name: /^save step 1$/i }))
 
     expect(updateTemplate).not.toHaveBeenCalled()
-    expect(await screen.findByText(/params\.unknown_one/i)).toBeInTheDocument()
-    expect(screen.getByText(/undeclared/i)).toBeInTheDocument()
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/params\.unknown_one/i)
+    expect(alert).toHaveTextContent(/undeclared/i)
   })
 
   it('blocks save when instruction references an unknown reference key', async () => {
@@ -368,6 +369,7 @@ describe('TemplateDetailPage — steps editor', () => {
     await user.click(screen.getByRole('button', { name: /^save step 1$/i }))
 
     expect(updateTemplate).not.toHaveBeenCalled()
-    expect(await screen.findByText(/ref:nonexistent/i)).toBeInTheDocument()
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/ref:nonexistent/i)
   })
 })

--- a/src/components/TemplateDetailPage.test.jsx
+++ b/src/components/TemplateDetailPage.test.jsx
@@ -287,9 +287,10 @@ describe('TemplateDetailPage — references CRUD', () => {
 describe('TemplateDetailPage — steps editor', () => {
   it('renders one step block per step, labeled with order and agent', async () => {
     renderAtRoute()
-    expect(await screen.findByText(/step 1/i)).toBeInTheDocument()
+    await screen.findByLabelText(/step 1 instruction/i)
+    expect(screen.getByLabelText(/step 1 instruction/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/step 2 instruction/i)).toBeInTheDocument()
     expect(screen.getByText(/pedro pesquisa/i)).toBeInTheDocument()
-    expect(screen.getByText(/step 2/i)).toBeInTheDocument()
     expect(screen.getByText(/iago instagram/i)).toBeInTheDocument()
   })
 

--- a/src/components/TemplateDetailPage.test.jsx
+++ b/src/components/TemplateDetailPage.test.jsx
@@ -295,7 +295,7 @@ describe('TemplateDetailPage — steps editor', () => {
 
   it('renders structural fields read-only and instruction as a textarea', async () => {
     renderAtRoute()
-    await screen.findByText(/step 1/i)
+    await screen.findByLabelText(/step 1 instruction/i)
 
     // Read-only display: agent_id should appear as text, not in an editable input.
     const agentIdReadonly = screen.getAllByText(/pedro-pesquisa/i)
@@ -317,7 +317,7 @@ describe('TemplateDetailPage — steps editor', () => {
     )
     const user = userEvent.setup()
     renderAtRoute()
-    await screen.findByText(/step 1/i)
+    await screen.findByLabelText(/step 1 instruction/i)
 
     const instruction = screen.getByLabelText(/step 1 instruction/i)
     await user.clear(instruction)
@@ -343,7 +343,7 @@ describe('TemplateDetailPage — steps editor', () => {
   it('blocks save when instruction has an undeclared placeholder, surfacing inline error', async () => {
     const user = userEvent.setup()
     renderAtRoute()
-    await screen.findByText(/step 1/i)
+    await screen.findByLabelText(/step 1 instruction/i)
 
     const instruction = screen.getByLabelText(/step 1 instruction/i)
     await user.clear(instruction)
@@ -359,7 +359,7 @@ describe('TemplateDetailPage — steps editor', () => {
   it('blocks save when instruction references an unknown reference key', async () => {
     const user = userEvent.setup()
     renderAtRoute()
-    await screen.findByText(/step 1/i)
+    await screen.findByLabelText(/step 1 instruction/i)
 
     const instruction = screen.getByLabelText(/step 1 instruction/i)
     await user.clear(instruction)

--- a/src/lib/templateReferencesApi.js
+++ b/src/lib/templateReferencesApi.js
@@ -1,0 +1,147 @@
+// Supabase wrapper for the `template_references` table and the
+// private `template-references` Storage bucket. Mirrors the shape of
+// `templatesApi.js` so the two CRUD surfaces feel identical.
+//
+// Reads return `[]` when supabase is null (e.g. dev without env vars).
+// Missing-table errors degrade to the empty list — same fail-safe used
+// by `templatesApi.fetchTemplates`.
+
+import { supabase } from './supabase'
+
+const BUCKET = 'template-references'
+const TABLE = 'template_references'
+
+const MISSING_TABLE_CODES = new Set(['42P01', 'PGRST205'])
+
+function isMissingTableError(error) {
+  return Boolean(error && MISSING_TABLE_CODES.has(error.code))
+}
+
+function randomId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function extractExtension(filename, fallback = '') {
+  if (typeof filename !== 'string') return fallback
+  const idx = filename.lastIndexOf('.')
+  if (idx === -1 || idx === filename.length - 1) return fallback
+  return filename.slice(idx)
+}
+
+export async function fetchReferences(templateId) {
+  if (!supabase) return []
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('template_id', templateId)
+    .order('created_at', { ascending: true })
+  if (error) {
+    if (isMissingTableError(error)) {
+      console.warn('[template_references] table not reachable, returning []', error)
+      return []
+    }
+    throw new Error(error.message || 'Failed to load references')
+  }
+  return data || []
+}
+
+export async function createTextReference(templateId, payload) {
+  if (!supabase) return null
+  const row = {
+    template_id: templateId,
+    key: payload.key,
+    kind: 'text',
+    content_text: payload.content_text ?? null,
+    mime_type: payload.mime_type ?? 'text/markdown',
+    original_filename: payload.original_filename ?? null,
+  }
+  const { data, error } = await supabase.from(TABLE).insert(row).select().single()
+  if (error) throw new Error(error.message || 'Failed to create text reference')
+  return data
+}
+
+export async function createImageReference(templateId, payload) {
+  if (!supabase) return null
+  const { file, key, mime_type, original_filename } = payload
+  const ext = extractExtension(original_filename) || extractExtension(file?.name) || ''
+  const path = `${templateId}/${randomId()}${ext}`
+
+  const { data: uploadData, error: uploadError } = await supabase.storage
+    .from(BUCKET)
+    .upload(path, file, {
+      contentType: mime_type,
+      upsert: false,
+    })
+  if (uploadError) {
+    throw new Error(uploadError.message || 'Failed to upload reference image')
+  }
+
+  const storagePath = uploadData?.path ?? path
+  const row = {
+    template_id: templateId,
+    key,
+    kind: 'image',
+    storage_path: storagePath,
+    mime_type,
+    original_filename: original_filename ?? null,
+  }
+  const { data, error } = await supabase.from(TABLE).insert(row).select().single()
+  if (error) throw new Error(error.message || 'Failed to create image reference')
+  return data
+}
+
+export async function updateReference(id, updates) {
+  if (!supabase) return null
+  const allowed = {}
+  if (typeof updates.key === 'string') allowed.key = updates.key
+  if (typeof updates.content_text === 'string') {
+    allowed.content_text = updates.content_text
+  }
+  if (typeof updates.original_filename === 'string') {
+    allowed.original_filename = updates.original_filename
+  }
+  allowed.updated_at = new Date().toISOString()
+
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(allowed)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw new Error(error.message || 'Failed to update reference')
+  return data
+}
+
+export async function deleteReference(id) {
+  if (!supabase) return
+  const { error } = await supabase.from(TABLE).delete().eq('id', id)
+  if (error) throw new Error(error.message || 'Failed to delete reference')
+}
+
+export async function getReferenceSignedUrl(storagePath, ttlSeconds = 3600) {
+  if (!supabase) return null
+  if (typeof storagePath !== 'string' || storagePath.length === 0) return null
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(storagePath, ttlSeconds)
+  if (error) throw new Error(error.message || 'Failed to mint signed URL')
+  return data?.signedUrl ?? null
+}
+
+export async function fetchTemplateById(id) {
+  if (!supabase) return null
+  const { data, error } = await supabase
+    .from('task_templates')
+    .select('*')
+    .eq('id', id)
+    .single()
+  if (error) {
+    if (error.code === 'PGRST116') return null // single row not found
+    if (isMissingTableError(error)) return null
+    throw new Error(error.message || 'Failed to load template')
+  }
+  return data
+}

--- a/src/lib/templateReferencesApi.test.js
+++ b/src/lib/templateReferencesApi.test.js
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// We mock supabase before importing the module so the module resolves the
+// stub from `./supabase`. Each test customises the chain via the helper
+// functions below.
+
+let mockClient
+
+vi.mock('./supabase', () => ({
+  get supabase() {
+    return mockClient
+  },
+}))
+
+import {
+  fetchReferences,
+  createTextReference,
+  createImageReference,
+  updateReference,
+  deleteReference,
+  getReferenceSignedUrl,
+} from './templateReferencesApi'
+
+beforeEach(() => {
+  mockClient = null
+  vi.clearAllMocks()
+})
+
+function buildSelectChain(result) {
+  const order = vi.fn().mockResolvedValue(result)
+  const eq = vi.fn().mockReturnValue({ order })
+  const select = vi.fn().mockReturnValue({ eq })
+  return { from: vi.fn().mockReturnValue({ select }), select, eq, order }
+}
+
+describe('fetchReferences', () => {
+  it('returns rows for the given template_id ordered by created_at', async () => {
+    const rows = [
+      { id: 'r1', template_id: 't1', key: 'tone', kind: 'text' },
+      { id: 'r2', template_id: 't1', key: 'mood', kind: 'image' },
+    ]
+    const chain = buildSelectChain({ data: rows, error: null })
+    mockClient = { from: chain.from }
+
+    const result = await fetchReferences('t1')
+
+    expect(chain.from).toHaveBeenCalledWith('template_references')
+    expect(chain.select).toHaveBeenCalledWith('*')
+    expect(chain.eq).toHaveBeenCalledWith('template_id', 't1')
+    expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: true })
+    expect(result).toEqual(rows)
+  })
+
+  it('returns empty array when supabase is null', async () => {
+    mockClient = null
+    const result = await fetchReferences('t1')
+    expect(result).toEqual([])
+  })
+
+  it('throws when supabase returns an unknown error', async () => {
+    const chain = buildSelectChain({
+      data: null,
+      error: { code: '500', message: 'boom' },
+    })
+    mockClient = { from: chain.from }
+    await expect(fetchReferences('t1')).rejects.toThrow(/boom/)
+  })
+
+  it('returns empty array when the table is missing (42P01)', async () => {
+    const chain = buildSelectChain({
+      data: null,
+      error: { code: '42P01', message: 'relation does not exist' },
+    })
+    mockClient = { from: chain.from }
+    const result = await fetchReferences('t1')
+    expect(result).toEqual([])
+  })
+})
+
+describe('createTextReference', () => {
+  it('inserts a row with kind=text and content_text payload', async () => {
+    const row = {
+      id: 'r1',
+      template_id: 't1',
+      key: 'tone',
+      kind: 'text',
+      content_text: 'Speak warmly',
+      original_filename: 'tone.md',
+    }
+    const single = vi.fn().mockResolvedValue({ data: row, error: null })
+    const select = vi.fn().mockReturnValue({ single })
+    const insert = vi.fn().mockReturnValue({ select })
+    mockClient = { from: vi.fn().mockReturnValue({ insert }) }
+
+    const result = await createTextReference('t1', {
+      key: 'tone',
+      content_text: 'Speak warmly',
+      original_filename: 'tone.md',
+    })
+
+    expect(mockClient.from).toHaveBeenCalledWith('template_references')
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template_id: 't1',
+        key: 'tone',
+        kind: 'text',
+        content_text: 'Speak warmly',
+        original_filename: 'tone.md',
+      }),
+    )
+    expect(result).toEqual(row)
+  })
+
+  it('throws when supabase returns an error', async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: '500', message: 'insert failed' },
+    })
+    const select = vi.fn().mockReturnValue({ single })
+    const insert = vi.fn().mockReturnValue({ select })
+    mockClient = { from: vi.fn().mockReturnValue({ insert }) }
+
+    await expect(
+      createTextReference('t1', { key: 'tone', content_text: 'x' }),
+    ).rejects.toThrow(/insert failed/)
+  })
+})
+
+describe('createImageReference', () => {
+  it('uploads to template-references Storage then inserts a kind=image row', async () => {
+    const file = new Blob(['fake png bytes'], { type: 'image/png' })
+    file.name = 'mood.png'
+
+    const upload = vi.fn().mockResolvedValue({
+      data: { path: 't1/r-uuid.png' },
+      error: null,
+    })
+    const insertedRow = {
+      id: 'r-uuid',
+      template_id: 't1',
+      key: 'mood',
+      kind: 'image',
+      storage_path: 't1/r-uuid.png',
+      mime_type: 'image/png',
+      original_filename: 'mood.png',
+    }
+    const single = vi.fn().mockResolvedValue({ data: insertedRow, error: null })
+    const select = vi.fn().mockReturnValue({ single })
+    const insert = vi.fn().mockReturnValue({ select })
+
+    mockClient = {
+      from: vi.fn().mockReturnValue({ insert }),
+      storage: { from: vi.fn().mockReturnValue({ upload }) },
+    }
+
+    const result = await createImageReference('t1', {
+      key: 'mood',
+      file,
+      mime_type: 'image/png',
+      original_filename: 'mood.png',
+    })
+
+    expect(mockClient.storage.from).toHaveBeenCalledWith('template-references')
+    expect(upload).toHaveBeenCalledTimes(1)
+    const [path, body, opts] = upload.mock.calls[0]
+    expect(path.startsWith('t1/')).toBe(true)
+    expect(body).toBe(file)
+    expect(opts).toMatchObject({ contentType: 'image/png' })
+
+    expect(mockClient.from).toHaveBeenCalledWith('template_references')
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template_id: 't1',
+        key: 'mood',
+        kind: 'image',
+        mime_type: 'image/png',
+        storage_path: 't1/r-uuid.png',
+        original_filename: 'mood.png',
+      }),
+    )
+    expect(result).toEqual(insertedRow)
+  })
+
+  it('throws when the upload itself fails', async () => {
+    const file = new Blob(['x'], { type: 'image/png' })
+    file.name = 'fail.png'
+    const upload = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'storage down' },
+    })
+    mockClient = {
+      from: vi.fn(),
+      storage: { from: vi.fn().mockReturnValue({ upload }) },
+    }
+    await expect(
+      createImageReference('t1', {
+        key: 'k',
+        file,
+        mime_type: 'image/png',
+        original_filename: 'fail.png',
+      }),
+    ).rejects.toThrow(/storage down/)
+  })
+})
+
+describe('updateReference', () => {
+  it('updates only allowed fields', async () => {
+    const row = { id: 'r1', key: 'tone-renamed', content_text: 'new content' }
+    const single = vi.fn().mockResolvedValue({ data: row, error: null })
+    const select = vi.fn().mockReturnValue({ single })
+    const eq = vi.fn().mockReturnValue({ select })
+    const update = vi.fn().mockReturnValue({ eq })
+    mockClient = { from: vi.fn().mockReturnValue({ update }) }
+
+    const result = await updateReference('r1', {
+      key: 'tone-renamed',
+      content_text: 'new content',
+    })
+
+    expect(mockClient.from).toHaveBeenCalledWith('template_references')
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'tone-renamed',
+        content_text: 'new content',
+      }),
+    )
+    expect(eq).toHaveBeenCalledWith('id', 'r1')
+    expect(result).toEqual(row)
+  })
+})
+
+describe('deleteReference', () => {
+  it('deletes the row by id', async () => {
+    const eq = vi.fn().mockResolvedValue({ data: null, error: null })
+    const del = vi.fn().mockReturnValue({ eq })
+    mockClient = { from: vi.fn().mockReturnValue({ delete: del }) }
+
+    await deleteReference('r1')
+
+    expect(mockClient.from).toHaveBeenCalledWith('template_references')
+    expect(del).toHaveBeenCalled()
+    expect(eq).toHaveBeenCalledWith('id', 'r1')
+  })
+
+  it('throws on supabase error', async () => {
+    const eq = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'gone' },
+    })
+    const del = vi.fn().mockReturnValue({ eq })
+    mockClient = { from: vi.fn().mockReturnValue({ delete: del }) }
+    await expect(deleteReference('r1')).rejects.toThrow(/gone/)
+  })
+})
+
+describe('getReferenceSignedUrl', () => {
+  it('mints a signed URL for a storage_path', async () => {
+    const createSignedUrl = vi.fn().mockResolvedValue({
+      data: { signedUrl: 'https://signed.example/x' },
+      error: null,
+    })
+    mockClient = {
+      storage: { from: vi.fn().mockReturnValue({ createSignedUrl }) },
+    }
+
+    const url = await getReferenceSignedUrl('t1/r-uuid.png', 60)
+
+    expect(mockClient.storage.from).toHaveBeenCalledWith('template-references')
+    expect(createSignedUrl).toHaveBeenCalledWith('t1/r-uuid.png', 60)
+    expect(url).toBe('https://signed.example/x')
+  })
+
+  it('returns null when the path is missing', async () => {
+    mockClient = { storage: { from: vi.fn() } }
+    expect(await getReferenceSignedUrl('', 60)).toBeNull()
+    expect(await getReferenceSignedUrl(null, 60)).toBeNull()
+  })
+
+  it('throws on supabase error', async () => {
+    const createSignedUrl = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'no such object' },
+    })
+    mockClient = {
+      storage: { from: vi.fn().mockReturnValue({ createSignedUrl }) },
+    }
+    await expect(getReferenceSignedUrl('p', 60)).rejects.toThrow(/no such object/)
+  })
+})

--- a/src/lib/templateValidate.js
+++ b/src/lib/templateValidate.js
@@ -1,0 +1,83 @@
+// Frontend port of templateRenderer.validate (supabase/functions/_shared/templateRenderer.ts).
+//
+// Pure: no I/O, no Supabase. Used by `/templates/[id]` to gate saves on the
+// same Mustache placeholder rules the Edge Function enforces at runtime.
+// Keep the placeholder grammar in sync with the Deno module — both are
+// driven by the same regex below.
+
+const PLACEHOLDER_RE = /\{\{\s*([^{}]+?)\s*\}\}/g
+
+export function parsePlaceholderInner(inner) {
+  const paramMatch = /^params\.([A-Za-z_][A-Za-z0-9_]*)$/.exec(inner)
+  if (paramMatch) return { kind: 'param', name: paramMatch[1] }
+
+  const stepOutputMatch = /^step-(\d+)\.output$/.exec(inner)
+  if (stepOutputMatch) {
+    return { kind: 'step_output', index: Number(stepOutputMatch[1]) }
+  }
+
+  const stepFilesMatch = /^step-(\d+)\.output_files$/.exec(inner)
+  if (stepFilesMatch) {
+    return { kind: 'step_output_files', index: Number(stepFilesMatch[1]) }
+  }
+
+  const refMatch = /^ref:([A-Za-z0-9_\-.]+)$/.exec(inner)
+  if (refMatch) return { kind: 'ref', key: refMatch[1] }
+
+  return { kind: 'unknown' }
+}
+
+function parsePlaceholders(instruction) {
+  const out = []
+  PLACEHOLDER_RE.lastIndex = 0
+  let m
+  while ((m = PLACEHOLDER_RE.exec(instruction)) !== null) {
+    out.push({ raw: m[0], inner: m[1].trim() })
+  }
+  return out
+}
+
+export function validateTemplateStep(
+  step,
+  declaredParamsKeys,
+  declaredNeedsOutputsFrom,
+  declaredReferenceIds,
+) {
+  const instruction = step?.instruction ?? ''
+  const placeholders = parsePlaceholders(instruction)
+  const errors = []
+  const seen = new Set()
+
+  const paramSet = new Set(declaredParamsKeys || [])
+  const stepSet = new Set(declaredNeedsOutputsFrom || [])
+  const refSet = new Set(declaredReferenceIds || [])
+
+  for (const ph of placeholders) {
+    if (seen.has(ph.inner)) continue
+    seen.add(ph.inner)
+
+    const c = parsePlaceholderInner(ph.inner)
+
+    if (c.kind === 'param') {
+      if (!paramSet.has(c.name)) {
+        errors.push({ kind: 'undeclared_param', placeholder: ph.inner })
+      }
+      continue
+    }
+    if (c.kind === 'step_output' || c.kind === 'step_output_files') {
+      if (!stepSet.has(c.index)) {
+        errors.push({ kind: 'undeclared_step', placeholder: ph.inner })
+      }
+      continue
+    }
+    if (c.kind === 'ref') {
+      if (!refSet.has(c.key)) {
+        errors.push({ kind: 'undeclared_ref', placeholder: ph.inner })
+      }
+      continue
+    }
+    errors.push({ kind: 'unknown_placeholder', placeholder: ph.inner })
+  }
+
+  return errors
+}

--- a/src/lib/templateValidate.test.js
+++ b/src/lib/templateValidate.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { validateTemplateStep, parsePlaceholderInner } from './templateValidate'
+
+describe('parsePlaceholderInner', () => {
+  it('classifies params placeholders', () => {
+    expect(parsePlaceholderInner('params.topic')).toEqual({
+      kind: 'param',
+      name: 'topic',
+    })
+  })
+
+  it('classifies step output placeholders', () => {
+    expect(parsePlaceholderInner('step-2.output')).toEqual({
+      kind: 'step_output',
+      index: 2,
+    })
+  })
+
+  it('classifies step output_files placeholders', () => {
+    expect(parsePlaceholderInner('step-3.output_files')).toEqual({
+      kind: 'step_output_files',
+      index: 3,
+    })
+  })
+
+  it('classifies ref placeholders', () => {
+    expect(parsePlaceholderInner('ref:tone_of_voice')).toEqual({
+      kind: 'ref',
+      key: 'tone_of_voice',
+    })
+  })
+
+  it('returns unknown for garbage', () => {
+    expect(parsePlaceholderInner('garbage')).toEqual({ kind: 'unknown' })
+  })
+})
+
+describe('validateTemplateStep', () => {
+  it('returns no errors when every placeholder is declared', () => {
+    const errors = validateTemplateStep(
+      {
+        instruction:
+          'Topic: {{params.topic}} | Prior: {{step-1.output}} | Voice: {{ref:tone}}',
+      },
+      ['topic'],
+      [1],
+      ['tone'],
+    )
+    expect(errors).toEqual([])
+  })
+
+  it('flags undeclared param', () => {
+    const errors = validateTemplateStep(
+      { instruction: '{{params.topic}} {{params.audience}}' },
+      ['topic'],
+      [],
+      [],
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0].kind).toBe('undeclared_param')
+    expect(errors[0].placeholder).toBe('params.audience')
+  })
+
+  it('flags undeclared step output dependency', () => {
+    const errors = validateTemplateStep(
+      { instruction: '{{step-1.output}} {{step-2.output}}' },
+      [],
+      [1],
+      [],
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0].kind).toBe('undeclared_step')
+    expect(errors[0].placeholder).toBe('step-2.output')
+  })
+
+  it('flags undeclared step output_files dependency', () => {
+    const errors = validateTemplateStep(
+      { instruction: '{{step-3.output_files}}' },
+      [],
+      [1, 2],
+      [],
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0].kind).toBe('undeclared_step')
+    expect(errors[0].placeholder).toBe('step-3.output_files')
+  })
+
+  it('flags undeclared reference key', () => {
+    const errors = validateTemplateStep(
+      { instruction: '{{ref:moodboard}}' },
+      [],
+      [],
+      ['tone_of_voice'],
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0].kind).toBe('undeclared_ref')
+    expect(errors[0].placeholder).toBe('ref:moodboard')
+  })
+
+  it('flags unknown placeholder format', () => {
+    const errors = validateTemplateStep(
+      { instruction: 'Weird: {{garbage}}' },
+      [],
+      [],
+      [],
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0].kind).toBe('unknown_placeholder')
+  })
+
+  it('collects multiple errors in left-to-right order', () => {
+    const errors = validateTemplateStep(
+      {
+        instruction:
+          '{{params.unknown_param}} {{step-9.output}} {{ref:nope}} {{whatever}}',
+      },
+      [],
+      [],
+      [],
+    )
+    expect(errors).toHaveLength(4)
+    expect(errors[0].kind).toBe('undeclared_param')
+    expect(errors[1].kind).toBe('undeclared_step')
+    expect(errors[2].kind).toBe('undeclared_ref')
+    expect(errors[3].kind).toBe('unknown_placeholder')
+  })
+
+  it('does not report the same placeholder more than once', () => {
+    const errors = validateTemplateStep(
+      { instruction: '{{params.x}} and {{params.x}} again' },
+      [],
+      [],
+      [],
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0].placeholder).toBe('params.x')
+  })
+
+  it('instruction without placeholders has no errors', () => {
+    expect(validateTemplateStep({ instruction: 'plain text' }, [], [], [])).toEqual([])
+  })
+
+  it('tolerates whitespace inside braces', () => {
+    expect(
+      validateTemplateStep(
+        { instruction: 'Topic: {{ params.topic }}' },
+        ['topic'],
+        [],
+        [],
+      ),
+    ).toEqual([])
+  })
+
+  it('treats null/missing instruction as empty', () => {
+    expect(validateTemplateStep({}, [], [], [])).toEqual([])
+    expect(validateTemplateStep(null, [], [], [])).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #353

Replaces the placeholder `/templates/[id]` page with a detail and
partial-editor view (PRD #344). Three editable sections plus
read-only structural fields per step.

## Sections

- **Brand context** — Markdown textarea, save inline via `updateTemplate`.
- **References CRUD** — list with key + kind + filename; upload `.md`/text
  files as `kind=text` (content stored in `content_text`); upload
  `.png`/`.jpg`/`image/*` files as `kind=image` (uploaded to the private
  `template-references` Storage bucket; signed URLs power preview thumbs);
  delete with confirmation gate.
- **Plan steps** — one block per step, structural fields (`agent_id`,
  `tool_keys`, `needs_outputs_from`, `params_keys`) rendered read-only;
  editable instruction textarea + requires-approval toggle.

Saves call Supabase directly under the user's session — RLS handles
authorization. Each step save runs `validateTemplateStep` (a frontend
port of `templateRenderer.validate`); validation errors render inline
in a `role="alert"` region and block the API call.

## Modules added

- `src/lib/templateValidate.js` — pure JS port of the Mustache placeholder
  validator from `supabase/functions/_shared/templateRenderer.ts`.
  Same grammar, same error kinds (`undeclared_param`, `undeclared_step`,
  `undeclared_ref`, `unknown_placeholder`).
- `src/lib/templateReferencesApi.js` — Supabase wrapper for the
  `template_references` table and the `template-references` Storage
  bucket. Exposes `fetchReferences`, `createTextReference`,
  `createImageReference`, `updateReference`, `deleteReference`,
  `getReferenceSignedUrl`, and `fetchTemplateById`. Missing-table errors
  degrade to empty-list, mirroring `templatesApi.fetchTemplates`.

## TDD

- Tests added: `src/lib/templateValidate.test.js` (16 cases),
  `src/lib/templateReferencesApi.test.js` (14 cases),
  `src/components/TemplateDetailPage.test.jsx` (15 cases — replaces the
  prior 2-case smoke).
- Before implementation (red): `templateValidate.test.js` failed with
  module-not-found; `templateReferencesApi.test.js` failed likewise;
  `TemplateDetailPage.test.jsx` had 14 failing cases against the
  placeholder implementation.
- After implementation (green): \`npm test\` → 504 passed (45 new).
  \`npm run test:functions\` → 170 ok. \`npm run lint\` → 0 errors.

## Notes
- The 13 messy \`auto: update …\` commits on this branch come from the
  user's local auto-commit hook on every Edit. Squash-merge collapses
  them; the squash subject is this PR title (Conventional Commits OK).