### PR TITLE
docs(chat): document native web_search/web_fetch + Tavily fallback (#348)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,6 +500,50 @@ If the user clicks Approve or Cancel before `createTaskFromPlan` has resolved, t
 - Refining a plan multiple times keeps a single row — there is no per-revision history.
 - Clearing the chat (the "Clear" button) drops the in-memory `boardTaskRef` map but leaves the rows in Supabase intact, so prior conversations still appear on the board.
 
+## Native web research tools (`web_search` / `web_fetch`)
+
+When an executor-branch step (the orchestrated planner path) has an agent that declares `web_search` and/or `web_fetch`, the per-step Anthropic request is built with Anthropic's **native server-side** tool definitions — `web_search_20250305` and `web_fetch_20250910` — instead of the client-side schemas. The model performs the search/fetch on Anthropic's side and returns results inline as `web_search_tool_result` / `web_fetch_tool_result` content blocks; the executor never has to round-trip the call through `TOOL_HANDLERS`. This is the **primary** research path because it is faster (one request instead of two), produces more relevant results, and does not require a Tavily key.
+
+The Tavily-backed `web_search` handler stays in `TOOL_HANDLERS` as a **fallback** path that activates when the native call returns zero results or errors out (e.g. `max_uses_exceeded`). The fallback fires at most once per step, the same query is used, and the model gets the Tavily results re-prompted as a follow-up user message.
+
+### Module layout
+
+- `supabase/functions/chat/webResearchTools.ts` — pure helpers, zero I/O.
+  - `buildNativeWebTools(declaredIds)` returns the native tool defs to inject. Reads `web_search` and/or `web_fetch` from the agent's declared tool ids.
+  - `findFailedNativeSearches(content)` scans the response's content blocks and returns `{ tool_use_id, query, reason }[]` for `web_search_tool_result` blocks that came back empty (`reason: 'no_results'`) or errored (`reason: 'error'`). Pairs each failed result with the original query by indexing the matching `server_tool_use` blocks.
+- `supabase/functions/chat/executor.ts` — wires the helpers into the per-step loop:
+  - Filters `web_search` / `web_fetch` out of the client-side schema list and adds them via `buildNativeWebTools` instead, so the request never carries a duplicate `web_search` tool name.
+  - When `web_fetch` is in the toolset, adds the `anthropic-beta: web-fetch-2025-09-10` request header (required while the native fetch tool is in beta).
+  - After each turn, when the model emits text-only (no `tool_use` blocks), runs `findFailedNativeSearches` and if any failed, calls the local `webSearch` (Tavily) handler once per failed query, appends the results as a user message, and continues the loop. The flag `nativeFallbackUsed` ensures Tavily is invoked at most once per step.
+  - Emits a structured telemetry log line whenever the fallback triggers: `console.log(JSON.stringify({ event: 'web_search.fallback.tavily', step_id, query, reason }))`. This is the contract downstream log analysis depends on — do not rename the event.
+
+### Scope: executor branch only
+
+The native + fallback wiring lives in the executor branch (multi-step planner runs). The **selected-agent branch** (`selectedAgentBranch.ts`, used when the user picks an agent directly from the chat composer) keeps the plain client-side `web_search` schema and goes straight to Tavily. That is intentional: the selected-agent path streams turns and is shorter; the additional latency of the native+fallback dance is not worth it for a single-shot interaction. If you ever expand the selected-agent path to use the native tool, mirror the executor's wiring rather than building a parallel one.
+
+### Failure modes and what they look like
+
+| Native response                                                                                          | What the executor does                                                                              |
+|----------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `web_search_tool_result.content: [...non-empty results]`                                                 | No fallback. Loop continues normally — model uses the inline results.                                |
+| `web_search_tool_result.content: []` (zero results)                                                      | One Tavily call per zero-result query, results re-prompted, telemetry emitted with `reason: no_results`. |
+| `web_search_tool_result.content: { type: 'web_search_tool_result_error', error_code: '...' }`            | Same as zero-result path, telemetry emitted with `reason: error`.                                    |
+| Native HTTP error (rare — Anthropic API itself fails)                                                    | Surfaces as the existing `step.error` event; no Tavily fallback.                                     |
+
+### Required secrets
+
+| Variable | Required | Notes |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | Yes | Same key the rest of the chat function already uses. The native tools have no separate key. |
+| `TAVILY_API_KEY` | Optional but recommended | When unset, the Tavily fallback returns a structured "not configured" error to the model. The native path still works — only the fallback is disabled. |
+
+### Where the tests live
+
+- `supabase/functions/chat/webResearchTools.test.ts` — unit tests for the two pure helpers.
+- `supabase/functions/chat/executor.test.ts` — covers request-shape assertions (native tool def injected when declared, omitted when not declared, beta header added for `web_fetch`), the two fallback paths (zero results, error), the no-fallback-on-success path, and the `web_search.fallback.tavily` telemetry contract.
+
+Both run via `npm run test:functions`.
+
 ## Adding a New Agent
 
 The catalog lives in the Supabase `agents` table. There are two paths:


### PR DESCRIPTION
Closes #348

## TDD
- Skipped: docs-only change. The behavior asked for by the issue (native `web_search_20250305` / `web_fetch_20250910` as primary, Tavily fallback on zero-results/error, `web_search.fallback.tavily` telemetry) was already implemented in #368 and the telemetry contract test landed in #384. All five acceptance criteria are covered by existing passing tests in `executor.test.ts` and `webResearchTools.test.ts`. This PR only adds documentation so the architecture is discoverable.

## Notes
- New CLAUDE.md section "Native web research tools (`web_search` / `web_fetch`)" between "AI Assistant ↔ Kanban board sync" and "Adding a New Agent".
- Documents: module layout (`webResearchTools.ts` + executor wiring), executor-only scope (selected-agent branch is intentionally not wired), failure-mode table, required secrets, and the `web_search.fallback.tavily` telemetry contract that downstream log analysis depends on.
- Verified locally: `npm test` (534 frontend tests pass), `npm run test:functions` (198 Edge Function tests pass), `npm run lint` (0 errors).