### PR TITLE
test(chat): assert desktop AiAssistant has no mic input (#392)

### DIFF
--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -108,6 +108,12 @@ describe('AiAssistant', () => {
     expect(screen.getByText(/Hi! I'm your AI assistant/)).toBeInTheDocument()
   })
 
+  it('does not render the mic / voice input button', () => {
+    renderWithProviders(<AiAssistant open={true} onClose={() => {}} />)
+    expect(screen.queryByLabelText(/Voice input/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Stop voice input/i)).not.toBeInTheDocument()
+  })
+
   it('streams an assistant reply from the session', async () => {
     scriptSession([
       { type: 'router.classified', mode: 'chat' },


### PR DESCRIPTION
Closes #392

## TDD
- Tests added/modified: `src/components/AiAssistant.test.jsx`
- Before implementation (red): n/a — the production fix landed in #391/PR #406 (commit ae4508a), which removed the mic FAB, `lib/voice.js`, and all associated state from `MobileChat.jsx`. The desktop `AiAssistant.jsx` never had a mic icon. Issue #392 duplicates #391 but explicitly asks to verify the removal on **both** mobile and desktop. Mobile already has a regression test (`does not render the mic / voice input button` in `MobileChat.test.jsx`); the desktop did not. This PR adds the equivalent assertion for the desktop chat so a future re-introduction is caught by CI.
- After implementation (green): full frontend suite passes — 547 tests across 49 files.

## Notes
- The new test mirrors the mobile regression test exactly (same `queryByLabelText(/Voice input/i)` / `/Stop voice input/i` matchers) so any future "voice input" UI surfaces in either platform will trip a test.
- No production code changes; no lint regressions.