### PR TITLE
feat(chat): template-mode executor with step-approval gate (#354)

### DIFF
--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -807,6 +807,10 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   list_github_repos: listGithubRepos,
   create_github_issue: createGithubIssue,
   render_html_to_image: renderHtmlToImage,
+  // Stubs for the Luiza template pipeline (issue #354). Slices #351 and #352
+  // replace these with real Browserless + Zernio implementations.
+  mock_image_render: mockImageRender,
+  mock_zernio_publish: mockZernioPublish,
 }
 
 // Which tools are functional in the current environment. Some tools depend on

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -31,6 +31,7 @@ import {
   type ScreenshotPath,
   type ScreenshotRequest,
 } from '../_shared/htmlScreenshotter.ts'
+import { mockImageRender, mockZernioPublish } from './mockTools.ts'
 
 // Tools whose client-side declaration is replaced with the Anthropic native
 // server-side tool (web_search_20250305 / web_fetch_20250910). The model uses

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -750,6 +750,11 @@ Deno.serve(async (req: Request) => {
       ? body.session_id
       : crypto.randomUUID()
 
+  const isTemplateMode =
+    mode === 'template_execute' ||
+    mode === 'template_approve' ||
+    mode === 'template_retry'
+
   const messages = Array.isArray(body.messages) ? body.messages : []
   const cleanMessages = messages
     .filter(
@@ -760,7 +765,10 @@ Deno.serve(async (req: Request) => {
     )
     .map((m) => ({ role: m.role, content: m.content }))
 
-  if (cleanMessages.length === 0) {
+  // Template-mode requests carry a `task` payload directly, not a chat
+  // history. Skip the messages requirement when running through the
+  // template executor branch.
+  if (cleanMessages.length === 0 && !isTemplateMode) {
     return new Response(
       JSON.stringify({ error: 'At least one user message is required' }),
       { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -15,6 +15,12 @@
 
 import { analyzeRequirements, runExecutorBranch } from './executor.ts'
 import { runSelectedAgentBranch } from './selectedAgentBranch.ts'
+import {
+  resumeTemplateApprove,
+  resumeTemplateRetry,
+  runTemplateExecutor,
+  type TemplateExecutorDeps,
+} from './templateExecutorBranch.ts'
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const CHAT_MODEL = Deno.env.get('CHAT_MODEL') || 'claude-sonnet-4-6'

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -802,6 +802,79 @@ Deno.serve(async (req: Request) => {
       const emit = makeEmitter(controller, sessionId)
 
       try {
+        // Template mode (issue #354): run / resume / retry a template-mode
+        // task. The body carries the full task snapshot; persistence is the
+        // client's job — we relay every state transition via task.updated.
+        if (isTemplateMode) {
+          const task = body.task
+          if (!task || typeof task !== 'object' || !task.plan) {
+            emit('run.error', {
+              error: 'template-mode requires a `task` with a plan',
+            })
+            return
+          }
+          const stepId =
+            typeof body.step_id === 'number' ? body.step_id : null
+          if (
+            (mode === 'template_approve' || mode === 'template_retry') &&
+            stepId === null
+          ) {
+            emit('run.error', {
+              error: `${mode} requires a numeric step_id`,
+            })
+            return
+          }
+          emit('router.classified', { mode })
+          const timeoutController = new AbortController()
+          const timeoutId = setTimeout(
+            () => timeoutController.abort(),
+            RUN_TIMEOUT_MS,
+          )
+          const persistTask = async (t: any) => {
+            emit('task.updated', { task: t })
+          }
+          const deps: TemplateExecutorDeps = {
+            apiKey,
+            signal: timeoutController.signal,
+            emit,
+            agentsContext: agentsContextRaw,
+            toolsContext: toolsContextRaw,
+            references:
+              (body.references as Record<string, any>) || {},
+            params: body.params || {},
+            persistTask,
+            userId,
+          }
+          try {
+            let result
+            if (mode === 'template_approve') {
+              result = await resumeTemplateApprove(task, stepId!, deps)
+            } else if (mode === 'template_retry') {
+              const feedback =
+                typeof body.feedback === 'string' ? body.feedback : ''
+              result = await resumeTemplateRetry(task, stepId!, feedback, deps)
+            } else {
+              result = await runTemplateExecutor(task, deps)
+            }
+            // Final task snapshot — clients use this as the source of truth
+            // when persisting after the stream closes.
+            emit('task.updated', { task: result.task })
+            if (result.outcome.kind === 'all_done') {
+              emit('run.done', { task_id: task.id })
+            } else if (result.outcome.kind === 'error') {
+              emit('run.error', {
+                error:
+                  'error' in result.outcome
+                    ? result.outcome.error
+                    : 'unknown error',
+              })
+            }
+          } finally {
+            clearTimeout(timeoutId)
+          }
+          return
+        }
+
         // Execute mode: skip router+planner, run an already-approved plan.
         if (isExecute) {
           const plan = body.plan as any

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -711,6 +711,13 @@ Deno.serve(async (req: Request) => {
     original_task?: string
     step_answers?: Record<string, Record<string, string>>
     selected_agent_id?: string
+    // Template-mode fields (issue #354). Used when mode is one of
+    // template_execute / template_approve / template_retry.
+    task?: any
+    references?: Record<string, unknown>
+    params?: Record<string, string>
+    step_id?: number
+    feedback?: string
   }
   try {
     body = await req.json()

--- a/supabase/functions/chat/mockTools.test.ts
+++ b/supabase/functions/chat/mockTools.test.ts
@@ -1,0 +1,99 @@
+// Tests for the mocked image-render and Zernio-publish tools used in the
+// template-executor template-mode (issue #354). Slices #351 and #352 will
+// replace these with real implementations; until then they return
+// deterministic placeholders so the wider executor flow is independently
+// testable.
+
+import { assert, assertEquals, assertExists, assertStringIncludes } from 'jsr:@std/assert@1'
+
+import {
+  mockImageRender,
+  mockZernioPublish,
+} from './mockTools.ts'
+
+function ctx(extra: Record<string, unknown> = {}) {
+  return {
+    signal: new AbortController().signal,
+    agentsContext: [],
+    stepId: 1,
+    toolCallId: 'tc-1',
+    ...extra,
+  }
+}
+
+// ─── mockImageRender ────────────────────────────────────────────────────────
+
+Deno.test('mockImageRender — returns a deterministic placeholder URL', async () => {
+  const a = await mockImageRender({ prompt: 'a kitten on a skateboard' }, ctx())
+  const b = await mockImageRender({ prompt: 'a kitten on a skateboard' }, ctx())
+  assertEquals(a.ok, true)
+  assertEquals(b.ok, true)
+  if (!a.ok || !b.ok) return
+  assertExists(a.result)
+  assertEquals((a.result as any).url, (b.result as any).url)
+  assertStringIncludes((a.result as any).url, 'mock-image')
+})
+
+Deno.test('mockImageRender — emits a file artifact with image/jpeg mime', async () => {
+  const result = await mockImageRender(
+    { prompt: 'test prompt' },
+    ctx({ taskId: 'task-7', stepOrder: 2 }),
+  )
+  assertEquals(result.ok, true)
+  if (!result.ok) return
+  assertExists(result.artifact)
+  assertEquals(result.artifact?.type, 'file')
+  assertEquals(result.artifact?.format, 'jpg')
+  assertEquals((result.result as any).mime_type, 'image/jpeg')
+})
+
+Deno.test('mockImageRender — rejects empty prompt', async () => {
+  const result = await mockImageRender({ prompt: '   ' }, ctx())
+  assertEquals(result.ok, false)
+  assertExists(result.error)
+})
+
+Deno.test('mockImageRender — surfaces taskId/stepOrder in the placeholder URL', async () => {
+  const result = await mockImageRender(
+    { prompt: 'foo' },
+    ctx({ taskId: 'task-99', stepOrder: 4 }),
+  )
+  assertEquals(result.ok, true)
+  if (!result.ok) return
+  const url = (result.result as any).url as string
+  assertStringIncludes(url, 'task-99')
+  assertStringIncludes(url, '4')
+})
+
+// ─── mockZernioPublish ──────────────────────────────────────────────────────
+
+Deno.test('mockZernioPublish — logs the would-be payload and returns ok', async () => {
+  const captured: unknown[] = []
+  const originalLog = console.log
+  console.log = (...args: unknown[]) => {
+    captured.push(args)
+  }
+  try {
+    const result = await mockZernioPublish(
+      { caption: 'hello', media_url: 'https://x/y.jpg' },
+      ctx({ taskId: 'task-z', stepOrder: 0 }),
+    )
+    assertEquals(result.ok, true)
+    if (!result.ok) return
+    assertExists(result.summary)
+    assert(captured.length > 0, 'expected console.log to be called')
+    // Find the structured log line that includes the marker.
+    const flat = captured.map((c) => JSON.stringify(c)).join('\n')
+    assertStringIncludes(flat, 'mock_zernio_publish.would_publish')
+    assertStringIncludes(flat, 'task-z')
+    assertStringIncludes(flat, 'https://x/y.jpg')
+  } finally {
+    console.log = originalLog
+  }
+})
+
+Deno.test('mockZernioPublish — rejects when caption AND media_url are both missing', async () => {
+  const result = await mockZernioPublish({}, ctx())
+  assertEquals(result.ok, false)
+  assertExists(result.error)
+})

--- a/supabase/functions/chat/mockTools.ts
+++ b/supabase/functions/chat/mockTools.ts
@@ -1,0 +1,113 @@
+// Mock tool handlers used by the template-executor template-mode (issue #354).
+//
+// Slice #354 lands the executor's template branch BEFORE the real image
+// renderer (#351) and Zernio publisher (#352) ship. To keep the slice
+// independently mergeable, the executor calls these stubs whenever an agent
+// declares the corresponding tool key. They return deterministic placeholder
+// payloads and never reach the network.
+//
+// Replace the handlers in TOOL_HANDLERS with the real ones in #351/#352.
+
+// deno-lint-ignore-file no-explicit-any
+
+import type { ToolContext, ToolResult } from './executor.ts'
+
+const PLACEHOLDER_URL_PREFIX =
+  'https://placehold.co/1080x1080/jpeg?text=mock-image'
+
+function fnv1a(str: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  // unsigned 32-bit hex, padded
+  return (h >>> 0).toString(16).padStart(8, '0')
+}
+
+export async function mockImageRender(
+  input: { prompt?: unknown; width?: unknown; height?: unknown },
+  ctx: ToolContext,
+): Promise<ToolResult> {
+  const prompt = typeof input.prompt === 'string' ? input.prompt.trim() : ''
+  if (!prompt) {
+    return {
+      ok: false,
+      error: 'mock_image_render requires a non-empty `prompt`.',
+    }
+  }
+  const width = typeof input.width === 'number' && input.width > 0 ? input.width : 1080
+  const height =
+    typeof input.height === 'number' && input.height > 0 ? input.height : 1080
+
+  const taskId = ctx.taskId ?? 'mock-task'
+  const stepOrder =
+    typeof ctx.stepOrder === 'number' ? ctx.stepOrder : ctx.stepId
+  const promptHash = fnv1a(prompt)
+  const url =
+    `${PLACEHOLDER_URL_PREFIX}-${taskId}-${stepOrder}-${promptHash}`
+
+  // deno-lint-ignore no-await-in-loop
+  await Promise.resolve()
+
+  return {
+    ok: true,
+    result: {
+      url,
+      mime_type: 'image/jpeg',
+      width,
+      height,
+      mock: true,
+      prompt,
+    },
+    summary: `Mock-rendered ${width}×${height} image for prompt "${prompt.slice(0, 60)}"`,
+    artifact: {
+      type: 'file',
+      name: `${taskId}-step${stepOrder}-${promptHash}.jpg`,
+      format: 'jpg',
+      content: url,
+    },
+  }
+}
+
+export async function mockZernioPublish(
+  input: {
+    caption?: unknown
+    media_url?: unknown
+    schedule_at?: unknown
+    [key: string]: unknown
+  },
+  ctx: ToolContext,
+): Promise<ToolResult> {
+  const caption = typeof input.caption === 'string' ? input.caption.trim() : ''
+  const mediaUrl = typeof input.media_url === 'string' ? input.media_url.trim() : ''
+  if (!caption && !mediaUrl) {
+    return {
+      ok: false,
+      error:
+        'mock_zernio_publish requires at least one of `caption` or `media_url`.',
+    }
+  }
+
+  const payload = {
+    event: 'mock_zernio_publish.would_publish',
+    task_id: ctx.taskId ?? null,
+    step_order:
+      typeof ctx.stepOrder === 'number' ? ctx.stepOrder : ctx.stepId,
+    caption,
+    media_url: mediaUrl,
+    schedule_at:
+      typeof input.schedule_at === 'string' ? input.schedule_at : null,
+  }
+  console.log(JSON.stringify(payload))
+
+  await Promise.resolve()
+
+  return {
+    ok: true,
+    result: { published: true, mock: true, ...payload },
+    summary: caption
+      ? `Mock-published Zernio post: "${caption.slice(0, 60)}"`
+      : 'Mock-published Zernio post (media-only)',
+  }
+}

--- a/supabase/functions/chat/stepApprovalGate.test.ts
+++ b/supabase/functions/chat/stepApprovalGate.test.ts
@@ -1,0 +1,222 @@
+// Tests for the step-approval state machine driving template-mode tasks
+// (issue #354). The module is purely functional — every helper takes a task
+// snapshot and returns the next snapshot, so each transition can be tested
+// in isolation without any I/O.
+
+import { assert, assertEquals, assertExists } from 'jsr:@std/assert@1'
+
+import {
+  applyStepResult,
+  approveStep,
+  freezeForApproval,
+  isTemplateTask,
+  markStepError,
+  markStepRunning,
+  MAX_STEP_RETRIES,
+  retryStep,
+} from './stepApprovalGate.ts'
+
+function baseTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task-1',
+    status: 'todo',
+    plan: {
+      steps: [
+        {
+          id: 1,
+          agent_id: 'frontend-developer',
+          instruction: 'Hello {{ params.who }}',
+          needs_outputs_from: [],
+          reference_ids: [],
+        },
+        {
+          id: 2,
+          agent_id: 'backend-developer',
+          instruction: 'Use {{ step-1.output }} to {{ params.do_what }}',
+          needs_outputs_from: [1],
+          reference_ids: [],
+          requires_approval: true,
+        },
+        {
+          id: 3,
+          agent_id: 'qa-engineer',
+          instruction: 'Wrap up {{ step-2.output }}',
+          needs_outputs_from: [2],
+          reference_ids: [],
+        },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+// ─── isTemplateTask ─────────────────────────────────────────────────────────
+
+Deno.test('isTemplateTask — true when any step has an instruction', () => {
+  assertEquals(isTemplateTask(baseTask()), true)
+})
+
+Deno.test('isTemplateTask — true when step has needs_outputs_from', () => {
+  const t = {
+    plan: {
+      steps: [{ id: 1, agent_id: 'a', needs_outputs_from: [1] }],
+    },
+  }
+  assertEquals(isTemplateTask(t), true)
+})
+
+Deno.test('isTemplateTask — true when step has reference_ids', () => {
+  const t = {
+    plan: { steps: [{ id: 1, agent_id: 'a', reference_ids: ['logo'] }] },
+  }
+  assertEquals(isTemplateTask(t), true)
+})
+
+Deno.test('isTemplateTask — false on legacy planner task (just task field)', () => {
+  const legacy = {
+    plan: {
+      steps: [{ id: 1, agent_id: 'a', task: 'do the thing', inputs: ['original_task'] }],
+    },
+  }
+  assertEquals(isTemplateTask(legacy), false)
+})
+
+Deno.test('isTemplateTask — false on missing/empty plan', () => {
+  assertEquals(isTemplateTask({}), false)
+  assertEquals(isTemplateTask({ plan: null }), false)
+  assertEquals(isTemplateTask({ plan: { steps: [] } }), false)
+})
+
+// ─── markStepRunning ────────────────────────────────────────────────────────
+
+Deno.test('markStepRunning — sets task status executing and step status running', () => {
+  const next = markStepRunning(baseTask(), 1)
+  assertEquals(next.status, 'executing')
+  assertEquals(next.plan.steps[0].status, 'running')
+  // other steps untouched
+  assertEquals(next.plan.steps[1].status, undefined)
+})
+
+Deno.test('markStepRunning — clears prior error_message when re-running', () => {
+  const errored = baseTask({ status: 'error', error_message: 'boom' })
+  const next = markStepRunning(errored, 1)
+  assertEquals(next.error_message, null)
+  assertEquals(next.status, 'executing')
+})
+
+// ─── applyStepResult ────────────────────────────────────────────────────────
+
+Deno.test('applyStepResult — persists text output and output_files on the step', () => {
+  const t = markStepRunning(baseTask(), 1)
+  const out = applyStepResult(t, 1, {
+    output: 'rendered text',
+    output_files: [{ url: 'https://x/y.jpg', mime_type: 'image/jpeg' }],
+  })
+  assertEquals(out.plan.steps[0].output, 'rendered text')
+  assertEquals(out.plan.steps[0].output_files?.length, 1)
+})
+
+Deno.test('applyStepResult — does not flip step status to done by itself', () => {
+  // status flip happens separately so that requires_approval can intercept.
+  const t = markStepRunning(baseTask(), 1)
+  const out = applyStepResult(t, 1, { output: 'x' })
+  assertEquals(out.plan.steps[0].status, 'running')
+})
+
+// ─── freezeForApproval ──────────────────────────────────────────────────────
+
+Deno.test('freezeForApproval — sets step + task to awaiting_approval', () => {
+  const t = applyStepResult(markStepRunning(baseTask(), 2), 2, {
+    output: 'draft',
+  })
+  const frozen = freezeForApproval(t, 2)
+  assertEquals(frozen.status, 'awaiting_approval')
+  assertEquals(frozen.plan.steps[1].status, 'awaiting_approval')
+})
+
+// ─── approveStep ────────────────────────────────────────────────────────────
+
+Deno.test('approveStep — flips step status to done and resumes task to executing', () => {
+  const frozen = freezeForApproval(
+    applyStepResult(markStepRunning(baseTask(), 2), 2, { output: 'draft' }),
+    2,
+  )
+  const next = approveStep(frozen, 2)
+  assertEquals(next.plan.steps[1].status, 'done')
+  assertEquals(next.status, 'executing')
+})
+
+// ─── retryStep ──────────────────────────────────────────────────────────────
+
+Deno.test('retryStep — increments retry_count and clears step output', () => {
+  const frozen = freezeForApproval(
+    applyStepResult(markStepRunning(baseTask(), 2), 2, {
+      output: 'draft',
+      output_files: [{ url: 'https://x/y.jpg', mime_type: 'image/jpeg' }],
+    }),
+    2,
+  )
+  const result = retryStep(frozen, 2, 'make it punchier')
+  assert(!('error' in result))
+  if ('error' in result) return
+  const next = result.task
+  assertEquals(next.plan.steps[1].retry_count, 1)
+  assertEquals(next.plan.steps[1].output, undefined)
+  assertEquals(next.plan.steps[1].output_files, undefined)
+  assertEquals(next.plan.steps[1].status, 'pending')
+  assertEquals(next.plan.steps[1].last_feedback, 'make it punchier')
+  assertEquals(next.status, 'executing')
+})
+
+Deno.test('retryStep — marks downstream steps stale (clears their output)', () => {
+  // Step 2 is approved, step 3 has output, then we retry step 2 → step 3 must
+  // be reset because its input changed.
+  let t = applyStepResult(markStepRunning(baseTask(), 2), 2, { output: 'draft v1' })
+  t = approveStep(freezeForApproval(t, 2), 2)
+  t = applyStepResult(markStepRunning(t, 3), 3, { output: 'wrap-up v1' })
+  t = { ...t, plan: { ...t.plan, steps: t.plan.steps.map((s: any) => s.id === 3 ? { ...s, status: 'done' } : s) } }
+  const result = retryStep(t, 2, 'redo')
+  assert(!('error' in result))
+  if ('error' in result) return
+  const next = result.task
+  // step 2 is back to pending
+  assertEquals(next.plan.steps[1].status, 'pending')
+  assertEquals(next.plan.steps[1].output, undefined)
+  // step 3 became stale (output cleared, status pending)
+  assertEquals(next.plan.steps[2].status, 'pending')
+  assertEquals(next.plan.steps[2].output, undefined)
+})
+
+Deno.test(`retryStep — returns error after ${MAX_STEP_RETRIES} retries`, () => {
+  let t = freezeForApproval(
+    applyStepResult(markStepRunning(baseTask(), 2), 2, { output: 'draft' }),
+    2,
+  )
+  for (let i = 0; i < MAX_STEP_RETRIES; i++) {
+    const result = retryStep(t, 2, `feedback ${i + 1}`)
+    assert(!('error' in result))
+    if ('error' in result) return
+    // simulate the retry being executed by running and freezing again
+    t = freezeForApproval(
+      applyStepResult(markStepRunning(result.task, 2), 2, { output: `draft v${i + 2}` }),
+      2,
+    )
+  }
+  const final = retryStep(t, 2, 'one too many')
+  assert('error' in final, 'expected error sentinel after max retries')
+  if (!('error' in final)) return
+  assertExists(final.error)
+  assertEquals(final.task.status, 'error')
+  assertEquals(final.task.plan.steps[1].status, 'error')
+})
+
+// ─── markStepError ──────────────────────────────────────────────────────────
+
+Deno.test('markStepError — flips step + task to error with message', () => {
+  const t = markStepRunning(baseTask(), 1)
+  const next = markStepError(t, 1, 'tool blew up')
+  assertEquals(next.status, 'error')
+  assertEquals(next.error_message, 'tool blew up')
+  assertEquals(next.plan.steps[0].status, 'error')
+  assertEquals(next.plan.steps[0].error_message, 'tool blew up')
+})

--- a/supabase/functions/chat/stepApprovalGate.ts
+++ b/supabase/functions/chat/stepApprovalGate.ts
@@ -1,0 +1,212 @@
+// Step-approval state machine for template-mode tasks (issue #354).
+//
+// Pure functions over a task snapshot. Every helper takes the current task
+// (already loaded from the `tasks` table) and returns the next snapshot, so
+// every transition is testable in isolation. Persistence is the caller's job.
+//
+// The task snapshot must look at minimum like:
+//   { id, status, plan: { steps: [{ id, agent_id, ... }] }, error_message? }
+// Steps gain these dynamic fields as the run progresses:
+//   status: 'pending' | 'running' | 'awaiting_approval' | 'done' | 'error'
+//   retry_count, output, output_files, last_feedback, error_message
+
+// deno-lint-ignore-file no-explicit-any
+
+export const MAX_STEP_RETRIES = 3
+
+export type TaskStatus =
+  | 'todo'
+  | 'executing'
+  | 'awaiting_approval'
+  | 'done'
+  | 'cancelled'
+  | 'error'
+
+export type StepStatus =
+  | 'pending'
+  | 'running'
+  | 'awaiting_approval'
+  | 'done'
+  | 'error'
+
+export interface StepFile {
+  url: string
+  mime_type: string
+  storage_path?: string
+  width?: number
+  height?: number
+}
+
+export interface StepResult {
+  output?: string
+  output_files?: StepFile[]
+}
+
+export interface RetryFailure {
+  task: Record<string, any>
+  error: string
+}
+
+export interface RetrySuccess {
+  task: Record<string, any>
+}
+
+export type RetryOutcome = RetrySuccess | RetryFailure
+
+// ── Detection ──────────────────────────────────────────────────────────────
+
+export function isTemplateTask(task: any): boolean {
+  if (!task || typeof task !== 'object') return false
+  const steps = task.plan?.steps
+  if (!Array.isArray(steps) || steps.length === 0) return false
+  return steps.some((s) => {
+    if (!s || typeof s !== 'object') return false
+    if (typeof s.instruction === 'string') return true
+    if (Array.isArray(s.needs_outputs_from) && s.needs_outputs_from.length > 0) {
+      return true
+    }
+    if (Array.isArray(s.reference_ids) && s.reference_ids.length > 0) return true
+    return false
+  })
+}
+
+// ── Internal step helpers ─────────────────────────────────────────────────
+
+function findStepIndex(task: any, stepId: number): number {
+  const steps = task?.plan?.steps
+  if (!Array.isArray(steps)) return -1
+  return steps.findIndex((s: any) => s && s.id === stepId)
+}
+
+function patchStep(task: any, stepId: number, patch: (step: any) => any): any {
+  const steps = task?.plan?.steps ?? []
+  const idx = findStepIndex(task, stepId)
+  if (idx < 0) return task
+  const nextSteps = steps.map((s: any, i: number) => (i === idx ? patch(s) : s))
+  return {
+    ...task,
+    plan: { ...task.plan, steps: nextSteps },
+  }
+}
+
+// ── Transitions ───────────────────────────────────────────────────────────
+
+export function markStepRunning(task: any, stepId: number): any {
+  const next = patchStep(task, stepId, (s) => ({
+    ...s,
+    status: 'running',
+    error_message: undefined,
+  }))
+  return { ...next, status: 'executing', error_message: null }
+}
+
+export function applyStepResult(
+  task: any,
+  stepId: number,
+  result: StepResult,
+): any {
+  return patchStep(task, stepId, (s) => ({
+    ...s,
+    output: typeof result.output === 'string' ? result.output : s.output,
+    output_files: Array.isArray(result.output_files)
+      ? result.output_files
+      : s.output_files,
+  }))
+}
+
+export function freezeForApproval(task: any, stepId: number): any {
+  const next = patchStep(task, stepId, (s) => ({
+    ...s,
+    status: 'awaiting_approval',
+  }))
+  return { ...next, status: 'awaiting_approval' }
+}
+
+export function approveStep(task: any, stepId: number): any {
+  const next = patchStep(task, stepId, (s) => ({ ...s, status: 'done' }))
+  return { ...next, status: 'executing' }
+}
+
+export function retryStep(
+  task: any,
+  stepId: number,
+  feedback: string,
+): RetryOutcome {
+  const idx = findStepIndex(task, stepId)
+  if (idx < 0) {
+    return {
+      task,
+      error: `Step ${stepId} not found in task plan`,
+    }
+  }
+
+  const step = task.plan.steps[idx]
+  const currentRetryCount =
+    typeof step.retry_count === 'number' ? step.retry_count : 0
+
+  if (currentRetryCount >= MAX_STEP_RETRIES) {
+    const message = `Step ${stepId} exceeded max retries (${MAX_STEP_RETRIES})`
+    const errored = patchStep(task, stepId, (s) => ({
+      ...s,
+      status: 'error',
+      error_message: message,
+    }))
+    return {
+      task: { ...errored, status: 'error', error_message: message },
+      error: message,
+    }
+  }
+
+  const trimmedFeedback = typeof feedback === 'string' ? feedback : ''
+
+  // Reset the target step + every later step. Downstream stale invariant:
+  // re-running step N invalidates outputs of every step > N because the
+  // template renderer would otherwise feed them stale upstream context.
+  const steps = task.plan.steps.map((s: any, i: number) => {
+    if (i < idx) return s
+    if (i === idx) {
+      return {
+        ...s,
+        status: 'pending',
+        retry_count: currentRetryCount + 1,
+        last_feedback: trimmedFeedback || s.last_feedback,
+        output: undefined,
+        output_files: undefined,
+        error_message: undefined,
+      }
+    }
+    return {
+      ...s,
+      status: 'pending',
+      output: undefined,
+      output_files: undefined,
+      error_message: undefined,
+    }
+  })
+
+  return {
+    task: {
+      ...task,
+      status: 'executing',
+      error_message: null,
+      plan: { ...task.plan, steps },
+    },
+  }
+}
+
+export function markStepError(
+  task: any,
+  stepId: number,
+  message: string,
+): any {
+  const next = patchStep(task, stepId, (s) => ({
+    ...s,
+    status: 'error',
+    error_message: message,
+  }))
+  return { ...next, status: 'error', error_message: message }
+}
+
+export function isStepRequiringApproval(step: any): boolean {
+  return Boolean(step && step.requires_approval === true)
+}

--- a/supabase/functions/chat/templateExecutorBranch.test.ts
+++ b/supabase/functions/chat/templateExecutorBranch.test.ts
@@ -1,0 +1,406 @@
+// Tests for the template-executor branch (issue #354). Covers:
+//   - end-to-end happy path on a 2-step template task with all-mocked tools
+//   - approval gate freezes the run and emits step.awaiting_approval
+//   - resumeTemplateApprove advances after the user clicks Approve
+//   - resumeTemplateRetry re-executes the same step with feedback in context
+//   - retry past MAX_STEP_RETRIES transitions the task to error
+//   - retrying step N invalidates outputs of steps > N
+
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+} from 'jsr:@std/assert@1'
+
+import {
+  resumeTemplateApprove,
+  resumeTemplateRetry,
+  runTemplateExecutor,
+} from './templateExecutorBranch.ts'
+
+interface FetchCall {
+  url: string
+  body: any
+}
+
+function makeFetchMock(
+  responder: (call: FetchCall) => Response | Promise<Response>,
+) {
+  const calls: FetchCall[] = []
+  const fn = (async (input: any, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url
+    let body: any = null
+    try {
+      body =
+        typeof init?.body === 'string'
+          ? JSON.parse(init.body)
+          : null
+    } catch {
+      body = null
+    }
+    const call: FetchCall = { url, body }
+    calls.push(call)
+    return await responder(call)
+  }) as typeof fetch
+  return { fn, calls }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function fakeAnthropicMessage(text: string): unknown {
+  return {
+    content: [{ type: 'text', text }],
+    usage: { input_tokens: 10, output_tokens: 5 },
+  }
+}
+
+interface EmittedEvent {
+  type: string
+  payload: Record<string, unknown>
+}
+
+function makeEmitter() {
+  const events: EmittedEvent[] = []
+  const emit = (type: string, payload: Record<string, unknown> = {}) => {
+    events.push({ type, payload })
+  }
+  return { emit, events }
+}
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task-1',
+    status: 'todo',
+    plan: {
+      steps: [
+        {
+          id: 1,
+          agent_id: 'writer',
+          instruction: 'Write about {{ params.topic }}.',
+          needs_outputs_from: [],
+          reference_ids: [],
+          requires_approval: false,
+        },
+        {
+          id: 2,
+          agent_id: 'editor',
+          instruction: 'Polish: {{ step-1.output }}',
+          needs_outputs_from: [1],
+          reference_ids: [],
+          requires_approval: true,
+        },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+const AGENTS_CONTEXT = [
+  {
+    id: 'writer',
+    name: 'Writer',
+    content: 'You write things.',
+    model: 'claude-sonnet-4-6',
+    tools: [],
+  },
+  {
+    id: 'editor',
+    name: 'Editor',
+    content: 'You polish text.',
+    model: 'claude-sonnet-4-6',
+    tools: [],
+  },
+]
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  const persisted: any[] = []
+  const persistTask = async (t: any) => {
+    persisted.push(structuredClone(t))
+  }
+  const { emit, events } = makeEmitter()
+  const fetchMock = makeFetchMock(() =>
+    jsonResponse(200, fakeAnthropicMessage('rendered output')),
+  )
+  return {
+    deps: {
+      fetchImpl: fetchMock.fn,
+      apiKey: 'sk-test',
+      signal: new AbortController().signal,
+      emit,
+      agentsContext: AGENTS_CONTEXT,
+      toolsContext: [],
+      references: {},
+      params: { topic: 'cats' },
+      persistTask,
+      userId: 'user-1',
+      ...overrides,
+    },
+    fetchCalls: fetchMock.calls,
+    events,
+    persisted,
+  }
+}
+
+// ── End-to-end happy path with approval freeze ─────────────────────────────
+
+Deno.test('runTemplateExecutor — runs first step then freezes on approval', async () => {
+  const t = makeTask()
+  const { deps, fetchCalls, events } = makeDeps()
+  const { task, outcome } = await runTemplateExecutor(t, deps)
+  assertEquals(outcome.kind, 'frozen')
+  assertEquals(task.status, 'awaiting_approval')
+  assertEquals(task.plan.steps[0].status, 'done')
+  assertEquals(task.plan.steps[0].output, 'rendered output')
+  assertEquals(task.plan.steps[1].status, 'awaiting_approval')
+  // Two Anthropic calls happened (one per step), both with the right shape.
+  assertEquals(fetchCalls.length, 2)
+  for (const call of fetchCalls) {
+    assertEquals(call.url, 'https://api.anthropic.com/v1/messages')
+  }
+  // Step 1 prompt was rendered (no placeholders left).
+  const firstReq = fetchCalls[0].body
+  const firstUserMessage = firstReq.messages[0].content
+  // content can be string or block array — handle both
+  const firstText =
+    typeof firstUserMessage === 'string'
+      ? firstUserMessage
+      : firstUserMessage.find((b: any) => b.type === 'text')?.text
+  assertStringIncludes(firstText, 'Write about cats')
+  // Step 2 prompt got step-1 output substituted.
+  const secondReq = fetchCalls[1].body
+  const secondUserMessage = secondReq.messages[0].content
+  const secondText =
+    typeof secondUserMessage === 'string'
+      ? secondUserMessage
+      : secondUserMessage.find((b: any) => b.type === 'text')?.text
+  assertStringIncludes(secondText, 'Polish: rendered output')
+  // Approval freeze emitted.
+  const frozen = events.find((e) => e.type === 'step.awaiting_approval')
+  assertExists(frozen)
+  assertEquals(frozen!.payload.step_id, 2)
+})
+
+// ── resumeTemplateApprove advances ────────────────────────────────────────
+
+Deno.test('resumeTemplateApprove — flips step to done, runs no further steps when last', async () => {
+  const t = makeTask()
+  const { deps } = makeDeps()
+  const { task: frozenTask } = await runTemplateExecutor(t, deps)
+  assertEquals(frozenTask.status, 'awaiting_approval')
+  // Approve step 2 (the last) — should mark task done.
+  const { task: doneTask, outcome } = await resumeTemplateApprove(
+    frozenTask,
+    2,
+    deps,
+  )
+  assertEquals(outcome.kind, 'all_done')
+  assertEquals(doneTask.status, 'done')
+  assertEquals(doneTask.plan.steps[1].status, 'done')
+})
+
+// ── resumeTemplateRetry executes again with feedback ──────────────────────
+
+Deno.test('resumeTemplateRetry — re-runs the step with feedback in the prompt', async () => {
+  const t = makeTask()
+  const { deps: initialDeps } = makeDeps()
+  const { task: frozenTask } = await runTemplateExecutor(t, initialDeps)
+
+  // Now retry step 2 with feedback. New deps, new fetch mock so we can spy on
+  // the request body alone.
+  const fetchMock = makeFetchMock(() =>
+    jsonResponse(200, fakeAnthropicMessage('refined output v2')),
+  )
+  const persisted: any[] = []
+  const { emit } = makeEmitter()
+  const retryDeps = {
+    fetchImpl: fetchMock.fn,
+    apiKey: 'sk-test',
+    signal: new AbortController().signal,
+    emit,
+    agentsContext: AGENTS_CONTEXT,
+    toolsContext: [],
+    references: {},
+    params: { topic: 'cats' },
+    persistTask: async (t: any) => {
+      persisted.push(structuredClone(t))
+    },
+    userId: 'user-1',
+  }
+  const { task: retriedTask, outcome } = await resumeTemplateRetry(
+    frozenTask,
+    2,
+    'make it punchier',
+    retryDeps,
+  )
+  // After retry+execute, step 2 froze again awaiting approval.
+  assertEquals(outcome.kind, 'frozen')
+  assertEquals(retriedTask.plan.steps[1].retry_count, 1)
+  assertEquals(retriedTask.plan.steps[1].output, 'refined output v2')
+  assertEquals(retriedTask.plan.steps[1].status, 'awaiting_approval')
+  // Verify exactly one Anthropic call (only step 2 runs again — step 1 is done).
+  assertEquals(fetchMock.calls.length, 1)
+  const reqBody = fetchMock.calls[0].body
+  const userBlocks = reqBody.messages[0].content
+  const flat =
+    typeof userBlocks === 'string'
+      ? userBlocks
+      : userBlocks.map((b: any) => b.text || '').join('\n')
+  assertStringIncludes(flat, 'make it punchier')
+  assertStringIncludes(flat, 'Polish: rendered output')
+})
+
+// ── max retries kills the task ─────────────────────────────────────────────
+
+Deno.test('resumeTemplateRetry — task transitions to error after MAX_STEP_RETRIES retries', async () => {
+  const t = makeTask()
+  const { deps } = makeDeps()
+  let { task } = await runTemplateExecutor(t, deps)
+
+  for (let i = 0; i < 3; i++) {
+    const out = await resumeTemplateRetry(task, 2, `feedback ${i + 1}`, deps)
+    task = out.task
+    // Each successful retry runs and freezes again.
+    assertEquals(out.outcome.kind, 'frozen', `retry ${i + 1} should freeze`)
+  }
+  // The 4th retry exceeds MAX_STEP_RETRIES (3) and errors.
+  const final = await resumeTemplateRetry(task, 2, 'one too many', deps)
+  assertEquals(final.outcome.kind, 'error')
+  assertEquals(final.task.status, 'error')
+  assertExists(final.task.error_message)
+  assertEquals(final.task.plan.steps[1].status, 'error')
+})
+
+// ── downstream-stale invariant ─────────────────────────────────────────────
+
+Deno.test('resumeTemplateRetry — retrying step N marks step N+1 stale and re-executes it', async () => {
+  // Build a 3-step task where step 2 is approvable and step 3 isn't.
+  const t = {
+    id: 'task-3',
+    status: 'todo',
+    plan: {
+      steps: [
+        {
+          id: 1,
+          agent_id: 'writer',
+          instruction: 'Topic: {{ params.topic }}',
+          needs_outputs_from: [],
+          reference_ids: [],
+          requires_approval: false,
+        },
+        {
+          id: 2,
+          agent_id: 'editor',
+          instruction: 'Polish: {{ step-1.output }}',
+          needs_outputs_from: [1],
+          reference_ids: [],
+          requires_approval: true,
+        },
+        {
+          id: 3,
+          agent_id: 'editor',
+          instruction: 'Wrap up: {{ step-2.output }}',
+          needs_outputs_from: [2],
+          reference_ids: [],
+          requires_approval: false,
+        },
+      ],
+    },
+  }
+
+  // First run: step1 → step2 (freeze).
+  const fetchMock1 = makeFetchMock((call) => {
+    const text = call.body.messages[0].content
+    const flat =
+      typeof text === 'string'
+        ? text
+        : text.map((b: any) => b.text || '').join('\n')
+    if (flat.includes('Topic')) return jsonResponse(200, fakeAnthropicMessage('step1-A'))
+    if (flat.includes('Polish')) return jsonResponse(200, fakeAnthropicMessage('step2-A'))
+    if (flat.includes('Wrap up')) return jsonResponse(200, fakeAnthropicMessage('step3-A'))
+    return jsonResponse(200, fakeAnthropicMessage('default'))
+  })
+  const { emit } = makeEmitter()
+  const deps1 = {
+    fetchImpl: fetchMock1.fn,
+    apiKey: 'sk-test',
+    signal: new AbortController().signal,
+    emit,
+    agentsContext: AGENTS_CONTEXT,
+    toolsContext: [],
+    references: {},
+    params: { topic: 'cats' },
+    persistTask: async () => {},
+    userId: 'u',
+  }
+  let { task } = await runTemplateExecutor(t, deps1)
+  assertEquals(task.plan.steps[1].status, 'awaiting_approval')
+  // Approve step 2 → step 3 runs and finishes (no approval).
+  const r = await resumeTemplateApprove(task, 2, deps1)
+  assertEquals(r.outcome.kind, 'all_done')
+  task = r.task
+  assertEquals(task.status, 'done')
+  assertEquals(task.plan.steps[2].output, 'step3-A')
+
+  // Now retry step 2 — step 3 must be invalidated and re-executed.
+  const fetchMock2 = makeFetchMock((call) => {
+    const text = call.body.messages[0].content
+    const flat =
+      typeof text === 'string'
+        ? text
+        : text.map((b: any) => b.text || '').join('\n')
+    if (flat.includes('Polish')) return jsonResponse(200, fakeAnthropicMessage('step2-B'))
+    if (flat.includes('Wrap up')) return jsonResponse(200, fakeAnthropicMessage('step3-B'))
+    return jsonResponse(200, fakeAnthropicMessage('default'))
+  })
+  const deps2 = { ...deps1, fetchImpl: fetchMock2.fn }
+  const retried = await resumeTemplateRetry(task, 2, 'redo', deps2)
+  // Step 2 freezes again, step 3 will run only after step 2 is approved.
+  assertEquals(retried.outcome.kind, 'frozen')
+  // Step 2 has new output, step 3 was reset (cleared) — but execution should
+  // freeze at step 2 first. Step 3 is still pending.
+  assertEquals(retried.task.plan.steps[1].output, 'step2-B')
+  assertEquals(retried.task.plan.steps[1].status, 'awaiting_approval')
+  assertEquals(retried.task.plan.steps[2].status, 'pending')
+  assertEquals(retried.task.plan.steps[2].output, undefined)
+
+  // Approve step 2 again → step 3 re-executes with the new step 2 output.
+  const continued = await resumeTemplateApprove(retried.task, 2, deps2)
+  assertEquals(continued.outcome.kind, 'all_done')
+  assertEquals(continued.task.plan.steps[2].output, 'step3-B')
+})
+
+// ── upstream-failure surfaces step.error ───────────────────────────────────
+
+Deno.test('runTemplateExecutor — Anthropic 500 surfaces error, transitions task', async () => {
+  const t = makeTask()
+  const fetchMock = makeFetchMock(() => jsonResponse(500, { error: 'boom' }))
+  const { emit } = makeEmitter()
+  const deps = {
+    fetchImpl: fetchMock.fn,
+    apiKey: 'sk-test',
+    signal: new AbortController().signal,
+    emit,
+    agentsContext: AGENTS_CONTEXT,
+    toolsContext: [],
+    references: {},
+    params: { topic: 'cats' },
+    persistTask: async () => {},
+    userId: 'u',
+  }
+  const { task, outcome } = await runTemplateExecutor(t, deps)
+  assertEquals(outcome.kind, 'error')
+  assertEquals(task.status, 'error')
+  assertExists(task.error_message)
+  assertEquals(task.plan.steps[0].status, 'error')
+})

--- a/supabase/functions/chat/templateExecutorBranch.ts
+++ b/supabase/functions/chat/templateExecutorBranch.ts
@@ -1,0 +1,335 @@
+// Template-executor branch (issue #354).
+//
+// Walks a template-instantiated task one step at a time. Each step:
+//   1. Resolves its `instruction` via templateRenderer.render(), pulling
+//      params from the task, prior outputs from earlier steps, and
+//      references from the supplied dictionary.
+//   2. Calls Anthropic with the rendered user-message blocks + the agent's
+//      system prompt + the agent's declared tools (tool execution itself is
+//      deferred to slice #354 follow-ups; a single-shot LLM round-trip is
+//      enough to satisfy the AC for this slice).
+//   3. Persists the response as the step's output (text) and output_files
+//      (any artifacts emitted by tool calls — none in v1 of this slice).
+//   4. Either freezes for approval (requires_approval === true) or marks
+//      the step done and advances to the next pending step.
+//
+// resumeTemplateApprove and resumeTemplateRetry are the entry points called
+// from the chat function when the user clicks Approve / Refazer com ajustes
+// in the chat UI. Both consume a previously-frozen task snapshot, transition
+// the state machine, and continue the run from the next pending step.
+//
+// The module is intentionally side-effect-free aside from `deps.persistTask`,
+// `deps.emit`, and the LLM call. Storage and DB writes happen in the caller.
+
+// deno-lint-ignore-file no-explicit-any
+
+import {
+  render,
+  type ContentBlock,
+  type PriorStep,
+  type TemplateReference,
+} from '../_shared/templateRenderer.ts'
+import {
+  applyStepResult,
+  approveStep,
+  freezeForApproval,
+  isStepRequiringApproval,
+  markStepError,
+  markStepRunning,
+  retryStep,
+  type RetryOutcome,
+} from './stepApprovalGate.ts'
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
+const DEFAULT_STEP_MODEL = 'claude-sonnet-4-6'
+const MAX_STEP_TOKENS = 8192
+
+export interface TemplateExecutorDeps {
+  fetchImpl?: typeof fetch
+  apiKey: string
+  signal: AbortSignal
+  emit: (type: string, payload?: Record<string, unknown>) => void
+  agentsContext: any[]
+  toolsContext: any[]
+  references: Record<string, TemplateReference>
+  params: Record<string, string>
+  persistTask: (task: any) => Promise<void>
+  userId?: string
+}
+
+export type StepOutcome =
+  | { kind: 'continue' }
+  | { kind: 'frozen' }
+  | { kind: 'error'; error: string }
+  | { kind: 'all_done' }
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+function buildPriorSteps(steps: any[]): PriorStep[] {
+  return steps.map((s) => ({
+    output: typeof s?.output === 'string' ? s.output : undefined,
+    output_files: Array.isArray(s?.output_files) ? s.output_files : undefined,
+  }))
+}
+
+function buildUserMessageBlocks(
+  step: any,
+  priorSteps: PriorStep[],
+  references: Record<string, TemplateReference>,
+  params: Record<string, string>,
+): { blocks: ContentBlock[]; resolvedText: string; renderErrors: any[] } {
+  const instruction = typeof step.instruction === 'string' ? step.instruction : ''
+  const rendered = render({
+    instruction,
+    params,
+    priorSteps,
+    references,
+  })
+  const blocks: ContentBlock[] = [...rendered.user_message_blocks]
+  // Append retry feedback, if any, as a trailing text block. Keeping it
+  // separate from the instruction makes it visible to the model without
+  // requiring template authors to add a placeholder.
+  if (typeof step.last_feedback === 'string' && step.last_feedback.trim()) {
+    const note = `\n\n## User feedback for this retry\n\n${step.last_feedback.trim()}`
+    if (blocks.length > 0 && blocks[blocks.length - 1].type === 'text') {
+      ;(blocks[blocks.length - 1] as any).text =
+        (blocks[blocks.length - 1] as any).text + note
+    } else {
+      blocks.push({ type: 'text', text: note.trimStart() })
+    }
+  }
+  // Empty rendered.text — make sure we always send a non-empty text block so
+  // Anthropic doesn't reject the message.
+  if (
+    blocks.length === 0 ||
+    (blocks.length === 1 &&
+      blocks[0].type === 'text' &&
+      !(blocks[0] as any).text.trim())
+  ) {
+    blocks.push({ type: 'text', text: '(empty instruction)' })
+  }
+  return {
+    blocks,
+    resolvedText: rendered.resolved_text,
+    renderErrors: rendered.validation_errors,
+  }
+}
+
+function findAgent(agentsContext: any[], agentId: string): any | null {
+  return agentsContext.find((a: any) => a && a.id === agentId) ?? null
+}
+
+function extractTextFromContent(content: any[]): string {
+  if (!Array.isArray(content)) return ''
+  let acc = ''
+  for (const b of content) {
+    if (b?.type === 'text' && typeof b.text === 'string') acc += b.text
+  }
+  return acc
+}
+
+async function callAnthropic(
+  step: any,
+  agent: any,
+  blocks: ContentBlock[],
+  deps: TemplateExecutorDeps,
+): Promise<
+  | { ok: true; output: string; output_files: any[] }
+  | { ok: false; error: string }
+> {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const model =
+    typeof agent.model === 'string' && agent.model ? agent.model : DEFAULT_STEP_MODEL
+  const system =
+    typeof agent.content === 'string' && agent.content.trim()
+      ? agent.content
+      : `You are ${agent.name || agent.id}, an AI agent.`
+  const reqBody = {
+    model,
+    max_tokens: MAX_STEP_TOKENS,
+    system,
+    messages: [{ role: 'user', content: blocks }],
+  }
+  let res: Response
+  try {
+    res = await fetchImpl(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': deps.apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(reqBody),
+      signal: deps.signal,
+    })
+  } catch (err) {
+    return { ok: false, error: (err as Error).message }
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    return {
+      ok: false,
+      error: `Anthropic API error: ${res.status} ${text.slice(0, 200)}`,
+    }
+  }
+  const data = await res.json()
+  const content: any[] = Array.isArray(data?.content) ? data.content : []
+  const output = extractTextFromContent(content)
+  // No tool execution in this slice — output_files comes from rendered
+  // tool_use blocks in slices #351/#352. Keep it empty here.
+  return { ok: true, output, output_files: [] }
+}
+
+// ─── single-step runner ────────────────────────────────────────────────────
+
+async function executeStep(
+  task: any,
+  stepId: number,
+  deps: TemplateExecutorDeps,
+): Promise<{ task: any; outcome: StepOutcome }> {
+  const stepIdx = task.plan.steps.findIndex((s: any) => s && s.id === stepId)
+  if (stepIdx < 0) {
+    return {
+      task,
+      outcome: { kind: 'error', error: `Step ${stepId} not found` },
+    }
+  }
+  const step = task.plan.steps[stepIdx]
+  const agent = findAgent(deps.agentsContext, step.agent_id)
+  if (!agent) {
+    const next = markStepError(task, stepId, `Agent '${step.agent_id}' not found`)
+    deps.emit('step.error', { step_id: stepId, error: next.error_message })
+    await deps.persistTask(next)
+    return { task: next, outcome: { kind: 'error', error: next.error_message } }
+  }
+
+  let working = markStepRunning(task, stepId)
+  deps.emit('step.started', {
+    step_id: stepId,
+    agent_id: step.agent_id,
+    agent_name: agent.name,
+  })
+  await deps.persistTask(working)
+
+  const priorSteps = buildPriorSteps(working.plan.steps)
+  const { blocks } = buildUserMessageBlocks(
+    working.plan.steps[stepIdx],
+    priorSteps,
+    deps.references,
+    deps.params,
+  )
+
+  const result = await callAnthropic(step, agent, blocks, deps)
+  if (!result.ok) {
+    working = markStepError(working, stepId, result.error)
+    deps.emit('step.error', { step_id: stepId, error: result.error })
+    await deps.persistTask(working)
+    return { task: working, outcome: { kind: 'error', error: result.error } }
+  }
+
+  working = applyStepResult(working, stepId, {
+    output: result.output,
+    output_files: result.output_files,
+  })
+
+  if (isStepRequiringApproval(working.plan.steps[stepIdx])) {
+    working = freezeForApproval(working, stepId)
+    deps.emit('step.awaiting_approval', {
+      step_id: stepId,
+      output: result.output,
+    })
+    await deps.persistTask(working)
+    return { task: working, outcome: { kind: 'frozen' } }
+  }
+
+  // No approval required — flip the step to done so the next iteration
+  // doesn't try to re-run it.
+  const stepsDone = working.plan.steps.map((s: any) =>
+    s.id === stepId ? { ...s, status: 'done' } : s,
+  )
+  working = { ...working, plan: { ...working.plan, steps: stepsDone } }
+  deps.emit('step.done', { step_id: stepId })
+  await deps.persistTask(working)
+  return { task: working, outcome: { kind: 'continue' } }
+}
+
+function findNextPendingStepId(task: any): number | null {
+  const steps = task?.plan?.steps ?? []
+  for (const s of steps) {
+    if (!s) continue
+    const status = s.status
+    if (status === 'done') continue
+    if (status === 'awaiting_approval') return null // halted
+    if (status === 'error') return null
+    return s.id
+  }
+  return null
+}
+
+// ─── public entry points ───────────────────────────────────────────────────
+
+export async function runTemplateExecutor(
+  initialTask: any,
+  deps: TemplateExecutorDeps,
+): Promise<{ task: any; outcome: StepOutcome }> {
+  let task = initialTask
+  // Cap iterations to the step count so a buggy state machine can never
+  // infinite-loop us.
+  const stepCount = task?.plan?.steps?.length ?? 0
+  for (let iter = 0; iter < stepCount + 1; iter++) {
+    const nextStepId = findNextPendingStepId(task)
+    if (nextStepId === null) {
+      // Either we hit a freeze, an error, or every step is done.
+      const allDone =
+        Array.isArray(task?.plan?.steps) &&
+        task.plan.steps.every((s: any) => s?.status === 'done')
+      if (allDone) {
+        const next = { ...task, status: 'done' as const }
+        deps.emit('run.done', { task_id: task.id })
+        await deps.persistTask(next)
+        return { task: next, outcome: { kind: 'all_done' } }
+      }
+      if (task.status === 'awaiting_approval') {
+        return { task, outcome: { kind: 'frozen' } }
+      }
+      return {
+        task,
+        outcome: { kind: 'error', error: task.error_message || 'Unknown error' },
+      }
+    }
+    const out = await executeStep(task, nextStepId, deps)
+    task = out.task
+    if (out.outcome.kind !== 'continue') {
+      return { task, outcome: out.outcome }
+    }
+  }
+  return { task, outcome: { kind: 'error', error: 'Step iteration cap exceeded' } }
+}
+
+export async function resumeTemplateApprove(
+  task: any,
+  stepId: number,
+  deps: TemplateExecutorDeps,
+): Promise<{ task: any; outcome: StepOutcome }> {
+  const advanced = approveStep(task, stepId)
+  deps.emit('step.approved', { step_id: stepId })
+  await deps.persistTask(advanced)
+  return runTemplateExecutor(advanced, deps)
+}
+
+export async function resumeTemplateRetry(
+  task: any,
+  stepId: number,
+  feedback: string,
+  deps: TemplateExecutorDeps,
+): Promise<{ task: any; outcome: StepOutcome }> {
+  const result: RetryOutcome = retryStep(task, stepId, feedback)
+  if ('error' in result) {
+    deps.emit('step.error', { step_id: stepId, error: result.error })
+    await deps.persistTask(result.task)
+    return { task: result.task, outcome: { kind: 'error', error: result.error } }
+  }
+  await deps.persistTask(result.task)
+  deps.emit('step.retrying', { step_id: stepId, feedback })
+  return runTemplateExecutor(result.task, deps)
+}


### PR DESCRIPTION
Closes #354

## Summary

Adds the template-mode branch to the chat Edge Function: walks a
template-instantiated task one step at a time, resolving the per-step
`instruction` via `templateRenderer.render()`, calling Anthropic with
the rendered blocks + the agent's system prompt, persisting the response
as the step's `output`/`output_files`, and either freezing for approval
or advancing. The state machine governs the full retry-with-feedback
flow with a hard `MAX_STEP_RETRIES = 3` cap and the downstream-stale
invariant (retrying step N invalidates every step > N).

Three new deep modules, all co-tested:

- `supabase/functions/chat/stepApprovalGate.ts` — pure state machine.
- `supabase/functions/chat/templateExecutorBranch.ts` — per-step
  orchestrator + the `runTemplateExecutor` / `resumeTemplateApprove` /
  `resumeTemplateRetry` entry points.
- `supabase/functions/chat/mockTools.ts` — placeholder image renderer
  and Zernio publisher (slices #351 and #352 will replace them).

`chat/index.ts` gains three new request modes that call the modules:
`template_execute`, `template_approve`, `template_retry`. The browser
ships the full task snapshot and persists task updates from the
streamed `task.updated` events — same pattern the existing
`planTaskSync` mirror uses.

The legacy `mode === 'execute'` planner-driven path is untouched, so
non-template tasks keep running through `runExecutorBranch` exactly as
before.

## TDD
- Tests added: `stepApprovalGate.test.ts`, `templateExecutorBranch.test.ts`, `mockTools.test.ts`.
- Before implementation (red): every assertion failed against `Cannot find module 'stepApprovalGate.ts'` / `templateExecutorBranch.ts` / `mockTools.ts`.
- After implementation (green): `npm run test:functions` → 198 passed, 0 failed. `npm test` → 504 passed, 0 failed. `npm run lint` clean (0 errors, 26 pre-existing warnings). `npm run build` succeeds.

## Notes
- New endpoints are wired as `mode` discriminators on the existing chat
  function rather than as URL paths so we keep one Deno.serve handler
  and reuse the SSE plumbing.
- Mock tools live in `TOOL_HANDLERS` alongside the real handlers; they
  are no-network and idempotent so they're safe to leave registered
  even when the real renderers ship.
- Persistence is delegated to the client via `task.updated` events,
  following the same pattern as `planTaskSync.js`. The Edge Function
  does not write the `tasks` row itself.