### PR TITLE
test(chat): cover web_search.fallback.tavily telemetry contract (#348)

### DIFF
--- a/supabase/functions/chat/executor.test.ts
+++ b/supabase/functions/chat/executor.test.ts
@@ -564,6 +564,76 @@ Deno.test('runStep — does NOT add native web tools when agent does not declare
   }
 })
 
+Deno.test('runStep — emits web_search.fallback.tavily telemetry log with original query', async () => {
+  const restoreAnthropic = withEnv('ANTHROPIC_API_KEY', 'sk-test')
+  const restoreTavily = withEnv('TAVILY_API_KEY', 'tv-test')
+  const originalQuery = 'react server components benchmarks'
+  let anthropicCallCount = 0
+  const { restore } = installFetchMock((call) => {
+    if (call.url === 'https://api.anthropic.com/v1/messages') {
+      anthropicCallCount++
+      if (anthropicCallCount === 1) {
+        return jsonResponse(200, {
+          content: [
+            {
+              type: 'server_tool_use',
+              id: 'srvtoolu_telemetry',
+              name: 'web_search',
+              input: { query: originalQuery },
+            },
+            {
+              type: 'web_search_tool_result',
+              tool_use_id: 'srvtoolu_telemetry',
+              content: [],
+            },
+            { type: 'text', text: 'No results.' },
+          ],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        })
+      }
+      return jsonResponse(200, {
+        content: [{ type: 'text', text: 'done' }],
+        usage: { input_tokens: 5, output_tokens: 5 },
+      })
+    }
+    if (call.url === 'https://api.tavily.com/search') {
+      return jsonResponse(200, { results: [] })
+    }
+    return jsonResponse(404, {})
+  })
+  const logged: string[] = []
+  const originalLog = console.log
+  console.log = (...args: unknown[]) => {
+    logged.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '))
+  }
+  try {
+    await runStep(
+      makeStep(['web_search']),
+      [RESEARCHER_AGENT],
+      [WEB_SEARCH_TOOL_META],
+      'context',
+      {},
+      () => {},
+      'sk-test',
+      new AbortController().signal,
+    )
+    const telemetryLine = logged.find((l) => l.includes('web_search.fallback.tavily'))
+    assertExists(
+      telemetryLine,
+      `expected a "web_search.fallback.tavily" telemetry log line. Got: ${logged.join(' | ')}`,
+    )
+    const parsed = JSON.parse(telemetryLine!)
+    assertEquals(parsed.event, 'web_search.fallback.tavily')
+    assertEquals(parsed.query, originalQuery)
+    assertEquals(parsed.reason, 'no_results')
+  } finally {
+    console.log = originalLog
+    restore()
+    restoreAnthropic()
+    restoreTavily()
+  }
+})
+
 Deno.test('runStep — successful native web_search does NOT trigger Tavily fallback', async () => {
   const restoreAnthropic = withEnv('ANTHROPIC_API_KEY', 'sk-test')
   const restoreTavily = withEnv('TAVILY_API_KEY', 'tv-test')

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -1084,15 +1084,14 @@ export async function runStep(
           nativeFallbackUsed = true
           const fallbackPayload: any[] = []
           for (const f of failed) {
-            // TEMPORARILY DISABLED FOR RED STEP
-            // console.log(
-            //   JSON.stringify({
-            //     event: 'web_search.fallback.tavily',
-            //     step_id: step.id,
-            //     query: f.query,
-            //     reason: f.reason,
-            //   }),
-            // )
+            console.log(
+              JSON.stringify({
+                event: 'web_search.fallback.tavily',
+                step_id: step.id,
+                query: f.query,
+                reason: f.reason,
+              }),
+            )
             const tavilyResult = await webSearch(
               { query: f.query },
               {

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -1084,14 +1084,15 @@ export async function runStep(
           nativeFallbackUsed = true
           const fallbackPayload: any[] = []
           for (const f of failed) {
-            console.log(
-              JSON.stringify({
-                event: 'web_search.fallback.tavily',
-                step_id: step.id,
-                query: f.query,
-                reason: f.reason,
-              }),
-            )
+            // TEMPORARILY DISABLED FOR RED STEP
+            // console.log(
+            //   JSON.stringify({
+            //     event: 'web_search.fallback.tavily',
+            //     step_id: step.id,
+            //     query: f.query,
+            //     reason: f.reason,
+            //   }),
+            // )
             const tavilyResult = await webSearch(
               { query: f.query },
               {


### PR DESCRIPTION
Closes #348

## TDD
- Tests added/modified: `supabase/functions/chat/executor.test.ts` (new test: `runStep — emits web_search.fallback.tavily telemetry log with original query`)
- Before implementation (red): the new test failed with `expected a "web_search.fallback.tavily" telemetry log line. Got: ` after temporarily commenting out the `console.log(...)` block in `executor.ts` (verified locally).
- After implementation (green): all 171 Edge Function tests pass; all 504 frontend tests pass.

## Notes

The native Anthropic `web_search_20250305` / `web_fetch_20250910` wiring and the Tavily fallback path called for in this issue were already shipped in PR #368 (commit 9ed51fb). All five acceptance criteria already had matching tests:

1. Native `web_search_20250305` injected on agent declaration → `runStep — injects native web_search_20250305 tool def when agent declares web_search`
2. Tavily fallback on zero results → `runStep — falls back to Tavily when native web_search returns zero results`
3. Tavily fallback on errors → `runStep — falls back to Tavily when native web_search errors`
4. Existing tests untouched → all pre-existing tests still pass without modification
5. No regression for agents not declaring web_search → `runStep — does NOT add native web tools when agent does not declare them`

The only piece in the issue body not covered by an existing test was the structured telemetry log line (`web_search.fallback.tavily`). This PR adds that test so the contract is locked in: the log line includes the `event` name, the original `query`, and the `reason`. The implementation itself was already in place.

The branch carries three intermediate auto-commits from the editor hook (red/green/restore). Squash-merging the PR collapses them into a single commit on `dev`.