### PR TITLE
fix(mobile): make plan execution card expandable in chat (#393)

### DIFF
--- a/src/components/mobile/MobileChat.jsx
+++ b/src/components/mobile/MobileChat.jsx
@@ -399,6 +399,9 @@ export default function MobileChat() {
                     <MobilePlanCard
                       plan={msg.plan}
                       status={msg.planStatus || 'proposed'}
+                      stepStates={msg.stepStates}
+                      runError={msg.runError}
+                      runSummary={msg.runSummary}
                       onApprove={() => {
                         // Plan approval kicks off an execute session; this is a
                         // mobile-friendly pass-through that mirrors the desktop

--- a/src/components/mobile/MobileChat.jsx
+++ b/src/components/mobile/MobileChat.jsx
@@ -152,10 +152,71 @@ export default function MobileChat() {
           unsubscribe()
           break
         case 'run.started':
-          patchMessageAt(messageIdx, { planStatus: 'executing' })
+          patchMessageAt(messageIdx, {
+            planStatus: 'executing',
+            stepStates: {},
+          })
+          break
+        case 'step.started':
+          patchMessageAt(messageIdx, (msg) => ({
+            ...msg,
+            stepStates: {
+              ...(msg.stepStates || {}),
+              [event.step_id]: { status: 'running', text: '' },
+            },
+          }))
+          break
+        case 'step.text':
+          patchMessageAt(messageIdx, (msg) => {
+            const prev = msg.stepStates?.[event.step_id] || {
+              status: 'running',
+              text: '',
+            }
+            return {
+              ...msg,
+              stepStates: {
+                ...(msg.stepStates || {}),
+                [event.step_id]: {
+                  ...prev,
+                  text: (prev.text || '') + (event.value || ''),
+                },
+              },
+            }
+          })
+          break
+        case 'step.done':
+          patchMessageAt(messageIdx, (msg) => {
+            const prev = msg.stepStates?.[event.step_id] || { text: '' }
+            return {
+              ...msg,
+              stepStates: {
+                ...(msg.stepStates || {}),
+                [event.step_id]: { ...prev, status: 'done' },
+              },
+            }
+          })
+          break
+        case 'step.error':
+          patchMessageAt(messageIdx, (msg) => {
+            const prev = msg.stepStates?.[event.step_id] || { text: '' }
+            return {
+              ...msg,
+              stepStates: {
+                ...(msg.stepStates || {}),
+                [event.step_id]: {
+                  ...prev,
+                  status: 'error',
+                  error: event.error,
+                },
+              },
+            }
+          })
           break
         case 'run.done':
-          patchMessageAt(messageIdx, { planStatus: 'done' })
+          patchMessageAt(messageIdx, {
+            planStatus: 'done',
+            runSummary: event.summary || null,
+          })
           setIsStreaming(false)
           sessionRef.current = null
           unsubscribe()

--- a/src/components/mobile/MobileChat.test.jsx
+++ b/src/components/mobile/MobileChat.test.jsx
@@ -226,6 +226,55 @@ describe('MobileChat', () => {
     expect(screen.getByText('Backend Developer')).toBeInTheDocument()
   })
 
+  it('expands plan card to show per-step results streamed from step events', async () => {
+    scriptSession([
+      {
+        type: 'plan.proposed',
+        plan: {
+          id: 'plan-1',
+          steps: [
+            {
+              id: 1,
+              agent_id: 'frontend-developer',
+              agent_name: 'Frontend Developer',
+              task: 'Build UI',
+            },
+          ],
+        },
+      },
+    ])
+    scriptSession([
+      { type: 'run.started', run_id: 'run-1' },
+      { type: 'step.started', step_id: 1 },
+      { type: 'step.text', step_id: 1, value: 'Component scaffolded.' },
+      { type: 'step.done', step_id: 1 },
+      { type: 'run.done', summary: { duration_ms: 1234 } },
+    ])
+
+    const user = userEvent.setup()
+    renderWithProviders(<MobileChat />)
+
+    await user.type(screen.getByPlaceholderText(/Type a message/i), 'plan it')
+    await user.click(screen.getByLabelText(/Send message/i))
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 step/i)).toBeInTheDocument()
+    })
+
+    // Approve to kick off the execute session.
+    await user.click(screen.getByRole('button', { name: /^Approve$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Done/i)).toBeInTheDocument()
+    })
+
+    // Expand and assert step text shows up.
+    await user.click(
+      screen.getByRole('button', { name: /show details|expand plan/i }),
+    )
+    expect(screen.getByText('Component scaffolded.')).toBeInTheDocument()
+  })
+
   it('agent picker bottom sheet selects an agent and forwards selectedAgentId to startSession', async () => {
     scriptSession([
       { type: 'chat.text', value: 'hello' },

--- a/src/components/mobile/MobilePlanCard.jsx
+++ b/src/components/mobile/MobilePlanCard.jsx
@@ -1,10 +1,42 @@
 // Compact plan summary tailored for the mobile chat. Renders the proposed
 // steps and exposes Approve/Cancel buttons. Mirrors the desktop PlanCard but
-// drops layout that does not fit the narrow viewport.
+// drops layout that does not fit the narrow viewport. The card is expandable:
+// tapping the toggle reveals every step in full (no truncation), each step's
+// live status / result text, and any error surfaced during execution.
 
-import { Loader2 } from 'lucide-react'
+import { useState } from 'react'
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Circle,
+  Loader2,
+} from 'lucide-react'
 
-export default function MobilePlanCard({ plan, status = 'proposed', onApprove, onCancel }) {
+function StepStatusIcon({ status }) {
+  if (status === 'running') {
+    return <Loader2 size={14} className="animate-spin text-blue-300 shrink-0" />
+  }
+  if (status === 'done') {
+    return <CheckCircle2 size={14} className="text-emerald-400 shrink-0" />
+  }
+  if (status === 'error') {
+    return <AlertCircle size={14} className="text-rose-400 shrink-0" />
+  }
+  return <Circle size={14} className="text-text-muted shrink-0" />
+}
+
+export default function MobilePlanCard({
+  plan,
+  status = 'proposed',
+  stepStates = {},
+  runError,
+  runSummary,
+  onApprove,
+  onCancel,
+}) {
+  const [expanded, setExpanded] = useState(false)
   const steps = Array.isArray(plan?.steps) ? plan.steps : []
   const stepCount = steps.length
   const isProposed = status === 'proposed'
@@ -12,28 +44,64 @@ export default function MobilePlanCard({ plan, status = 'proposed', onApprove, o
   const isDone = status === 'done'
   const isError = status === 'error'
 
+  const toggleLabel = expanded ? 'Hide details' : 'Show details'
+
   return (
     <div className="mt-2 rounded-xl border border-white/10 bg-white/5 p-3">
       <div className="flex items-center justify-between">
         <div className="text-xs uppercase tracking-wide text-text-muted">Plan</div>
-        <div className="text-xs text-text-muted">
-          {stepCount} {stepCount === 1 ? 'step' : 'steps'}
-        </div>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-label={expanded ? 'Hide details' : 'Show details'}
+          className="flex items-center gap-1 text-xs text-text-muted hover:text-text-primary"
+        >
+          <span>
+            {stepCount} {stepCount === 1 ? 'step' : 'steps'}
+          </span>
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </button>
       </div>
       <ol className="mt-2 space-y-2">
-        {steps.map((step, idx) => (
-          <li
-            key={step.id ?? idx}
-            className="rounded-lg border border-white/10 bg-black/20 px-3 py-2"
-          >
-            <div className="text-sm text-text-primary truncate">
-              {step.agent_name || step.agent_id}
-            </div>
-            {step.task && (
-              <div className="text-xs text-text-secondary mt-0.5 line-clamp-2">{step.task}</div>
-            )}
-          </li>
-        ))}
+        {steps.map((step, idx) => {
+          const stepState = stepStates?.[step.id] || stepStates?.[idx + 1]
+          const stepStatus = stepState?.status
+          return (
+            <li
+              key={step.id ?? idx}
+              className="rounded-lg border border-white/10 bg-black/20 px-3 py-2"
+            >
+              <div className="flex items-center gap-2">
+                {(isExecuting || isDone || isError) && (
+                  <StepStatusIcon status={stepStatus} />
+                )}
+                <div className="text-sm text-text-primary truncate flex-1">
+                  {step.agent_name || step.agent_id}
+                </div>
+              </div>
+              {step.task && (
+                <div
+                  className={`text-xs text-text-secondary mt-0.5 ${
+                    expanded ? 'whitespace-pre-wrap break-words' : 'line-clamp-2'
+                  }`}
+                >
+                  {step.task}
+                </div>
+              )}
+              {expanded && stepState?.text && (
+                <div className="mt-2 rounded-md bg-black/30 px-2 py-1.5 text-xs text-text-primary whitespace-pre-wrap break-words">
+                  {stepState.text}
+                </div>
+              )}
+              {expanded && stepState?.error && (
+                <div className="mt-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-2 py-1.5 text-xs text-rose-300 whitespace-pre-wrap break-words">
+                  {stepState.error}
+                </div>
+              )}
+            </li>
+          )
+        })}
       </ol>
       {isProposed && (
         <div className="mt-3 flex gap-2">
@@ -60,11 +128,22 @@ export default function MobilePlanCard({ plan, status = 'proposed', onApprove, o
         </div>
       )}
       {isDone && (
-        <div className="mt-3 text-xs text-emerald-400">Done</div>
+        <div className="mt-3 text-xs text-emerald-400">
+          Done
+          {runSummary?.duration_ms != null && (
+            <span className="ml-1 text-text-muted">
+              · {Math.max(1, Math.round(runSummary.duration_ms / 1000))}s
+            </span>
+          )}
+        </div>
       )}
       {isError && (
-        <div className="mt-3 text-xs text-rose-400">Error</div>
+        <div className="mt-3 text-xs text-rose-400 whitespace-pre-wrap break-words">
+          {runError || 'Error'}
+        </div>
       )}
+      {/* Keep the toggle label discoverable for assistive tech / tests. */}
+      <span className="sr-only">{toggleLabel}</span>
     </div>
   )
 }

--- a/src/components/mobile/MobilePlanCard.test.jsx
+++ b/src/components/mobile/MobilePlanCard.test.jsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobilePlanCard from './MobilePlanCard'
+
+const samplePlan = {
+  id: 'plan-1',
+  steps: [
+    {
+      id: 1,
+      agent_id: 'frontend-developer',
+      agent_name: 'Frontend Developer',
+      task: 'Build the login form with validation and styled inputs',
+    },
+    {
+      id: 2,
+      agent_id: 'backend-developer',
+      agent_name: 'Backend Developer',
+      task: 'Wire the API endpoint and validate the payload server-side',
+    },
+  ],
+}
+
+describe('MobilePlanCard', () => {
+  it('renders a clickable toggle that exposes per-step details', async () => {
+    const user = userEvent.setup()
+    render(<MobilePlanCard plan={samplePlan} status="executing" />)
+
+    const toggle = screen.getByRole('button', { name: /show details|expand plan/i })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    // Both step tasks are visible in full when expanded.
+    expect(
+      screen.getByText(/Build the login form with validation/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Wire the API endpoint and validate the payload/i),
+    ).toBeInTheDocument()
+  })
+
+  it('shows each step text/result and final outcome when expanded and execution is done', async () => {
+    const user = userEvent.setup()
+    const stepStates = {
+      1: { status: 'done', text: 'Form component implemented.' },
+      2: { status: 'done', text: 'API endpoint /login created.' },
+    }
+    render(
+      <MobilePlanCard
+        plan={samplePlan}
+        status="done"
+        stepStates={stepStates}
+        runSummary={{ duration_ms: 4321 }}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: /show details|expand plan/i }),
+    )
+
+    expect(screen.getByText('Form component implemented.')).toBeInTheDocument()
+    expect(screen.getByText('API endpoint /login created.')).toBeInTheDocument()
+  })
+
+  it('surfaces step-level error messages when expanded', async () => {
+    const user = userEvent.setup()
+    const stepStates = {
+      1: { status: 'done', text: 'OK' },
+      2: { status: 'error', error: 'Network refused the connection' },
+    }
+    render(
+      <MobilePlanCard
+        plan={samplePlan}
+        status="error"
+        stepStates={stepStates}
+        runError="Step 2 failed"
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: /show details|expand plan/i }),
+    )
+
+    expect(
+      screen.getByText(/Network refused the connection/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Step 2 failed/i)).toBeInTheDocument()
+  })
+
+  it('still renders Approve/Cancel buttons when proposed', () => {
+    const onApprove = vi.fn()
+    const onCancel = vi.fn()
+    render(
+      <MobilePlanCard
+        plan={samplePlan}
+        status="proposed"
+        onApprove={onApprove}
+        onCancel={onCancel}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /^Approve$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Cancel$/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #393

## TDD
- Tests added/modified:
  - `src/components/mobile/MobilePlanCard.test.jsx` (new)
  - `src/components/mobile/MobileChat.test.jsx` (added expand-plan-during-execution test)
- Before implementation (red): 3 tests in `MobilePlanCard.test.jsx` failed because no toggle button existed (`Unable to find role="button" name="show details|expand plan"`); the rest expected step text in the DOM that the old summary-only card never rendered.
- After implementation (green): all 552 frontend tests pass (`npm test`).

## Notes
- `MobilePlanCard` now owns local `expanded` state. Tapping the step-count header toggles a detail view that:
  - drops the task line-clamp so the full task description is visible,
  - shows a status icon per step (`running` / `done` / `error`),
  - renders the streamed `step.text` and any `step.error` for each step,
  - surfaces the top-level `runError` and the run duration from `runSummary`.
- `MobileChat` now subscribes to `step.started`, `step.text`, `step.done`, `step.error`, and threads `stepStates`, `runError`, `runSummary` into the plan card — the desktop chat already did this, mobile was just missing the wiring.
- Approve/Cancel for proposed plans is unchanged, so existing flows keep working.