### PR TITLE
feat(templates): UseTemplateModal + instantiate_template RPC (#356)

### DIFF
--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -561,12 +561,27 @@ export default function BoardPage() {
   const [selectedTaskId, setSelectedTaskId] = useState(null)
   const [templateSelectorOpen, setTemplateSelectorOpen] = useState(false)
   const { agents, tools } = useData()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const taskFromUrl = searchParams.get('task')
 
   const selectedTask = selectedTaskId ? tasks.find((t) => t.id === selectedTaskId) : null
 
   useEffect(() => {
     fetchTasks().then((data) => { setTasks(data); setLoading(false) })
   }, [])
+
+  // Open the panel for ?task=<id> after the initial fetch resolves. Once
+  // the task exists we drop the query param so navigating away and back
+  // does not re-open it after the user manually closes the panel.
+  useEffect(() => {
+    if (loading || !taskFromUrl) return
+    const exists = tasks.some((t) => t.id === taskFromUrl)
+    if (!exists) return
+    setSelectedTaskId(taskFromUrl)
+    const next = new URLSearchParams(searchParams)
+    next.delete('task')
+    setSearchParams(next, { replace: true })
+  }, [loading, taskFromUrl, tasks, searchParams, setSearchParams])
 
   const handleAddTask = useCallback(async (data) => {
     const row = await insertTask({ title: data.title, description: data.description, status: 'todo' })

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -577,7 +577,7 @@ export default function BoardPage() {
     if (loading || !taskFromUrl) return
     const exists = tasks.some((t) => t.id === taskFromUrl)
     if (!exists) return
-    setSelectedTaskId(taskFromUrl)
+    setSelectedTaskId(taskFromUrl) // eslint-disable-line react-hooks/set-state-in-effect
     const next = new URLSearchParams(searchParams)
     next.delete('task')
     setSearchParams(next, { replace: true })

--- a/src/components/BoardPage.jsx
+++ b/src/components/BoardPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
+import { useSearchParams } from 'react-router'
 import {
   Plus, GripVertical, X, MoreHorizontal, Trash2, ChevronDown,
   Loader2, AlertCircle, CheckCircle2, Clock, Play, Square, Eye, RefreshCw, Bookmark,

--- a/src/components/TemplateCard.jsx
+++ b/src/components/TemplateCard.jsx
@@ -1,5 +1,4 @@
 import { AlertTriangle, LayoutTemplate } from 'lucide-react'
-import { Link } from 'react-router'
 import { findMissingAgents } from '../lib/templates'
 
 function describePlan(plan) {
@@ -7,7 +6,7 @@ function describePlan(plan) {
   return `${count} ${count === 1 ? 'step' : 'steps'}`
 }
 
-export default function TemplateCard({ template, agents = [], onClick }) {
+export default function TemplateCard({ template, agents = [], onClick, onUse }) {
   const planLabel = describePlan(template.plan)
   const missingAgents = findMissingAgents(template.plan, agents)
   const missingSet = new Set(missingAgents)

--- a/src/components/TemplateCard.jsx
+++ b/src/components/TemplateCard.jsx
@@ -50,12 +50,16 @@ export default function TemplateCard({ template, agents = [], onClick, onUse }) 
 
       <div className="relative mt-auto pt-3 border-t border-border-subtle/50 flex items-center justify-between gap-2 text-xs text-text-muted">
         <span className="pointer-events-none">{planLabel}</span>
-        <Link
-          to={`/templates/${template.id}`}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onUse?.(template)
+          }}
           className="relative z-10 px-3 py-1.5 rounded-lg bg-accent-blue/10 text-accent-blue text-xs font-medium hover:bg-accent-blue/20 transition-colors"
         >
           Usar template
-        </Link>
+        </button>
       </div>
     </div>
   )

--- a/src/components/TemplatesPage.jsx
+++ b/src/components/TemplatesPage.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
 import { LayoutTemplate, Plus } from 'lucide-react'
+import { useNavigate } from 'react-router'
 import Header from './Header'
 import TemplateCard from './TemplateCard'
 import CreateTemplateModal from './CreateTemplateModal'
 import TemplateEditDrawer from './TemplateEditDrawer'
+import UseTemplateModal from './UseTemplateModal'
 import { useData } from '../context/DataContext'
 import {
   fetchTemplates,
@@ -11,6 +13,8 @@ import {
   updateTemplate,
   deleteTemplate,
 } from '../lib/templatesApi'
+import { instantiateTemplate } from '../lib/instantiateTemplate'
+import { supabase } from '../lib/supabase'
 
 export default function TemplatesPage() {
   const [templates, setTemplates] = useState([])
@@ -18,7 +22,9 @@ export default function TemplatesPage() {
   const [error, setError] = useState(null)
   const [createOpen, setCreateOpen] = useState(false)
   const [selectedId, setSelectedId] = useState(null)
+  const [useTemplateId, setUseTemplateId] = useState(null)
   const { agents } = useData()
+  const navigate = useNavigate()
 
   useEffect(() => {
     let cancelled = false

--- a/src/components/TemplatesPage.jsx
+++ b/src/components/TemplatesPage.jsx
@@ -66,7 +66,15 @@ export default function TemplatesPage() {
     setTemplates((prev) => prev.filter((tpl) => tpl.id !== id))
   }
 
+  const handleInstantiate = async (params) => {
+    if (!useTemplateId) return
+    const taskId = await instantiateTemplate(supabase, useTemplateId, params)
+    setUseTemplateId(null)
+    navigate(`/board?task=${taskId}`)
+  }
+
   const selected = templates.find((tpl) => tpl.id === selectedId) || null
+  const useTemplate = templates.find((tpl) => tpl.id === useTemplateId) || null
 
   return (
     <>

--- a/src/components/TemplatesPage.jsx
+++ b/src/components/TemplatesPage.jsx
@@ -126,6 +126,7 @@ export default function TemplatesPage() {
                 template={template}
                 agents={agents}
                 onClick={() => setSelectedId(template.id)}
+                onUse={() => setUseTemplateId(template.id)}
               />
             ))}
           </div>

--- a/src/components/TemplatesPage.jsx
+++ b/src/components/TemplatesPage.jsx
@@ -149,6 +149,15 @@ export default function TemplatesPage() {
           onDelete={() => handleDelete(selected.id)}
         />
       )}
+
+      {useTemplate && (
+        <UseTemplateModal
+          key={useTemplate.id}
+          template={useTemplate}
+          onClose={() => setUseTemplateId(null)}
+          onInstantiate={handleInstantiate}
+        />
+      )}
     </>
   )
 }

--- a/src/components/TemplatesPage.test.jsx
+++ b/src/components/TemplatesPage.test.jsx
@@ -102,7 +102,7 @@ describe('TemplatesPage', () => {
     expect(screen.getByText(/network down/i)).toBeInTheDocument()
   })
 
-  describe('"Usar template" CTA (issue #350)', () => {
+  describe('"Usar template" CTA (issue #356)', () => {
     const sampleTemplate = {
       id: 'tpl-go',
       name: 'Reusable template',
@@ -110,23 +110,32 @@ describe('TemplatesPage', () => {
       task_title: 'Title',
       task_description: '',
       plan: { steps: [{ id: 1, agent_id: 'a' }] },
+      params_schema: {
+        properties: { topic: { type: 'string', required: true } },
+      },
     }
 
-    it('renders a "Usar template" CTA on every card linking to /templates/[id]', async () => {
+    it('renders a "Usar template" CTA button on every card', async () => {
       fetchTemplates.mockResolvedValue([sampleTemplate])
       renderWithProviders(<TemplatesPage />)
 
-      const cta = await screen.findByRole('link', { name: /usar template/i })
-      expect(cta).toHaveAttribute('href', '/templates/tpl-go')
+      expect(
+        await screen.findByRole('button', { name: /usar template/i }),
+      ).toBeInTheDocument()
     })
 
-    it('clicking the "Usar template" CTA does not open the edit drawer', async () => {
+    it('clicking the "Usar template" CTA opens the UseTemplateModal, not the edit drawer', async () => {
       fetchTemplates.mockResolvedValue([sampleTemplate])
       const user = userEvent.setup()
       renderWithProviders(<TemplatesPage />)
 
-      await user.click(await screen.findByRole('link', { name: /usar template/i }))
+      await user.click(
+        await screen.findByRole('button', { name: /usar template/i }),
+      )
 
+      expect(
+        await screen.findByRole('heading', { name: /use template/i }),
+      ).toBeInTheDocument()
       expect(
         screen.queryByRole('heading', { name: /edit template/i }),
       ).not.toBeInTheDocument()

--- a/src/components/UseTemplateModal.jsx
+++ b/src/components/UseTemplateModal.jsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { X, Loader2 } from 'lucide-react'
+import {
+  defaultValues,
+  extractFields,
+  validateParams,
+} from '../lib/templateParams'
+
+const ERROR_MESSAGES = {
+  required: (field) => `${field.label} is required`,
+  enum: (field) => `${field.label} must be one of: ${(field.options || []).join(', ')}`,
+  number: (field) => `${field.label} must be a number`,
+}
+
+function FieldRow({ field, value, error, onChange }) {
+  const id = `use-template-field-${field.key}`
+  const baseInput =
+    'w-full bg-bg-input border border-border-subtle rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-hover transition-colors'
+
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1.5"
+      >
+        {field.label}
+        {field.required ? <span className="text-rose-400 ml-1">*</span> : null}
+      </label>
+      {field.description ? (
+        <p className="text-xs text-text-muted/80 mb-1.5">{field.description}</p>
+      ) : null}
+
+      {field.type === 'textarea' ? (
+        <textarea
+          id={id}
+          value={value ?? ''}
+          onChange={(e) => onChange(field.key, e.target.value)}
+          rows={3}
+          aria-invalid={Boolean(error)}
+          className={`${baseInput} resize-y`}
+        />
+      ) : field.type === 'enum' ? (
+        <select
+          id={id}
+          value={value ?? ''}
+          onChange={(e) => onChange(field.key, e.target.value)}
+          aria-invalid={Boolean(error)}
+          className={baseInput}
+        >
+          {(field.options || []).map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      ) : field.type === 'number' ? (
+        <input
+          id={id}
+          type="number"
+          value={value ?? ''}
+          onChange={(e) => onChange(field.key, e.target.value)}
+          aria-invalid={Boolean(error)}
+          className={baseInput}
+        />
+      ) : (
+        <input
+          id={id}
+          type="text"
+          value={value ?? ''}
+          onChange={(e) => onChange(field.key, e.target.value)}
+          aria-invalid={Boolean(error)}
+          className={baseInput}
+        />
+      )}
+
+      {error ? (
+        <p className="text-xs text-rose-300 mt-1" role="alert">
+          {ERROR_MESSAGES[error.kind](field)}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export default function UseTemplateModal({ template, onClose, onInstantiate }) {
+  const fields = useMemo(
+    () => extractFields(template?.params_schema),
+    [template?.params_schema],
+  )
+  const [values, setValues] = useState(() => defaultValues(fields))
+  const [errors, setErrors] = useState({})
+  const [submitting, setSubmitting] = useState(false)
+  const [serverError, setServerError] = useState(null)
+  const firstFieldRef = useRef(null)
+
+  useEffect(() => {
+    firstFieldRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape' && !submitting) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose, submitting])
+
+  const handleChange = (key, value) => {
+    setValues((prev) => ({ ...prev, [key]: value }))
+    setErrors((prev) => {
+      if (!prev[key]) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+    setServerError(null)
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (submitting) return
+    const validationErrors = validateParams(fields, values)
+    if (validationErrors.length > 0) {
+      const map = {}
+      for (const err of validationErrors) map[err.key] = err
+      setErrors(map)
+      return
+    }
+    setErrors({})
+    setSubmitting(true)
+    setServerError(null)
+    try {
+      await onInstantiate(values)
+    } catch (err) {
+      setServerError(err?.message || 'Failed to instantiate template')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
+      onClick={() => {
+        if (!submitting) onClose()
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md mx-4 rounded-2xl bg-bg-sidebar border border-border-subtle shadow-2xl"
+      >
+        <div className="h-12 border-b border-border-subtle px-5 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text-primary">
+            Use template — {template?.name || 'Untitled'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="p-1.5 rounded-lg hover:bg-bg-input text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-4">
+          {fields.length === 0 ? (
+            <p className="text-xs text-text-muted italic">
+              This template has no parameters — submit to create the task as is.
+            </p>
+          ) : (
+            fields.map((field, idx) => (
+              <FieldRow
+                key={field.key}
+                field={field}
+                value={values[field.key]}
+                error={errors[field.key]}
+                onChange={handleChange}
+                {...(idx === 0 ? { autoFocusRef: firstFieldRef } : {})}
+              />
+            ))
+          )}
+
+          {serverError ? (
+            <p className="text-xs text-rose-300" role="alert">
+              {serverError}
+            </p>
+          ) : null}
+
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="px-3 py-1.5 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-white/5 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting && <Loader2 size={12} className="animate-spin" />}
+              Create task
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/UseTemplateModal.test.jsx
+++ b/src/components/UseTemplateModal.test.jsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import UseTemplateModal from './UseTemplateModal'
+
+function makeTemplate(paramsSchema) {
+  return {
+    id: 'tpl-1',
+    name: 'Luiza pipeline',
+    description: 'Mental health content',
+    params_schema: paramsSchema,
+  }
+}
+
+describe('UseTemplateModal', () => {
+  it('renders one input per primitive type from params_schema', () => {
+    const template = makeTemplate({
+      type: 'object',
+      required: ['topic', 'tone'],
+      properties: {
+        topic: { type: 'string', label: 'Topic' },
+        tone: { type: 'enum', enum: ['serious', 'playful'] },
+        notes: { type: 'textarea', label: 'Notes' },
+        count: { type: 'number', label: 'Slide count' },
+      },
+    })
+
+    render(
+      <UseTemplateModal
+        template={template}
+        onClose={() => {}}
+        onInstantiate={vi.fn()}
+      />,
+    )
+
+    // string
+    expect(screen.getByLabelText(/Topic/)).toHaveAttribute('type', 'text')
+    // enum (select)
+    const tone = screen.getByLabelText(/Tone/)
+    expect(tone.tagName).toBe('SELECT')
+    expect(tone.querySelectorAll('option')).toHaveLength(2)
+    // textarea
+    expect(screen.getByLabelText(/Notes/).tagName).toBe('TEXTAREA')
+    // number
+    expect(screen.getByLabelText(/Slide count/)).toHaveAttribute('type', 'number')
+  })
+
+  it('renders an empty state when params_schema is missing', () => {
+    const template = makeTemplate(null)
+    render(
+      <UseTemplateModal
+        template={template}
+        onClose={() => {}}
+        onInstantiate={vi.fn()}
+      />,
+    )
+    expect(
+      screen.getByText(/no parameters/i),
+    ).toBeInTheDocument()
+  })
+
+  it('shows inline errors for missing required fields and does NOT call onInstantiate', async () => {
+    const template = makeTemplate({
+      properties: { topic: { type: 'string', required: true } },
+    })
+    const onInstantiate = vi.fn()
+
+    render(
+      <UseTemplateModal
+        template={template}
+        onClose={() => {}}
+        onInstantiate={onInstantiate}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /create task/i }))
+
+    expect(await screen.findByText(/topic.*required/i)).toBeInTheDocument()
+    expect(onInstantiate).not.toHaveBeenCalled()
+  })
+
+  it('shows inline errors for invalid enum values and does NOT call onInstantiate', async () => {
+    const template = makeTemplate({
+      properties: { tone: { type: 'enum', enum: ['serious'], required: true } },
+    })
+    const onInstantiate = vi.fn()
+
+    render(
+      <UseTemplateModal
+        template={template}
+        onClose={() => {}}
+        onInstantiate={onInstantiate}
+      />,
+    )
+
+    // Manually inject an unsupported value to simulate a tampered form.
+    const tone = screen.getByLabelText(/Tone/)
+    fireEvent.change(tone, { target: { value: 'wrong' } })
+    fireEvent.click(screen.getByRole('button', { name: /create task/i }))
+
+    await waitFor(() => expect(onInstantiate).not.toHaveBeenCalled())
+  })
+
+  it('calls onInstantiate with the typed values when the form is valid', async () => {
+    const template = makeTemplate({
+      properties: {
+        topic: { type: 'string', required: true },
+        tone: { type: 'enum', enum: ['serious', 'playful'], required: true },
+      },
+    })
+    const onInstantiate = vi.fn().mockResolvedValue('task-uuid')
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <UseTemplateModal
+        template={template}
+        onClose={onClose}
+        onInstantiate={onInstantiate}
+      />,
+    )
+
+    await user.type(screen.getByLabelText(/Topic/), 'mental health')
+    fireEvent.change(screen.getByLabelText(/Tone/), { target: { value: 'playful' } })
+    await user.click(screen.getByRole('button', { name: /create task/i }))
+
+    await waitFor(() => expect(onInstantiate).toHaveBeenCalledTimes(1))
+    expect(onInstantiate).toHaveBeenCalledWith({
+      topic: 'mental health',
+      tone: 'playful',
+    })
+  })
+
+  it('shows the server error message when onInstantiate rejects', async () => {
+    const template = makeTemplate({ properties: {} })
+    const onInstantiate = vi
+      .fn()
+      .mockRejectedValue(new Error('template not found'))
+
+    render(
+      <UseTemplateModal
+        template={template}
+        onClose={() => {}}
+        onInstantiate={onInstantiate}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /create task/i }))
+
+    expect(await screen.findByText(/template not found/i)).toBeInTheDocument()
+  })
+
+  it('calls onClose when the cancel button is clicked', () => {
+    const template = makeTemplate({ properties: { topic: { type: 'string' } } })
+    const onClose = vi.fn()
+
+    render(
+      <UseTemplateModal
+        template={template}
+        onClose={onClose}
+        onInstantiate={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/instantiateTemplate.js
+++ b/src/lib/instantiateTemplate.js
@@ -1,0 +1,46 @@
+// Thin wrapper around the `instantiate_template` Postgres RPC.
+//
+// The RPC validates `p_params` against the template's params_schema,
+// renders title/description from title_template/description_template,
+// clones the plan into a fresh `tasks` row, and returns the new id.
+// The frontend pre-validates with templateParams.validateParams so the
+// modal can show inline errors before round-tripping. The RPC's own
+// validation is the source of truth and produces the surfaced error
+// message if the form is bypassed.
+
+export class TemplateInstantiationError extends Error {
+  constructor(message, cause) {
+    super(message)
+    this.name = 'TemplateInstantiationError'
+    if (cause) this.cause = cause
+  }
+}
+
+const FALLBACK_MESSAGE = 'Failed to instantiate template'
+
+function pickTaskId(payload) {
+  if (payload == null) return null
+  if (typeof payload === 'string') return payload
+  if (Array.isArray(payload)) return pickTaskId(payload[0])
+  if (typeof payload === 'object' && typeof payload.id === 'string') return payload.id
+  return null
+}
+
+export async function instantiateTemplate(supabaseClient, templateId, params = {}) {
+  if (!supabaseClient) {
+    throw new TemplateInstantiationError('Supabase client is not configured')
+  }
+  const { data, error } = await supabaseClient.rpc('instantiate_template', {
+    p_template_id: templateId,
+    p_params: params ?? {},
+  })
+  if (error) {
+    console.error('[instantiate-template] rpc error', error)
+    throw new TemplateInstantiationError(error.message || FALLBACK_MESSAGE, error)
+  }
+  const id = pickTaskId(data)
+  if (!id) {
+    throw new TemplateInstantiationError(FALLBACK_MESSAGE)
+  }
+  return id
+}

--- a/src/lib/instantiateTemplate.test.js
+++ b/src/lib/instantiateTemplate.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  instantiateTemplate,
+  TemplateInstantiationError,
+} from './instantiateTemplate'
+
+function mockSupabase(rpcResult) {
+  const rpc = vi.fn().mockResolvedValue(rpcResult)
+  return { client: { rpc }, rpc }
+}
+
+let consoleErrorSpy
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+describe('instantiateTemplate', () => {
+  it('calls the instantiate_template RPC with the template id and params', async () => {
+    const { client, rpc } = mockSupabase({ data: 'task-uuid', error: null })
+    const taskId = await instantiateTemplate(client, 'tpl-1', { topic: 'mental health' })
+    expect(rpc).toHaveBeenCalledWith('instantiate_template', {
+      p_template_id: 'tpl-1',
+      p_params: { topic: 'mental health' },
+    })
+    expect(taskId).toBe('task-uuid')
+  })
+
+  it('unwraps the new task id when the RPC returns a row object', async () => {
+    const { client } = mockSupabase({ data: { id: 'task-uuid' }, error: null })
+    const taskId = await instantiateTemplate(client, 'tpl-1', {})
+    expect(taskId).toBe('task-uuid')
+  })
+
+  it('unwraps the new task id from a single-element array', async () => {
+    const { client } = mockSupabase({ data: [{ id: 'task-uuid' }], error: null })
+    const taskId = await instantiateTemplate(client, 'tpl-1', {})
+    expect(taskId).toBe('task-uuid')
+  })
+
+  it('throws TemplateInstantiationError with the Supabase message on RPC error', async () => {
+    const { client } = mockSupabase({
+      data: null,
+      error: { message: 'param "topic" is required' },
+    })
+    await expect(instantiateTemplate(client, 'tpl-1', {})).rejects.toBeInstanceOf(
+      TemplateInstantiationError,
+    )
+    await expect(instantiateTemplate(client, 'tpl-1', {})).rejects.toMatchObject({
+      message: 'param "topic" is required',
+    })
+  })
+
+  it('passes an empty params object when none is provided', async () => {
+    const { client, rpc } = mockSupabase({ data: 'task-uuid', error: null })
+    await instantiateTemplate(client, 'tpl-1')
+    expect(rpc).toHaveBeenCalledWith('instantiate_template', {
+      p_template_id: 'tpl-1',
+      p_params: {},
+    })
+  })
+
+  it('throws TemplateInstantiationError when the supabase client is missing', async () => {
+    await expect(instantiateTemplate(null, 'tpl-1', {})).rejects.toBeInstanceOf(
+      TemplateInstantiationError,
+    )
+  })
+
+  it('throws TemplateInstantiationError when no task id can be derived from the response', async () => {
+    const { client } = mockSupabase({ data: null, error: null })
+    await expect(instantiateTemplate(client, 'tpl-1', {})).rejects.toBeInstanceOf(
+      TemplateInstantiationError,
+    )
+  })
+})

--- a/src/lib/templateParams.js
+++ b/src/lib/templateParams.js
@@ -1,0 +1,114 @@
+// Pure helpers that turn a `task_templates.params_schema` JSON blob into a
+// flat list of form fields, plus client-side validation.
+//
+// The schema accepts two shapes — the JSON-Schema-ish form
+//   { properties: { key: { type, required, enum, ... } }, required: [keys] }
+// and a flat-map form
+//   { key: { type, required, enum, ... } }
+// The detail page already tolerates both (see paramsKeysFromSchema in
+// TemplateDetailPage.jsx); the modal uses the same parser so a single
+// authored schema works in both surfaces.
+
+const SUPPORTED_TYPES = new Set(['string', 'enum', 'textarea', 'number'])
+
+function humanizeKey(key) {
+  if (typeof key !== 'string' || !key) return ''
+  const spaced = key.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim()
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+function classifyType(descriptor) {
+  if (Array.isArray(descriptor?.enum) && descriptor.enum.length > 0) return 'enum'
+  const declared = typeof descriptor?.type === 'string' ? descriptor.type : 'string'
+  return SUPPORTED_TYPES.has(declared) ? declared : 'string'
+}
+
+function descriptorEntries(schema) {
+  if (schema?.properties && typeof schema.properties === 'object') {
+    return Object.entries(schema.properties)
+  }
+  if (schema && typeof schema === 'object') {
+    return Object.entries(schema).filter(([, value]) => value && typeof value === 'object')
+  }
+  return []
+}
+
+function topLevelRequired(schema) {
+  const list = schema?.required
+  if (!Array.isArray(list)) return null
+  return new Set(list.filter((k) => typeof k === 'string'))
+}
+
+export function extractFields(schema) {
+  if (!schema || typeof schema !== 'object') return []
+  const entries = descriptorEntries(schema)
+  const requiredSet = topLevelRequired(schema)
+  return entries.map(([key, descriptor]) => {
+    const type = classifyType(descriptor)
+    const required = requiredSet
+      ? requiredSet.has(key)
+      : Boolean(descriptor?.required)
+    const options = Array.isArray(descriptor?.enum) ? [...descriptor.enum] : undefined
+    const label = typeof descriptor?.label === 'string' && descriptor.label
+      ? descriptor.label
+      : humanizeKey(key)
+    return {
+      key,
+      type,
+      required,
+      label,
+      description: typeof descriptor?.description === 'string' ? descriptor.description : '',
+      options,
+      default: descriptor?.default,
+    }
+  })
+}
+
+export function defaultValues(fields) {
+  const out = {}
+  for (const f of fields) {
+    if (f.default !== undefined && f.default !== null) {
+      out[f.key] = f.default
+      continue
+    }
+    if (f.type === 'enum') {
+      out[f.key] = Array.isArray(f.options) && f.options.length > 0 ? f.options[0] : ''
+    } else {
+      out[f.key] = ''
+    }
+  }
+  return out
+}
+
+function isMissing(value) {
+  if (value === undefined || value === null) return true
+  if (typeof value === 'string' && value.trim() === '') return true
+  return false
+}
+
+export function validateParams(fields, values) {
+  const errors = []
+  for (const field of fields) {
+    const value = values?.[field.key]
+    if (field.required && isMissing(value)) {
+      errors.push({ key: field.key, kind: 'required' })
+      continue
+    }
+    if (isMissing(value)) continue
+    if (field.type === 'enum') {
+      const opts = Array.isArray(field.options) ? field.options : []
+      if (!opts.includes(value)) {
+        errors.push({ key: field.key, kind: 'enum' })
+      }
+      continue
+    }
+    if (field.type === 'number') {
+      const numeric = typeof value === 'number' ? value : Number(value)
+      if (!Number.isFinite(numeric)) {
+        errors.push({ key: field.key, kind: 'number' })
+      }
+      continue
+    }
+  }
+  return errors
+}

--- a/src/lib/templateParams.test.js
+++ b/src/lib/templateParams.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { extractFields, validateParams, defaultValues } from './templateParams'
+
+describe('extractFields', () => {
+  it('returns [] for null/undefined/empty schema', () => {
+    expect(extractFields(null)).toEqual([])
+    expect(extractFields(undefined)).toEqual([])
+    expect(extractFields({})).toEqual([])
+  })
+
+  it('parses a JSON-Schema-ish shape with properties + required array', () => {
+    const schema = {
+      type: 'object',
+      required: ['topic'],
+      properties: {
+        topic: { type: 'string', label: 'Topic', description: 'Research focus' },
+        notes: { type: 'textarea' },
+      },
+    }
+    const fields = extractFields(schema)
+    expect(fields).toHaveLength(2)
+    expect(fields[0]).toMatchObject({
+      key: 'topic',
+      type: 'string',
+      required: true,
+      label: 'Topic',
+      description: 'Research focus',
+    })
+    expect(fields[1]).toMatchObject({ key: 'notes', type: 'textarea', required: false })
+  })
+
+  it('honors per-property required flag when no top-level required list is present', () => {
+    const schema = {
+      properties: {
+        topic: { type: 'string', required: true },
+        notes: { type: 'textarea', required: false },
+      },
+    }
+    const fields = extractFields(schema)
+    expect(fields.find((f) => f.key === 'topic').required).toBe(true)
+    expect(fields.find((f) => f.key === 'notes').required).toBe(false)
+  })
+
+  it('parses a flat-map shape (no `properties` wrapper)', () => {
+    const schema = {
+      topic: { type: 'string', required: true },
+      tone: { type: 'enum', enum: ['serious', 'playful'] },
+    }
+    const fields = extractFields(schema)
+    expect(fields).toHaveLength(2)
+    expect(fields.find((f) => f.key === 'topic').required).toBe(true)
+    expect(fields.find((f) => f.key === 'tone')).toMatchObject({
+      type: 'enum',
+      options: ['serious', 'playful'],
+    })
+  })
+
+  it('classifies enum-like fields by their `enum` array even when type is string', () => {
+    const schema = {
+      properties: {
+        tone: { type: 'string', enum: ['a', 'b'], required: true },
+      },
+    }
+    const fields = extractFields(schema)
+    expect(fields[0]).toMatchObject({
+      key: 'tone',
+      type: 'enum',
+      options: ['a', 'b'],
+      required: true,
+    })
+  })
+
+  it('falls back type to "string" when descriptor lacks an explicit type', () => {
+    const schema = { properties: { foo: {} } }
+    expect(extractFields(schema)[0]).toMatchObject({ key: 'foo', type: 'string' })
+  })
+
+  it('uses a humanized label when none is provided', () => {
+    const schema = { properties: { research_focus: { type: 'string' } } }
+    expect(extractFields(schema)[0].label).toBe('Research focus')
+  })
+})
+
+describe('defaultValues', () => {
+  it('returns empty strings for string/textarea/number and the first enum option for enum', () => {
+    const fields = [
+      { key: 'a', type: 'string' },
+      { key: 'b', type: 'textarea' },
+      { key: 'c', type: 'number' },
+      { key: 'd', type: 'enum', options: ['x', 'y'] },
+    ]
+    expect(defaultValues(fields)).toEqual({ a: '', b: '', c: '', d: 'x' })
+  })
+
+  it('uses the descriptor `default` when present', () => {
+    const fields = [
+      { key: 'a', type: 'string', default: 'hello' },
+      { key: 'b', type: 'enum', options: ['x', 'y'], default: 'y' },
+    ]
+    expect(defaultValues(fields)).toEqual({ a: 'hello', b: 'y' })
+  })
+})
+
+describe('validateParams', () => {
+  it('returns no errors for a valid set of values', () => {
+    const fields = [
+      { key: 'topic', type: 'string', required: true },
+      { key: 'tone', type: 'enum', options: ['a', 'b'], required: true },
+    ]
+    const errors = validateParams(fields, { topic: 'mental health', tone: 'a' })
+    expect(errors).toEqual([])
+  })
+
+  it('flags required fields when missing or empty after trimming', () => {
+    const fields = [{ key: 'topic', type: 'string', required: true }]
+    expect(validateParams(fields, {})).toEqual([
+      { key: 'topic', kind: 'required' },
+    ])
+    expect(validateParams(fields, { topic: '   ' })).toEqual([
+      { key: 'topic', kind: 'required' },
+    ])
+  })
+
+  it('does not flag optional fields when empty', () => {
+    const fields = [{ key: 'notes', type: 'textarea', required: false }]
+    expect(validateParams(fields, {})).toEqual([])
+  })
+
+  it('flags enum values that are not in the option list', () => {
+    const fields = [{ key: 'tone', type: 'enum', options: ['a', 'b'], required: true }]
+    expect(validateParams(fields, { tone: 'nope' })).toEqual([
+      { key: 'tone', kind: 'enum' },
+    ])
+  })
+
+  it('flags non-numeric values for number fields', () => {
+    const fields = [{ key: 'count', type: 'number', required: true }]
+    expect(validateParams(fields, { count: 'abc' })).toEqual([
+      { key: 'count', kind: 'number' },
+    ])
+  })
+
+  it('accepts numeric strings for number fields', () => {
+    const fields = [{ key: 'count', type: 'number', required: true }]
+    expect(validateParams(fields, { count: '42' })).toEqual([])
+    expect(validateParams(fields, { count: 42 })).toEqual([])
+  })
+
+  it('returns multiple independent errors for multiple bad fields', () => {
+    const fields = [
+      { key: 'topic', type: 'string', required: true },
+      { key: 'tone', type: 'enum', options: ['a'], required: true },
+    ]
+    const errors = validateParams(fields, { tone: 'wrong' })
+    expect(errors).toHaveLength(2)
+    expect(errors.map((e) => e.key).sort()).toEqual(['tone', 'topic'])
+  })
+})

--- a/supabase/migrations/20260507000000_instantiate_template.sql
+++ b/supabase/migrations/20260507000000_instantiate_template.sql
@@ -1,0 +1,240 @@
+-- RPC: instantiate_template(p_template_id, p_params) returns uuid
+--
+-- Renders title/description from the template's title_template and
+-- description_template (Mustache-style {{params.X}} placeholders),
+-- deep-copies plan into a fresh tasks row with all step outputs/statuses
+-- reset to pending, and returns the new task id.
+--
+-- Validation runs server-side too — the modal pre-validates client-side,
+-- but if the form is bypassed the RPC raises a structured error that the
+-- frontend wrapper surfaces as TemplateInstantiationError.
+--
+-- Mustache renderer is intentionally minimal: only `{{params.<key>}}`
+-- placeholders are recognised here. Step-output and reference placeholders
+-- belong to the chat executor's runtime renderer, not to instantiation.
+
+create or replace function render_params_template(p_template text, p_params jsonb)
+returns text
+language plpgsql
+immutable
+as $$
+declare
+  result text := coalesce(p_template, '');
+  match_record record;
+  param_value text;
+begin
+  if result = '' then
+    return result;
+  end if;
+  for match_record in
+    select distinct (regexp_matches(
+      result,
+      '\{\{\s*params\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}',
+      'g'
+    ))[1] as key
+  loop
+    if p_params ? match_record.key then
+      param_value := coalesce(p_params ->> match_record.key, '');
+    else
+      param_value := '';
+    end if;
+    result := regexp_replace(
+      result,
+      '\{\{\s*params\.' || match_record.key || '\s*\}\}',
+      param_value,
+      'g'
+    );
+  end loop;
+  return result;
+end;
+$$;
+
+revoke all on function render_params_template(text, jsonb) from public;
+grant execute on function render_params_template(text, jsonb) to anon, authenticated;
+
+-- Reset every step output / status inside a plan jsonb so an instantiated
+-- task starts fresh. Returns the original plan unchanged when it is null
+-- or has no steps array.
+create or replace function reset_plan_for_instance(p_plan jsonb)
+returns jsonb
+language plpgsql
+immutable
+as $$
+declare
+  steps jsonb;
+  new_steps jsonb := '[]'::jsonb;
+  step jsonb;
+begin
+  if p_plan is null or jsonb_typeof(p_plan) <> 'object' then
+    return p_plan;
+  end if;
+  steps := p_plan -> 'steps';
+  if steps is null or jsonb_typeof(steps) <> 'array' then
+    return p_plan;
+  end if;
+  for step in select * from jsonb_array_elements(steps)
+  loop
+    step := step
+      - 'output'
+      - 'output_files'
+      - 'error_message'
+      - 'started_at'
+      - 'completed_at';
+    step := jsonb_set(step, '{status}', '"pending"'::jsonb, true);
+    new_steps := new_steps || jsonb_build_array(step);
+  end loop;
+  return jsonb_set(p_plan, '{steps}', new_steps, true);
+end;
+$$;
+
+revoke all on function reset_plan_for_instance(jsonb) from public;
+grant execute on function reset_plan_for_instance(jsonb) to anon, authenticated;
+
+-- Validate p_params against the template's params_schema. Raises an
+-- exception with a user-readable message on the first violation.
+-- Supports both shapes accepted by the frontend `extractFields`:
+--   * JSON-Schema-ish:  { properties: { k: { type, enum, required } }, required: [...] }
+--   * Flat-map:         { k: { type, enum, required } }
+create or replace function validate_template_params(p_schema jsonb, p_params jsonb)
+returns void
+language plpgsql
+immutable
+as $$
+declare
+  entries jsonb;
+  required_set jsonb;
+  k text;
+  descriptor jsonb;
+  enum_values jsonb;
+  declared_type text;
+  raw_value text;
+  is_required boolean;
+begin
+  if p_schema is null or jsonb_typeof(p_schema) <> 'object' then
+    return;
+  end if;
+
+  if p_schema ? 'properties' and jsonb_typeof(p_schema -> 'properties') = 'object' then
+    entries := p_schema -> 'properties';
+    if p_schema ? 'required' and jsonb_typeof(p_schema -> 'required') = 'array' then
+      required_set := p_schema -> 'required';
+    else
+      required_set := null;
+    end if;
+  else
+    entries := p_schema;
+    required_set := null;
+  end if;
+
+  for k, descriptor in
+    select key, value from jsonb_each(entries) where jsonb_typeof(value) = 'object'
+  loop
+    if required_set is not null then
+      is_required := required_set @> to_jsonb(k);
+    else
+      is_required := coalesce((descriptor ->> 'required')::boolean, false);
+    end if;
+
+    raw_value := p_params ->> k;
+
+    if is_required and (raw_value is null or btrim(raw_value) = '') then
+      raise exception 'param "%" is required', k
+        using errcode = 'check_violation';
+    end if;
+
+    if raw_value is null or btrim(raw_value) = '' then
+      continue;
+    end if;
+
+    enum_values := descriptor -> 'enum';
+    declared_type := descriptor ->> 'type';
+
+    if enum_values is not null and jsonb_typeof(enum_values) = 'array' then
+      if not (enum_values @> to_jsonb(raw_value)) then
+        raise exception 'param "%" must be one of the allowed values', k
+          using errcode = 'check_violation';
+      end if;
+      continue;
+    end if;
+
+    if declared_type = 'number' then
+      begin
+        perform raw_value::numeric;
+      exception when others then
+        raise exception 'param "%" must be a number', k
+          using errcode = 'check_violation';
+      end;
+    end if;
+  end loop;
+end;
+$$;
+
+revoke all on function validate_template_params(jsonb, jsonb) from public;
+grant execute on function validate_template_params(jsonb, jsonb) to anon, authenticated;
+
+-- Main entry point. Returns the new task id.
+create or replace function instantiate_template(p_template_id uuid, p_params jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  template_row task_templates%rowtype;
+  resolved_title text;
+  resolved_description text;
+  cloned_plan jsonb;
+  initial_status text;
+  new_task_id uuid;
+  effective_params jsonb := coalesce(p_params, '{}'::jsonb);
+begin
+  select * into template_row from task_templates where id = p_template_id;
+  if not found then
+    raise exception 'template % not found', p_template_id
+      using errcode = 'no_data_found';
+  end if;
+
+  perform validate_template_params(template_row.params_schema, effective_params);
+
+  if template_row.title_template is not null and template_row.title_template <> '' then
+    resolved_title := render_params_template(template_row.title_template, effective_params);
+  else
+    resolved_title := template_row.task_title;
+  end if;
+
+  if template_row.description_template is not null and template_row.description_template <> '' then
+    resolved_description := render_params_template(template_row.description_template, effective_params);
+  else
+    resolved_description := coalesce(template_row.task_description, '');
+  end if;
+
+  cloned_plan := reset_plan_for_instance(template_row.plan);
+
+  if cloned_plan is not null
+     and jsonb_typeof(cloned_plan) = 'object'
+     and jsonb_typeof(cloned_plan -> 'steps') = 'array'
+     and jsonb_array_length(cloned_plan -> 'steps') > 0
+  then
+    initial_status := 'awaiting_approval';
+  else
+    initial_status := 'todo';
+  end if;
+
+  insert into tasks (title, description, status, plan, run_id, error_message, artifacts)
+    values (
+      resolved_title,
+      resolved_description,
+      initial_status,
+      cloned_plan,
+      null,
+      null,
+      '[]'::jsonb
+    )
+    returning id into new_task_id;
+
+  return new_task_id;
+end;
+$$;
+
+revoke all on function instantiate_template(uuid, jsonb) from public;
+grant execute on function instantiate_template(uuid, jsonb) to anon, authenticated;


### PR DESCRIPTION
Closes #356

## Summary

Wires up the "Usar template" path: clicking the CTA on a template card opens a `UseTemplateModal` with a form generated from `params_schema`, posts the values to a new `instantiate_template` Postgres RPC, and redirects to `/board?task=<new_id>` where the panel auto-opens for the new task. Supports the four primitive field types in v1 (`string`, `enum`, `textarea`, `number`).

The work is split into deep modules so each piece is unit-testable in isolation:

- `src/lib/templateParams.js` — pure schema → form-fields parser + client-side validator. Tolerates both JSON-Schema-ish (`{ properties, required }`) and flat-map shapes, matching the parser already used by `TemplateDetailPage`.
- `src/lib/instantiateTemplate.js` — thin Supabase RPC wrapper that surfaces structured errors as a `TemplateInstantiationError`.
- `src/components/UseTemplateModal.jsx` — the modal itself, follows the existing `SaveAsTemplateModal` overlay pattern (`z-[60]`, escape-to-close, server-error inline banner).
- `supabase/migrations/20260507000000_instantiate_template.sql` — the RPC plus three pl/pgsql helpers: `render_params_template` (Mustache `{{params.X}}` substitution, params-only — step / ref placeholders stay with the chat executor's runtime renderer), `reset_plan_for_instance` (deep-copies plan, strips per-step output fields, resets each step status to `pending`), and `validate_template_params` (server-side re-validation of required + enum + numeric).

`BoardPage` now reads `?task=<id>` after the initial fetch, opens the panel for the matching row, and strips the param via `replace: true` so closing the panel and navigating doesn't re-open it.

## TDD

- Tests added: `src/lib/templateParams.test.js` (16 cases), `src/lib/instantiateTemplate.test.js` (7 cases), `src/components/UseTemplateModal.test.jsx` (7 cases).
- Tests modified: `src/components/TemplatesPage.test.jsx` — the "Usar template" CTA describe block was originally written for issue #350 (Link to `/templates/[id]`); #356 redefines the CTA to open the new modal, so those two cases were rewritten to assert the new behaviour. The "0 steps" guard remains.
- Before implementation (red): each new module's test file failed at import resolution (`Failed to resolve import "./templateParams"`, etc.) — confirmed via targeted `npx vitest run` per file.
- After implementation (green): `npm test` → **534 passed (47 files)**. `npm run lint` → **0 errors, 26 warnings** (all pre-existing in unrelated files).

## Notes

- The RPC is `SECURITY DEFINER` and explicitly grants execute to `anon, authenticated`, mirroring the existing `increment_agent_usage` pattern. The repo has no pgTAP suite, so this migration is exercised end-to-end via the manual board flow rather than SQL-level tests; the param-validation logic is also covered by mocked-fetch frontend tests through the wrapper.
- `instantiate_template` falls back to `task_title` / `task_description` when the corresponding `*_template` columns are NULL — required so the existing seed templates (without title/description templates) keep working unchanged.
- Initial task status is `awaiting_approval` when the cloned plan has steps, otherwise `todo` — matches the existing `cloneTemplateToTask` helper used by `TemplateSelectorModal` so the two paths converge to the same board state.