### PR TITLE
fix: nest Templates under Board in sidebar (#389)

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -11,12 +11,48 @@ export default function Sidebar() {
   const { user, signOut } = useAuth()
 
   const browseItems = [
-    { icon: Columns3, label: 'Board', path: '/board' },
-    { icon: LayoutTemplate, label: 'Templates', path: '/templates' },
+    {
+      icon: Columns3,
+      label: 'Board',
+      path: '/board',
+      children: [
+        { icon: LayoutTemplate, label: 'Templates', path: '/templates' },
+      ],
+    },
     { icon: Bot, label: 'Agents', count: agents.length, path: '/' },
     { icon: Users, label: 'Teams', count: teams.length, path: '/teams' },
     { icon: Wand2, label: 'Skills', path: '/skills' },
   ]
+
+  const renderNavLink = (item, { nested = false } = {}) => {
+    const isActive = item.path === '/'
+      ? location.pathname === '/' || location.pathname.startsWith('/agent') || location.pathname === '/create'
+      : location.pathname.startsWith(item.path)
+    return (
+      <Link
+        key={item.label}
+        to={item.path}
+        title={collapsed ? item.label : undefined}
+        className={`flex items-center ${collapsed ? 'justify-center px-0 py-2.5' : `gap-3 ${nested ? 'pl-8 pr-3' : 'px-3'} py-2`} rounded-lg text-sm transition-all duration-150 group ${
+          isActive
+            ? 'bg-accent-blue/10 text-accent-blue font-medium'
+            : 'text-text-secondary hover:bg-white/5 hover:text-text-primary'
+        }`}
+      >
+        <item.icon size={nested && !collapsed ? 16 : 18} className={isActive ? 'text-accent-blue' : 'text-text-muted group-hover:text-text-secondary'} />
+        {!collapsed && (
+          <>
+            <span className="flex-1">{item.label}</span>
+            {item.count && (
+              <span className={`text-xs font-mono ${isActive ? 'text-accent-blue/70' : 'text-text-muted'}`}>
+                {item.count}
+              </span>
+            )}
+          </>
+        )}
+      </Link>
+    )
+  }
 
   return (
     <aside className={`${collapsed ? 'w-[68px]' : 'w-56'} min-h-screen bg-bg-sidebar border-r border-border-subtle flex flex-col shrink-0 transition-all duration-200`}>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -94,35 +94,12 @@ export default function Sidebar() {
           <p className="text-[11px] font-semibold uppercase tracking-wider text-text-muted px-2 mb-2">Browse</p>
         )}
         <nav className="flex flex-col gap-0.5">
-          {browseItems.map((item) => {
-            const isActive = item.path === '/'
-              ? location.pathname === '/' || location.pathname.startsWith('/agent') || location.pathname === '/create'
-              : location.pathname.startsWith(item.path)
-            return (
-              <Link
-                key={item.label}
-                to={item.path}
-                title={collapsed ? item.label : undefined}
-                className={`flex items-center ${collapsed ? 'justify-center px-0 py-2.5' : 'gap-3 px-3 py-2'} rounded-lg text-sm transition-all duration-150 group ${
-                  isActive
-                    ? 'bg-accent-blue/10 text-accent-blue font-medium'
-                    : 'text-text-secondary hover:bg-white/5 hover:text-text-primary'
-                }`}
-              >
-                <item.icon size={18} className={isActive ? 'text-accent-blue' : 'text-text-muted group-hover:text-text-secondary'} />
-                {!collapsed && (
-                  <>
-                    <span className="flex-1">{item.label}</span>
-                    {item.count && (
-                      <span className={`text-xs font-mono ${isActive ? 'text-accent-blue/70' : 'text-text-muted'}`}>
-                        {item.count}
-                      </span>
-                    )}
-                  </>
-                )}
-              </Link>
-            )
-          })}
+          {browseItems.map((item) => (
+            <div key={item.label} className="flex flex-col gap-0.5">
+              {renderNavLink(item)}
+              {item.children && item.children.map((child) => renderNavLink(child, { nested: true }))}
+            </div>
+          ))}
         </nav>
       </div>
 

--- a/src/components/Sidebar.test.jsx
+++ b/src/components/Sidebar.test.jsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../test/test-utils'
+import Sidebar from './Sidebar'
+
+vi.mock('../lib/api', () => ({
+  fetchTeams: vi.fn().mockResolvedValue([]),
+  fetchTools: vi.fn().mockResolvedValue([]),
+  trackAgentUsage: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('../lib/agentsRepo', () => ({
+  listAgents: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../lib/supabase', () => ({
+  supabase: null,
+}))
+
+describe('Sidebar', () => {
+  it('renders Board and Templates links with the correct hrefs', () => {
+    renderWithProviders(<Sidebar />)
+    expect(screen.getByRole('link', { name: 'Board' })).toHaveAttribute('href', '/board')
+    expect(screen.getByRole('link', { name: 'Templates' })).toHaveAttribute('href', '/templates')
+  })
+
+  it('nests Templates under Board instead of rendering it as a top-level entry', () => {
+    renderWithProviders(<Sidebar />)
+    const boardLink = screen.getByRole('link', { name: 'Board' })
+    const templatesLink = screen.getByRole('link', { name: 'Templates' })
+    const agentsLink = screen.getByRole('link', { name: /^Agents/ })
+
+    // Templates must live inside Board's wrapper, deeper than the top-level entries.
+    expect(boardLink.parentElement).toContainElement(templatesLink)
+    // Top-level entries (Board, Agents) share the same direct parent; Templates does not.
+    expect(templatesLink.parentElement).not.toBe(agentsLink.parentElement)
+  })
+})


### PR DESCRIPTION
Closes #389

## Summary
Moves the **Templates** entry out of the top level of the side navigation and renders it as a nested child under **Board**. The link target (`/templates`) is unchanged; only the visual hierarchy and DOM structure change.

## TDD
- Tests added: `src/components/Sidebar.test.jsx`
- Before implementation (red): `Sidebar > nests Templates under Board instead of rendering it as a top-level entry` failed because Templates and Agents shared the same direct parent (`<nav>`).
- After implementation (green): all 564 tests pass; both new sidebar tests pass.

## Notes
- Extracted a small `renderNavLink(item, { nested })` helper so the parent and child entries share the same active-state and collapsed-mode logic without duplicating markup.
- Nested children get a `pl-8` indent and a slightly smaller icon (16 vs 18) when the sidebar is expanded; when collapsed, every icon stacks centered as before.