### PR TITLE
feat(orchestration): per-file Diana gallery + rerender endpoint (#357)

### DIFF
--- a/src/components/orchestration/DianaGallery.jsx
+++ b/src/components/orchestration/DianaGallery.jsx
@@ -204,7 +204,7 @@ export default function DianaGallery({
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
         {images.map(({ idx, file }) => (
           <ThumbCard
-            key={idx}
+            key={`${idx}:${file.signed_url || file.storage_path || ''}`}
             idx={idx}
             file={file}
             loading={loadingSet.has(idx)}

--- a/src/components/orchestration/DianaGallery.jsx
+++ b/src/components/orchestration/DianaGallery.jsx
@@ -12,7 +12,7 @@
 // Use `loadingIndices` to disable buttons on a thumbnail whose rerender is
 // in flight.
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import * as Icons from 'lucide-react'
 import {
   countApproved,

--- a/src/components/orchestration/DianaGallery.jsx
+++ b/src/components/orchestration/DianaGallery.jsx
@@ -35,15 +35,9 @@ function ThumbCard({
   const [feedback, setFeedback] = useState(
     typeof file.feedback === 'string' ? file.feedback : '',
   )
-
-  // Sync local editing buffer with incoming feedback (e.g. after a rerender
-  // resets state). Effect avoids stomping on user typing once the textarea
-  // is open.
-  useEffect(() => {
-    if (!editingOpen) {
-      setFeedback(typeof file.feedback === 'string' ? file.feedback : '')
-    }
-  }, [file.feedback, editingOpen])
+  // The parent passes a key bound to file.signed_url so this component
+  // remounts whenever the file is rerendered — that resets local state
+  // (editingOpen + feedback) without needing an effect.
 
   const stateBadge = (() => {
     if (state === 'approved') {

--- a/src/components/orchestration/DianaGallery.jsx
+++ b/src/components/orchestration/DianaGallery.jsx
@@ -1,0 +1,242 @@
+// Per-image approval gallery for Diana steps (issue #357).
+//
+// Replaces the textual approval gate (issue #355) for steps whose agent is
+// `diana-design`. Renders a grid of thumbnails — one per `output_files[]`
+// entry whose `mime_type` starts with `image/` — with three actions per
+// thumbnail: Aprovar, Pedir ajuste, Re-renderizar. The "Avançar" button at
+// the bottom is disabled until every image has `approval_state === 'approved'`.
+//
+// All state mutations live in the parent: this component is a thin
+// dispatcher. Pass `onApprove(idx)`, `onRequestEdit(idx, feedback)`,
+// `onRerender(idx, feedback?)`, and (optionally) `onAdvance()`.
+// Use `loadingIndices` to disable buttons on a thumbnail whose rerender is
+// in flight.
+
+import { useEffect, useState } from 'react'
+import * as Icons from 'lucide-react'
+import {
+  countApproved,
+  getFileApprovalState,
+  imageFiles,
+  isFullyApproved,
+  totalImages,
+} from '../../lib/dianaGallery'
+
+function ThumbCard({
+  file,
+  idx,
+  loading,
+  onApprove,
+  onRequestEdit,
+  onRerender,
+}) {
+  const state = getFileApprovalState(file)
+  const [editingOpen, setEditingOpen] = useState(state === 'edit_requested')
+  const [feedback, setFeedback] = useState(
+    typeof file.feedback === 'string' ? file.feedback : '',
+  )
+
+  // Sync local editing buffer with incoming feedback (e.g. after a rerender
+  // resets state). Effect avoids stomping on user typing once the textarea
+  // is open.
+  useEffect(() => {
+    if (!editingOpen) {
+      setFeedback(typeof file.feedback === 'string' ? file.feedback : '')
+    }
+  }, [file.feedback, editingOpen])
+
+  const stateBadge = (() => {
+    if (state === 'approved') {
+      return (
+        <span className="absolute top-2 right-2 flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-500/90 text-white shadow">
+          <Icons.Check size={10} />
+          Aprovado
+        </span>
+      )
+    }
+    if (state === 'edit_requested') {
+      return (
+        <span className="absolute top-2 right-2 flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-500/90 text-white shadow">
+          <Icons.Pencil size={10} />
+          Ajuste pedido
+        </span>
+      )
+    }
+    return null
+  })()
+
+  return (
+    <div
+      data-testid={`diana-thumb-${idx}`}
+      className="rounded-xl border border-border-subtle bg-bg-card overflow-hidden flex flex-col"
+    >
+      <div className="relative aspect-square bg-black/30">
+        {file.signed_url ? (
+          <img
+            src={file.signed_url}
+            alt={file.storage_path || `output_files[${idx}]`}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-text-muted">
+            <Icons.ImageOff size={28} />
+          </div>
+        )}
+        {stateBadge}
+        {loading && (
+          <div className="absolute inset-0 bg-black/60 flex items-center justify-center">
+            <Icons.Loader2 size={18} className="animate-spin text-white" />
+          </div>
+        )}
+      </div>
+
+      <div className="px-3 py-2 flex items-center gap-1.5 border-t border-border-subtle">
+        <button
+          type="button"
+          onClick={() => onApprove(idx)}
+          disabled={loading || state === 'approved'}
+          className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-[11px] font-medium text-emerald-200 bg-emerald-500/15 border border-emerald-500/30 hover:bg-emerald-500/25 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <Icons.Check size={11} />
+          Aprovar
+        </button>
+        <button
+          type="button"
+          onClick={() => setEditingOpen((open) => !open)}
+          disabled={loading}
+          className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-[11px] font-medium text-amber-200 bg-amber-500/15 border border-amber-500/30 hover:bg-amber-500/25 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <Icons.Pencil size={11} />
+          Pedir ajuste
+        </button>
+        <button
+          type="button"
+          onClick={() => onRerender(idx, feedback || file.feedback || '')}
+          disabled={loading}
+          className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-[11px] font-medium text-blue-200 bg-blue-500/15 border border-blue-500/30 hover:bg-blue-500/25 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <Icons.RotateCcw size={11} />
+          Re-renderizar
+        </button>
+      </div>
+
+      {editingOpen && (
+        <div className="px-3 pb-3 pt-1 border-t border-border-subtle bg-bg-input/40">
+          <label className="text-[10px] font-semibold uppercase tracking-wider text-text-muted block mb-1">
+            Feedback
+          </label>
+          <textarea
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            placeholder="Descreva o ajuste desejado…"
+            rows={3}
+            className="w-full px-2 py-1.5 rounded-md bg-bg-card border border-border-subtle text-xs text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-amber-500/30 resize-none"
+          />
+          <div className="flex justify-end gap-1.5 mt-1.5">
+            <button
+              type="button"
+              onClick={() => {
+                setEditingOpen(false)
+                setFeedback(file.feedback || '')
+              }}
+              className="px-2 py-1 rounded-md text-[10px] text-text-secondary hover:bg-bg-card transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                onRequestEdit(idx, feedback)
+                setEditingOpen(false)
+              }}
+              disabled={!feedback.trim()}
+              className="px-2 py-1 rounded-md text-[10px] font-medium text-white bg-amber-500 hover:bg-amber-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Enviar feedback
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function DianaGallery({
+  step,
+  onApprove,
+  onRequestEdit,
+  onRerender,
+  onAdvance,
+  loadingIndices = [],
+}) {
+  const images = imageFiles(step)
+  const total = totalImages(step)
+  const approved = countApproved(step)
+  const fullyApproved = isFullyApproved(step)
+  const loadingSet = new Set(loadingIndices)
+
+  if (images.length === 0) {
+    return (
+      <div
+        data-testid="diana-empty"
+        className="rounded-xl border border-dashed border-border-subtle bg-bg-card px-5 py-10 text-center"
+      >
+        <Icons.Image size={28} className="text-text-muted mx-auto mb-2" />
+        <p className="text-sm text-text-secondary">
+          Nenhum arquivo de imagem disponível para revisão neste passo.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-border-subtle bg-bg-card overflow-hidden">
+      <div className="px-4 py-3 border-b border-border-subtle flex items-center gap-3">
+        <Icons.Image size={16} className="text-purple-400" />
+        <h3 className="text-sm font-semibold text-text-primary flex-1">
+          Galeria — aprove cada imagem
+        </h3>
+        <span
+          data-testid="diana-counter"
+          className={`text-xs font-medium ${
+            fullyApproved ? 'text-emerald-300' : 'text-text-secondary'
+          }`}
+        >
+          {approved} / {total} aprovados
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+        {images.map(({ idx, file }) => (
+          <ThumbCard
+            key={idx}
+            idx={idx}
+            file={file}
+            loading={loadingSet.has(idx)}
+            onApprove={onApprove}
+            onRequestEdit={onRequestEdit}
+            onRerender={onRerender}
+          />
+        ))}
+      </div>
+
+      <div className="px-4 py-3 border-t border-border-subtle flex justify-end">
+        <button
+          type="button"
+          onClick={() => onAdvance && onAdvance()}
+          disabled={!fullyApproved || !onAdvance}
+          title={
+            fullyApproved
+              ? undefined
+              : 'Aprove todas as imagens antes de avançar'
+          }
+          className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Icons.ArrowRight size={12} />
+          Avançar
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/orchestration/DianaGallery.test.jsx
+++ b/src/components/orchestration/DianaGallery.test.jsx
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen, within } from '@testing-library/react'
+import { renderWithProviders } from '../../test/test-utils'
+import DianaGallery from './DianaGallery'
+
+const imgFile = (overrides = {}) => ({
+  storage_path: 'tasks/abc/feed_001.jpg',
+  signed_url: 'https://example.com/feed_001.jpg',
+  mime_type: 'image/jpeg',
+  width: 1080,
+  height: 1080,
+  ...overrides,
+})
+
+const stepWithFiles = (files) => ({
+  id: 1,
+  agent_id: 'diana-design',
+  agent_name: 'Diana Design',
+  status: 'awaiting_approval',
+  output_files: files,
+})
+
+describe('DianaGallery', () => {
+  it('renders one thumbnail per image file with idx-based test ids', () => {
+    const step = stepWithFiles([
+      imgFile({ signed_url: 'https://example.com/a.jpg' }),
+      imgFile({ signed_url: 'https://example.com/b.jpg' }),
+      imgFile({ signed_url: 'https://example.com/c.jpg' }),
+    ])
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+      />,
+    )
+    const thumbs = screen.getAllByTestId(/^diana-thumb-/)
+    expect(thumbs).toHaveLength(3)
+  })
+
+  it('skips non-image output_files', () => {
+    const step = stepWithFiles([
+      imgFile({ signed_url: 'https://example.com/a.jpg' }),
+      { mime_type: 'application/pdf', storage_path: 'b.pdf' },
+      imgFile({ signed_url: 'https://example.com/c.jpg' }),
+    ])
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+      />,
+    )
+    expect(screen.getAllByTestId(/^diana-thumb-/)).toHaveLength(2)
+  })
+
+  it('shows "0/N aprovados" when nothing is approved', () => {
+    const step = stepWithFiles([imgFile(), imgFile(), imgFile()])
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('diana-counter').textContent).toMatch(/0\s*\/\s*3/)
+  })
+
+  it('updates header counter for mixed approval states', () => {
+    const step = stepWithFiles([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'pending' }),
+      imgFile({ approval_state: 'approved' }),
+    ])
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('diana-counter').textContent).toMatch(/2\s*\/\s*3/)
+  })
+
+  it('disables the "Avançar" button until every image is approved', () => {
+    const step = stepWithFiles([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'pending' }),
+    ])
+    const onAdvance = vi.fn()
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+        onAdvance={onAdvance}
+      />,
+    )
+    const advance = screen.getByRole('button', { name: /avançar/i })
+    expect(advance).toBeDisabled()
+    fireEvent.click(advance)
+    expect(onAdvance).not.toHaveBeenCalled()
+  })
+
+  it('enables the "Avançar" button only when every image is approved', () => {
+    const step = stepWithFiles([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'approved' }),
+    ])
+    const onAdvance = vi.fn()
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+        onAdvance={onAdvance}
+      />,
+    )
+    const advance = screen.getByRole('button', { name: /avançar/i })
+    expect(advance).not.toBeDisabled()
+    fireEvent.click(advance)
+    expect(onAdvance).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onApprove with the file index when "Aprovar" is clicked', () => {
+    const step = stepWithFiles([imgFile(), imgFile()])
+    const onApprove = vi.fn()
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={onApprove}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+      />,
+    )
+    const thumb = screen.getByTestId('diana-thumb-1')
+    fireEvent.click(within(thumb).getByRole('button', { name: /aprovar/i }))
+    expect(onApprove).toHaveBeenCalledWith(1)
+  })
+
+  it('opens a feedback textarea when "Pedir ajuste" is clicked, and submits it via onRequestEdit', () => {
+    const step = stepWithFiles([imgFile(), imgFile()])
+    const onRequestEdit = vi.fn()
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={onRequestEdit}
+        onRerender={() => {}}
+      />,
+    )
+    const thumb = screen.getByTestId('diana-thumb-0')
+    fireEvent.click(within(thumb).getByRole('button', { name: /pedir ajuste/i }))
+    const textarea = within(thumb).getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'lighter colors' } })
+    fireEvent.click(within(thumb).getByRole('button', { name: /enviar feedback/i }))
+    expect(onRequestEdit).toHaveBeenCalledWith(0, 'lighter colors')
+  })
+
+  it('calls onRerender with file index (and current feedback) when "Re-renderizar" is clicked', () => {
+    const step = stepWithFiles([
+      imgFile({ approval_state: 'edit_requested', feedback: 'darker' }),
+    ])
+    const onRerender = vi.fn()
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={onRerender}
+      />,
+    )
+    const thumb = screen.getByTestId('diana-thumb-0')
+    fireEvent.click(within(thumb).getByRole('button', { name: /re-renderizar/i }))
+    expect(onRerender).toHaveBeenCalledWith(0, 'darker')
+  })
+
+  it('disables actions on a thumbnail while it is loading (rerender in flight)', () => {
+    const step = stepWithFiles([imgFile(), imgFile()])
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+        loadingIndices={[0]}
+      />,
+    )
+    const thumb = screen.getByTestId('diana-thumb-0')
+    const approve = within(thumb).getByRole('button', { name: /aprovar/i })
+    const rerender = within(thumb).getByRole('button', { name: /re-renderizar/i })
+    expect(approve).toBeDisabled()
+    expect(rerender).toBeDisabled()
+    // The other thumb's actions remain enabled.
+    const other = screen.getByTestId('diana-thumb-1')
+    expect(within(other).getByRole('button', { name: /aprovar/i })).not.toBeDisabled()
+  })
+
+  it('renders an empty-state message when there are no image files', () => {
+    const step = stepWithFiles([])
+    renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('diana-empty')).toBeInTheDocument()
+  })
+})

--- a/src/lib/dianaGallery.js
+++ b/src/lib/dianaGallery.js
@@ -1,0 +1,79 @@
+// Pure helpers for the per-file approval state machine used by Diana steps
+// (issue #357). Each entry of a step's `output_files[]` array carries an
+// optional `approval_state` field — `'pending' | 'approved' | 'edit_requested'`
+// — plus an optional `feedback` string when the user requests an adjustment.
+// The textual approval gate (issue #355) treats the whole step atomically;
+// Diana steps replace it with a per-image gate driven by these helpers.
+//
+// Every function returns a fresh step / array — never mutates input — so the
+// caller can confidently swap state into a React reducer.
+
+const VALID_STATES = new Set(['pending', 'approved', 'edit_requested'])
+
+const isImageFile = (file) =>
+  !!file && typeof file.mime_type === 'string' && file.mime_type.startsWith('image/')
+
+export function imageFiles(step) {
+  const files = step?.output_files
+  if (!Array.isArray(files)) return []
+  const out = []
+  for (let i = 0; i < files.length; i++) {
+    if (isImageFile(files[i])) out.push({ idx: i, file: files[i] })
+  }
+  return out
+}
+
+export function totalImages(step) {
+  return imageFiles(step).length
+}
+
+export function getFileApprovalState(file) {
+  const raw = file?.approval_state
+  return VALID_STATES.has(raw) ? raw : 'pending'
+}
+
+export function setFileApprovalState(step, fileIdx, state, feedback) {
+  if (!VALID_STATES.has(state)) {
+    throw new Error(`Unknown approval state: ${state}`)
+  }
+  const files = Array.isArray(step?.output_files) ? step.output_files : []
+  if (fileIdx < 0 || fileIdx >= files.length) {
+    throw new Error(`file index ${fileIdx} out of range`)
+  }
+  const target = files[fileIdx]
+  const next = { ...target, approval_state: state }
+  if (state === 'edit_requested' && typeof feedback === 'string' && feedback.trim()) {
+    next.feedback = feedback.trim()
+  } else {
+    delete next.feedback
+  }
+  const nextFiles = files.slice()
+  nextFiles[fileIdx] = next
+  return { ...step, output_files: nextFiles }
+}
+
+export function applyFileRerender(step, fileIdx, newFile) {
+  const files = Array.isArray(step?.output_files) ? step.output_files : []
+  if (fileIdx < 0 || fileIdx >= files.length) {
+    throw new Error(`file index ${fileIdx} out of range`)
+  }
+  const merged = { ...newFile, approval_state: 'pending' }
+  delete merged.feedback
+  const nextFiles = files.slice()
+  nextFiles[fileIdx] = merged
+  return { ...step, output_files: nextFiles }
+}
+
+export function countApproved(step) {
+  let count = 0
+  for (const { file } of imageFiles(step)) {
+    if (getFileApprovalState(file) === 'approved') count++
+  }
+  return count
+}
+
+export function isFullyApproved(step) {
+  const images = imageFiles(step)
+  if (images.length === 0) return false
+  return images.every(({ file }) => getFileApprovalState(file) === 'approved')
+}

--- a/src/lib/dianaGallery.test.js
+++ b/src/lib/dianaGallery.test.js
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyFileRerender,
+  countApproved,
+  getFileApprovalState,
+  imageFiles,
+  isFullyApproved,
+  setFileApprovalState,
+  totalImages,
+} from './dianaGallery'
+
+const buildStep = (files = []) => ({
+  id: 1,
+  agent_id: 'diana-design',
+  status: 'awaiting_approval',
+  output_files: files,
+})
+
+const imgFile = (overrides = {}) => ({
+  storage_path: 'tasks/abc/feed_001.jpg',
+  signed_url: 'https://example.com/feed_001.jpg',
+  mime_type: 'image/jpeg',
+  width: 1080,
+  height: 1080,
+  ...overrides,
+})
+
+describe('imageFiles', () => {
+  it('returns only image files with their original indices', () => {
+    const step = buildStep([
+      imgFile({ storage_path: 'a.jpg' }),
+      { mime_type: 'application/pdf', storage_path: 'b.pdf' },
+      imgFile({ storage_path: 'c.png', mime_type: 'image/png' }),
+    ])
+    const result = imageFiles(step)
+    expect(result).toHaveLength(2)
+    expect(result[0].idx).toBe(0)
+    expect(result[1].idx).toBe(2)
+    expect(result[0].file.storage_path).toBe('a.jpg')
+    expect(result[1].file.storage_path).toBe('c.png')
+  })
+
+  it('handles missing or non-array output_files', () => {
+    expect(imageFiles({})).toEqual([])
+    expect(imageFiles({ output_files: null })).toEqual([])
+    expect(imageFiles({ output_files: 'nope' })).toEqual([])
+  })
+})
+
+describe('totalImages', () => {
+  it('counts image files only', () => {
+    const step = buildStep([
+      imgFile(),
+      { mime_type: 'video/mp4' },
+      imgFile({ mime_type: 'image/png' }),
+    ])
+    expect(totalImages(step)).toBe(2)
+  })
+})
+
+describe('getFileApprovalState', () => {
+  it('defaults to pending when not set', () => {
+    expect(getFileApprovalState(imgFile())).toBe('pending')
+  })
+
+  it('reads explicit approval_state', () => {
+    expect(getFileApprovalState(imgFile({ approval_state: 'approved' }))).toBe(
+      'approved',
+    )
+    expect(
+      getFileApprovalState(imgFile({ approval_state: 'edit_requested' })),
+    ).toBe('edit_requested')
+  })
+
+  it('falls back to pending for unknown state values', () => {
+    expect(getFileApprovalState(imgFile({ approval_state: 'banana' }))).toBe(
+      'pending',
+    )
+  })
+})
+
+describe('setFileApprovalState', () => {
+  it('returns a new step with updated file approval_state', () => {
+    const step = buildStep([imgFile(), imgFile()])
+    const next = setFileApprovalState(step, 0, 'approved')
+    expect(next).not.toBe(step)
+    expect(next.output_files[0].approval_state).toBe('approved')
+    expect(next.output_files[1].approval_state).toBeUndefined()
+  })
+
+  it('persists feedback when transitioning to edit_requested', () => {
+    const step = buildStep([imgFile()])
+    const next = setFileApprovalState(step, 0, 'edit_requested', 'lighter colors')
+    expect(next.output_files[0].approval_state).toBe('edit_requested')
+    expect(next.output_files[0].feedback).toBe('lighter colors')
+  })
+
+  it('clears feedback when transitioning to approved', () => {
+    const step = buildStep([
+      imgFile({ approval_state: 'edit_requested', feedback: 'lighter' }),
+    ])
+    const next = setFileApprovalState(step, 0, 'approved')
+    expect(next.output_files[0].approval_state).toBe('approved')
+    expect(next.output_files[0].feedback).toBeUndefined()
+  })
+
+  it('throws on out-of-range index', () => {
+    const step = buildStep([imgFile()])
+    expect(() => setFileApprovalState(step, 5, 'approved')).toThrow(
+      /file index/i,
+    )
+  })
+
+  it('rejects unknown states', () => {
+    const step = buildStep([imgFile()])
+    expect(() => setFileApprovalState(step, 0, 'banana')).toThrow(
+      /approval state/i,
+    )
+  })
+})
+
+describe('applyFileRerender', () => {
+  it('replaces file at idx and resets approval_state to pending', () => {
+    const step = buildStep([
+      imgFile({ approval_state: 'edit_requested', feedback: 'darker' }),
+      imgFile({ approval_state: 'approved' }),
+    ])
+    const newFile = imgFile({ storage_path: 'tasks/abc/feed_001_v2.jpg' })
+    const next = applyFileRerender(step, 0, newFile)
+    expect(next.output_files[0].storage_path).toBe(
+      'tasks/abc/feed_001_v2.jpg',
+    )
+    expect(next.output_files[0].approval_state).toBe('pending')
+    expect(next.output_files[0].feedback).toBeUndefined()
+    expect(next.output_files[1].approval_state).toBe('approved')
+  })
+
+  it('throws on out-of-range index', () => {
+    const step = buildStep([imgFile()])
+    expect(() => applyFileRerender(step, 5, imgFile())).toThrow(/file index/i)
+  })
+})
+
+describe('countApproved', () => {
+  it('counts only approved image files', () => {
+    const step = buildStep([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'pending' }),
+      imgFile({ approval_state: 'approved' }),
+      { mime_type: 'video/mp4', approval_state: 'approved' },
+    ])
+    expect(countApproved(step)).toBe(2)
+  })
+})
+
+describe('isFullyApproved', () => {
+  it('is true when every image file is approved', () => {
+    const step = buildStep([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'approved' }),
+    ])
+    expect(isFullyApproved(step)).toBe(true)
+  })
+
+  it('is false when any image file is not approved', () => {
+    const step = buildStep([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'pending' }),
+    ])
+    expect(isFullyApproved(step)).toBe(false)
+  })
+
+  it('is false when there are no image files at all', () => {
+    expect(isFullyApproved(buildStep([]))).toBe(false)
+  })
+})

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -759,7 +759,8 @@ Deno.serve(async (req: Request) => {
   const isTemplateMode =
     mode === 'template_execute' ||
     mode === 'template_approve' ||
-    mode === 'template_retry'
+    mode === 'template_retry' ||
+    mode === 'template_rerender_file'
 
   const messages = Array.isArray(body.messages) ? body.messages : []
   const cleanMessages = messages

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -823,12 +823,100 @@ Deno.serve(async (req: Request) => {
           const stepId =
             typeof body.step_id === 'number' ? body.step_id : null
           if (
-            (mode === 'template_approve' || mode === 'template_retry') &&
+            (mode === 'template_approve' ||
+              mode === 'template_retry' ||
+              mode === 'template_rerender_file') &&
             stepId === null
           ) {
             emit('run.error', {
               error: `${mode} requires a numeric step_id`,
             })
+            return
+          }
+          if (mode === 'template_rerender_file') {
+            const fileIdx =
+              typeof body.file_idx === 'number' ? body.file_idx : -1
+            if (fileIdx < 0) {
+              emit('run.error', {
+                error: 'template_rerender_file requires a numeric file_idx',
+              })
+              return
+            }
+            emit('router.classified', { mode })
+            const timeoutController = new AbortController()
+            const timeoutId = setTimeout(
+              () => timeoutController.abort(),
+              RUN_TIMEOUT_MS,
+            )
+            try {
+              const renderHandler = TOOL_HANDLERS.render_html_to_image
+              if (!renderHandler) {
+                emit('run.error', {
+                  error: 'render_html_to_image tool is not registered',
+                })
+                return
+              }
+              const renderFile = async (req: {
+                html: string
+                width: number
+                height: number
+                feedback?: string
+              }) => {
+                const ctx = {
+                  userId,
+                  taskId:
+                    typeof task.id === 'string' ? task.id : `task-${task.id}`,
+                  stepId: stepId!,
+                  stepOrder: stepId!,
+                  toolCallId: `rerender-${stepId}-${fileIdx}-${Date.now()}`,
+                  signal: timeoutController.signal,
+                } as any
+                const out = await renderHandler(
+                  {
+                    html: req.html,
+                    width: req.width,
+                    height: req.height,
+                  },
+                  ctx,
+                )
+                if (!out.ok || !out.result) {
+                  throw new Error(
+                    out.error ||
+                      'render_html_to_image failed without an error message',
+                  )
+                }
+                return out.result as {
+                  storage_path: string
+                  signed_url: string
+                  mime_type: string
+                  width: number
+                  height: number
+                }
+              }
+              const result = await rerenderStepFile(
+                task,
+                stepId!,
+                fileIdx,
+                {
+                  renderFile,
+                  feedback:
+                    typeof body.feedback === 'string'
+                      ? body.feedback
+                      : undefined,
+                },
+              )
+              emit('step.file.rerendered', {
+                step_id: stepId,
+                file_idx: fileIdx,
+                file: result.newFile,
+              })
+              emit('task.updated', { task: result.task })
+              emit('run.done', { task_id: task.id })
+            } catch (err) {
+              emit('run.error', { error: (err as Error).message })
+            } finally {
+              clearTimeout(timeoutId)
+            }
             return
           }
           emit('router.classified', { mode })

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -13,7 +13,11 @@
 
 // deno-lint-ignore-file no-explicit-any
 
-import { analyzeRequirements, runExecutorBranch } from './executor.ts'
+import {
+  analyzeRequirements,
+  runExecutorBranch,
+  TOOL_HANDLERS,
+} from './executor.ts'
 import { runSelectedAgentBranch } from './selectedAgentBranch.ts'
 import {
   resumeTemplateApprove,
@@ -21,6 +25,7 @@ import {
   runTemplateExecutor,
   type TemplateExecutorDeps,
 } from './templateExecutorBranch.ts'
+import { rerenderStepFile } from './templateRerenderFile.ts'
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const CHAT_MODEL = Deno.env.get('CHAT_MODEL') || 'claude-sonnet-4-6'

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -722,6 +722,7 @@ Deno.serve(async (req: Request) => {
     references?: Record<string, unknown>
     params?: Record<string, string>
     step_id?: number
+    file_idx?: number
     feedback?: string
   }
   try {

--- a/supabase/functions/chat/templateRerenderFile.test.ts
+++ b/supabase/functions/chat/templateRerenderFile.test.ts
@@ -1,0 +1,202 @@
+// Tests for the per-file rerender helper used by Diana steps (issue #357).
+// The module is pure: it takes a task snapshot and a renderFile callback,
+// validates the request, invokes the callback exactly once for a single
+// output_file, and returns a fresh task with the file replaced.
+
+import { assert, assertEquals, assertRejects } from 'jsr:@std/assert@1'
+
+import { rerenderStepFile } from './templateRerenderFile.ts'
+
+const baseFile = (overrides: Record<string, unknown> = {}) => ({
+  storage_path: 'tasks/abc/feed_001.jpg',
+  signed_url: 'https://example.com/feed_001.jpg',
+  mime_type: 'image/jpeg',
+  width: 1080,
+  height: 1080,
+  source_html: '<html><body>v1</body></html>',
+  approval_state: 'edit_requested',
+  feedback: 'lighten the background',
+  ...overrides,
+})
+
+function baseTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task-1',
+    status: 'awaiting_approval',
+    plan: {
+      steps: [
+        {
+          id: 1,
+          agent_id: 'diana-design',
+          status: 'awaiting_approval',
+          requires_approval: true,
+          output_files: [
+            baseFile(),
+            baseFile({
+              storage_path: 'tasks/abc/feed_002.jpg',
+              approval_state: 'approved',
+            }),
+          ],
+        },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+Deno.test('rerenderStepFile — invokes renderFile exactly once with stored html + dims', async () => {
+  const calls: Array<Record<string, unknown>> = []
+  const renderFile = (req: any) => {
+    calls.push(req)
+    return Promise.resolve({
+      storage_path: 'tasks/abc/feed_001_v2.jpg',
+      signed_url: 'https://example.com/feed_001_v2.jpg',
+      mime_type: 'image/jpeg',
+      width: 1080,
+      height: 1080,
+    })
+  }
+  const result = await rerenderStepFile(baseTask(), 1, 0, { renderFile })
+  assertEquals(calls.length, 1)
+  assertEquals(calls[0].html, '<html><body>v1</body></html>')
+  assertEquals(calls[0].width, 1080)
+  assertEquals(calls[0].height, 1080)
+  // The rerendered file replaces idx 0 only.
+  assertEquals(
+    result.task.plan.steps[0].output_files[0].storage_path,
+    'tasks/abc/feed_001_v2.jpg',
+  )
+  assertEquals(
+    result.task.plan.steps[0].output_files[1].storage_path,
+    'tasks/abc/feed_002.jpg',
+  )
+  // Approved file at idx 1 is preserved untouched.
+  assertEquals(
+    result.task.plan.steps[0].output_files[1].approval_state,
+    'approved',
+  )
+})
+
+Deno.test('rerenderStepFile — resets the rerendered file approval_state to pending', async () => {
+  const renderFile = () =>
+    Promise.resolve({
+      storage_path: 'new.jpg',
+      signed_url: 'https://example.com/new.jpg',
+      mime_type: 'image/jpeg',
+      width: 1080,
+      height: 1080,
+    })
+  const result = await rerenderStepFile(baseTask(), 1, 0, { renderFile })
+  assertEquals(result.task.plan.steps[0].output_files[0].approval_state, 'pending')
+  assertEquals(
+    result.task.plan.steps[0].output_files[0].feedback,
+    undefined,
+  )
+})
+
+Deno.test('rerenderStepFile — propagates user-provided feedback into the renderFile call', async () => {
+  let received: Record<string, unknown> | null = null
+  const renderFile = (req: any) => {
+    received = req
+    return Promise.resolve({
+      storage_path: 'new.jpg',
+      signed_url: 'https://example.com/new.jpg',
+      mime_type: 'image/jpeg',
+      width: 1080,
+      height: 1080,
+    })
+  }
+  await rerenderStepFile(baseTask(), 1, 0, {
+    renderFile,
+    feedback: 'darker tones',
+  })
+  assert(received !== null)
+  assertEquals((received as Record<string, unknown>).feedback, 'darker tones')
+})
+
+Deno.test('rerenderStepFile — rejects when step does not exist', async () => {
+  const renderFile = () =>
+    Promise.resolve({
+      storage_path: 'x',
+      signed_url: 'x',
+      mime_type: 'image/jpeg',
+      width: 1,
+      height: 1,
+    })
+  await assertRejects(
+    () => rerenderStepFile(baseTask(), 999, 0, { renderFile }),
+    Error,
+    'step',
+  )
+})
+
+Deno.test('rerenderStepFile — rejects when file index is out of range', async () => {
+  const renderFile = () =>
+    Promise.resolve({
+      storage_path: 'x',
+      signed_url: 'x',
+      mime_type: 'image/jpeg',
+      width: 1,
+      height: 1,
+    })
+  await assertRejects(
+    () => rerenderStepFile(baseTask(), 1, 99, { renderFile }),
+    Error,
+    'file',
+  )
+})
+
+Deno.test('rerenderStepFile — rejects when target file is not an image', async () => {
+  const task = baseTask()
+  task.plan.steps[0].output_files[0] = {
+    ...baseFile(),
+    mime_type: 'application/pdf',
+  }
+  const renderFile = () =>
+    Promise.resolve({
+      storage_path: 'x',
+      signed_url: 'x',
+      mime_type: 'image/jpeg',
+      width: 1,
+      height: 1,
+    })
+  await assertRejects(
+    () => rerenderStepFile(task, 1, 0, { renderFile }),
+    Error,
+    'image',
+  )
+})
+
+Deno.test('rerenderStepFile — rejects when source_html is missing', async () => {
+  const task = baseTask()
+  delete (task.plan.steps[0].output_files[0] as Record<string, unknown>).source_html
+  const renderFile = () =>
+    Promise.resolve({
+      storage_path: 'x',
+      signed_url: 'x',
+      mime_type: 'image/jpeg',
+      width: 1,
+      height: 1,
+    })
+  await assertRejects(
+    () => rerenderStepFile(task, 1, 0, { renderFile }),
+    Error,
+    'source_html',
+  )
+})
+
+Deno.test('rerenderStepFile — preserves source_html on the rerendered file so subsequent rerenders work', async () => {
+  const renderFile = () =>
+    Promise.resolve({
+      storage_path: 'tasks/abc/feed_001_v2.jpg',
+      signed_url: 'https://example.com/feed_001_v2.jpg',
+      mime_type: 'image/jpeg',
+      width: 1080,
+      height: 1080,
+    })
+  const result = await rerenderStepFile(baseTask(), 1, 0, { renderFile })
+  assertEquals(
+    result.task.plan.steps[0].output_files[0].source_html,
+    '<html><body>v1</body></html>',
+  )
+})

--- a/supabase/functions/chat/templateRerenderFile.ts
+++ b/supabase/functions/chat/templateRerenderFile.ts
@@ -1,0 +1,98 @@
+// Per-file rerender for Diana steps (issue #357).
+//
+// When the user clicks "Re-renderizar" on a single thumbnail in the Diana
+// gallery, the chat function dispatches into this helper. It locates the
+// target step + output_file, re-invokes `render_html_to_image` for that
+// single file via the supplied `renderFile` callback, and returns a fresh
+// task snapshot with the file replaced and its `approval_state` reset to
+// `'pending'`. Sibling files — including ones already approved — are
+// untouched.
+//
+// The module is intentionally pure: storage and DB writes happen in the
+// caller (`chat/index.ts`). Tests inject a fake `renderFile` to assert the
+// call shape and count without spinning up Browserless.
+
+// deno-lint-ignore-file no-explicit-any
+
+export interface RerenderFileRequest {
+  html: string
+  width: number
+  height: number
+  feedback?: string
+}
+
+export interface RerenderFileResult {
+  storage_path: string
+  signed_url: string
+  mime_type: 'image/jpeg' | string
+  width: number
+  height: number
+}
+
+export interface RerenderStepFileDeps {
+  renderFile: (req: RerenderFileRequest) => Promise<RerenderFileResult>
+  feedback?: string
+}
+
+export interface RerenderStepFileOutcome {
+  task: any
+  newFile: RerenderFileResult
+}
+
+const isImageMime = (m: unknown) =>
+  typeof m === 'string' && m.startsWith('image/')
+
+export async function rerenderStepFile(
+  task: any,
+  stepId: number,
+  fileIdx: number,
+  deps: RerenderStepFileDeps,
+): Promise<RerenderStepFileOutcome> {
+  const steps: any[] = Array.isArray(task?.plan?.steps) ? task.plan.steps : []
+  const stepPos = steps.findIndex((s: any) => s && s.id === stepId)
+  if (stepPos < 0) {
+    throw new Error(`step ${stepId} not found`)
+  }
+  const step = steps[stepPos]
+  const files: any[] = Array.isArray(step.output_files) ? step.output_files : []
+  if (fileIdx < 0 || fileIdx >= files.length) {
+    throw new Error(`file index ${fileIdx} out of range`)
+  }
+  const target = files[fileIdx]
+  if (!isImageMime(target?.mime_type)) {
+    throw new Error('target file is not an image')
+  }
+  const html = typeof target.source_html === 'string' ? target.source_html : ''
+  if (!html.trim()) {
+    throw new Error(
+      'cannot rerender — source_html is missing on the target file',
+    )
+  }
+  const width = typeof target.width === 'number' ? target.width : 0
+  const height = typeof target.height === 'number' ? target.height : 0
+
+  const newFile = await deps.renderFile({
+    html,
+    width,
+    height,
+    feedback: deps.feedback,
+  })
+
+  const merged: Record<string, unknown> = {
+    ...newFile,
+    source_html: html,
+    approval_state: 'pending',
+  }
+  // Drop any stale feedback so the freshly-rendered file starts clean.
+  delete merged.feedback
+
+  const nextFiles = files.slice()
+  nextFiles[fileIdx] = merged
+  const nextSteps = steps.slice()
+  nextSteps[stepPos] = { ...step, output_files: nextFiles }
+  const nextTask = {
+    ...task,
+    plan: { ...task.plan, steps: nextSteps },
+  }
+  return { task: nextTask, newFile }
+}


### PR DESCRIPTION
Closes #357

## Summary

Adds the per-image approval gate that replaces the textual approval gate
for steps whose agent is `diana-design` in template-mode tasks. Three
deep modules, all co-tested:

- `src/lib/dianaGallery.js` — pure helpers for the per-file approval
  state machine (`approval_state` ∈ `pending | approved | edit_requested`,
  optional `feedback`). Every helper returns a fresh step.
- `src/components/orchestration/DianaGallery.jsx` — gallery UI with
  thumbnails, per-thumb Aprovar/Pedir ajuste/Re-renderizar actions,
  live "N/M aprovados" counter, and a footer Avançar button gated on
  full-batch approval.
- `supabase/functions/chat/templateRerenderFile.ts` — pure rerender
  helper that re-invokes a `renderFile` callback for ONE output_file
  using its stored `source_html`/dimensions, replaces the file at the
  target idx, resets that file's `approval_state` to `pending`, and
  preserves sibling files (including approved ones) untouched.

`chat/index.ts` gains a new request mode `template_rerender_file` that
constructs a `renderFile` callback bound to
`TOOL_HANDLERS.render_html_to_image` and dispatches into the helper.
The new mode emits a `step.file.rerendered` event plus the standard
`task.updated` / `run.done` pair.

## TDD
- Tests added:
  - `src/lib/dianaGallery.test.js` (17 tests)
  - `src/components/orchestration/DianaGallery.test.jsx` (11 tests)
  - `supabase/functions/chat/templateRerenderFile.test.ts` (8 tests)
- Before implementation (red):
  - `dianaGallery.test.js` failed with `Failed to resolve import "./dianaGallery"`.
  - `DianaGallery.test.jsx` failed with `Failed to resolve import "./DianaGallery"`.
  - `templateRerenderFile.test.ts` failed with `Cannot find module 'templateRerenderFile.ts'`.
- After implementation (green):
  - `npm test` → 562 passed, 0 failed.
  - `npm run test:functions` → 206 passed, 0 failed.
  - `npm run lint` → 0 errors, 26 warnings (all pre-existing).

## Notes

- BoardPage integration of the gallery is intentionally deferred to a
  follow-up PR — issue #355 (textual approval gate UI, currently
  `claude-working`) owns the integration surface. This PR ships the
  gallery component, state machine, and rerender endpoint so #355 can
  plug them in once it lands.
- The rerender endpoint relies on each `output_files[i]` carrying a
  `source_html` field (and `width`/`height`) when it was first rendered.
  Persisting `source_html` on tool-result emission is the executor's
  responsibility (slice #351 / templateExecutorBranch follow-up); this
  PR throws a clear "source_html missing" error if a caller invokes
  rerender on a file that lacks it, so the contract is explicit.