### PR TITLE
fix(skills): support category-nested layout in catalog proxy/client (#394)

### DIFF
--- a/src/components/SkillCard.jsx
+++ b/src/components/SkillCard.jsx
@@ -4,8 +4,8 @@ import { Wand2, ExternalLink, Copy, Check, Plus } from 'lucide-react'
 
 const SKILL_CREATOR_PATH = '/agent/ai-specialists/skill-creator'
 
-function buildInstallCommand(slug) {
-  return `npx degit --mode=git lucasfe/skills/${slug} ~/.claude/skills/${slug}`
+function buildInstallCommand(category, slug) {
+  return `npx degit --mode=git lucasfe/skills/${category}/${slug} ~/.claude/skills/${slug}`
 }
 
 export default function SkillCard({ skill, variant }) {

--- a/src/components/SkillCard.jsx
+++ b/src/components/SkillCard.jsx
@@ -31,7 +31,7 @@ export default function SkillCard({ skill, variant }) {
     )
   }
 
-  const installCommand = buildInstallCommand(skill.slug)
+  const installCommand = buildInstallCommand(skill.category, skill.slug)
 
   const handleCopy = async (e) => {
     e.preventDefault()

--- a/src/components/SkillCard.test.jsx
+++ b/src/components/SkillCard.test.jsx
@@ -46,7 +46,7 @@ describe('SkillCard — default variant', () => {
     await user.click(screen.getByRole('button', { name: /copy install command/i }))
     expect(writeText).toHaveBeenCalledTimes(1)
     expect(writeText).toHaveBeenCalledWith(
-      'npx degit --mode=git lucasfe/skills/grill-me ~/.claude/skills/grill-me',
+      'npx degit --mode=git lucasfe/skills/meta/grill-me ~/.claude/skills/grill-me',
     )
   })
 

--- a/src/components/SkillCard.test.jsx
+++ b/src/components/SkillCard.test.jsx
@@ -64,7 +64,7 @@ describe('SkillCard — default variant', () => {
     const link = screen.getByRole('link', { name: /view on github/i })
     expect(link).toHaveAttribute(
       'href',
-      'https://github.com/lucasfe/skills/tree/main/grill-me',
+      'https://github.com/lucasfe/skills/tree/main/meta/grill-me',
     )
   })
 

--- a/src/components/SkillCard.test.jsx
+++ b/src/components/SkillCard.test.jsx
@@ -13,9 +13,10 @@ vi.mock('../lib/api', () => ({
 
 const mockSkill = {
   slug: 'grill-me',
+  category: 'meta',
   name: 'grill-me',
   description: 'Interview the user relentlessly about a plan',
-  sourceUrl: 'https://github.com/lucasfe/skills/tree/main/grill-me',
+  sourceUrl: 'https://github.com/lucasfe/skills/tree/main/meta/grill-me',
 }
 
 function setupClipboard() {

--- a/src/components/SkillDetailPage.jsx
+++ b/src/components/SkillDetailPage.jsx
@@ -6,8 +6,8 @@ import Markdown from '../lib/markdown'
 import { getSkill } from '../lib/skills'
 import { useAuth } from '../context/AuthContext'
 
-function buildInstallCommand(slug) {
-  return `npx degit --mode=git lucasfe/skills/${slug} ~/.claude/skills/${slug}`
+function buildInstallCommand(category, slug) {
+  return `npx degit --mode=git lucasfe/skills/${category}/${slug} ~/.claude/skills/${slug}`
 }
 
 export default function SkillDetailPage() {

--- a/src/components/SkillDetailPage.jsx
+++ b/src/components/SkillDetailPage.jsx
@@ -40,7 +40,7 @@ export default function SkillDetailPage() {
     return () => { cancelled = true }
   }, [slug, accessToken])
 
-  const installCommand = skill ? buildInstallCommand(skill.slug) : ''
+  const installCommand = skill ? buildInstallCommand(skill.category, skill.slug) : ''
 
   const handleCopy = async () => {
     if (!installCommand) return

--- a/src/components/SkillDetailPage.test.jsx
+++ b/src/components/SkillDetailPage.test.jsx
@@ -45,24 +45,27 @@ describe('SkillDetailPage', () => {
   it('renders the install command, body, and source link on success', async () => {
     getSkill.mockResolvedValue({
       slug: 'grill-me',
+      category: 'meta',
       name: 'grill-me',
       description: 'Interview the user',
       body: '## Heading\n\nFull body here.',
-      sourceUrl: 'https://github.com/lucasfe/skills/tree/main/grill-me',
+      sourceUrl: 'https://github.com/lucasfe/skills/tree/main/meta/grill-me',
     })
 
     renderAtSlug('grill-me')
 
     expect(await screen.findByRole('heading', { name: 'grill-me', level: 1 })).toBeInTheDocument()
     expect(
-      screen.getByText('npx degit --mode=git lucasfe/skills/grill-me ~/.claude/skills/grill-me'),
+      screen.getByText(
+        'npx degit --mode=git lucasfe/skills/meta/grill-me ~/.claude/skills/grill-me',
+      ),
     ).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /heading/i, level: 2 })).toBeInTheDocument()
     expect(screen.getByText(/full body here/i)).toBeInTheDocument()
     const sourceLink = screen.getByRole('link', { name: /view source on github/i })
     expect(sourceLink).toHaveAttribute(
       'href',
-      'https://github.com/lucasfe/skills/tree/main/grill-me',
+      'https://github.com/lucasfe/skills/tree/main/meta/grill-me',
     )
   })
 

--- a/src/components/SkillDetailPage.test.jsx
+++ b/src/components/SkillDetailPage.test.jsx
@@ -99,10 +99,11 @@ describe('SkillDetailPage', () => {
   it('copies the install command on click', async () => {
     getSkill.mockResolvedValue({
       slug: 'grill-me',
+      category: 'meta',
       name: 'grill-me',
       description: 'Interview the user',
       body: 'body',
-      sourceUrl: 'https://github.com/lucasfe/skills/tree/main/grill-me',
+      sourceUrl: 'https://github.com/lucasfe/skills/tree/main/meta/grill-me',
     })
     const user = userEvent.setup()
     const writeText = vi
@@ -115,7 +116,7 @@ describe('SkillDetailPage', () => {
     await user.click(button)
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(
-        'npx degit --mode=git lucasfe/skills/grill-me ~/.claude/skills/grill-me',
+        'npx degit --mode=git lucasfe/skills/meta/grill-me ~/.claude/skills/grill-me',
       ),
     )
   })

--- a/src/lib/skills.js
+++ b/src/lib/skills.js
@@ -6,8 +6,11 @@
 // authenticated user's `accessToken` (Supabase session token) so the
 // function's JWT gate accepts the call — there is no anonymous mode.
 //
-// This module only knows about reaching the proxy and parsing what comes
-// back. Frontmatter parsing is delegated to `./skillFrontmatter.js`.
+// The skills repo organizes skills under category folders at the root
+// (e.g. `development/<slug>/SKILL.md`, `meta/<slug>/SKILL.md`). The proxy
+// returns the flat catalog `{ slug, category, path }[]`; this module fetches
+// each `SKILL.md` via `?op=raw&category=<cat>&slug=<slug>` and parses the
+// frontmatter. Categories and slugs are discovered, never hard-coded.
 
 import { parseFrontmatter } from './skillFrontmatter.js'
 
@@ -46,8 +49,11 @@ function buildHeaders(accessToken) {
   }
 }
 
-export async function listSkills(options = {}) {
-  const { accessToken } = options
+function sourceUrlFor(category, slug) {
+  return `https://github.com/${REPO}/tree/main/${category}/${slug}`
+}
+
+async function fetchCatalog(accessToken) {
   const headers = buildHeaders(accessToken)
   const res = await fetch(buildProxyUrl('list'), { headers })
   if (!res.ok) {
@@ -57,67 +63,74 @@ export async function listSkills(options = {}) {
   if (!Array.isArray(entries)) {
     throw new SkillsApiError('Proxy returned an unexpected response shape.', 502)
   }
-  const folders = entries.filter(
-    (entry) => entry && entry.type === 'dir' && typeof entry.name === 'string',
+  return entries.filter(
+    (entry) =>
+      entry &&
+      typeof entry.slug === 'string' &&
+      entry.slug.length > 0 &&
+      typeof entry.category === 'string' &&
+      entry.category.length > 0,
   )
-  const skills = []
-  for (const folder of folders) {
-    const skill = await fetchSkillForFolder(folder.name, accessToken)
-    if (skill) skills.push(skill)
-  }
-  return skills
 }
 
-async function fetchSkillForFolder(slug, accessToken) {
+async function fetchSkillFile(category, slug, accessToken) {
   const headers = buildHeaders(accessToken)
-  const res = await fetch(buildProxyUrl('raw', { slug }), { headers })
-  if (res.status === 404) return null
+  const res = await fetch(buildProxyUrl('raw', { category, slug }), { headers })
+  if (res.status === 404) return { status: 404, parsed: null }
   if (!res.ok) {
-    if (res.status === 403 || res.status >= 500) {
-      throw new SkillsApiError(
-        `Failed to fetch SKILL.md for "${slug}" (${res.status}).`,
-        res.status,
-      )
-    }
-    return null
+    throw new SkillsApiError(
+      `Failed to fetch SKILL.md for "${category}/${slug}" (${res.status}).`,
+      res.status,
+    )
   }
   const text = await res.text()
-  const parsed = parseFrontmatter(text)
+  return { status: 200, parsed: parseFrontmatter(text) }
+}
+
+function extractNameAndDescription(parsed) {
   if (!parsed) return null
   const name = typeof parsed.name === 'string' ? parsed.name.trim() : ''
-  const description = typeof parsed.description === 'string' ? parsed.description.trim() : ''
+  const description =
+    typeof parsed.description === 'string' ? parsed.description.trim() : ''
   if (!name || !description) return null
-  return {
-    slug,
-    name,
-    description,
-    sourceUrl: `https://github.com/${REPO}/tree/main/${slug}`,
+  return { name, description }
+}
+
+export async function listSkills(options = {}) {
+  const { accessToken } = options
+  const entries = await fetchCatalog(accessToken)
+  const skills = []
+  for (const entry of entries) {
+    const { slug, category } = entry
+    const { parsed } = await fetchSkillFile(category, slug, accessToken)
+    const meta = extractNameAndDescription(parsed)
+    if (!meta) continue
+    skills.push({
+      slug,
+      category,
+      name: meta.name,
+      description: meta.description,
+      sourceUrl: sourceUrlFor(category, slug),
+    })
   }
+  return skills
 }
 
 export async function getSkill(slug, options = {}) {
   if (typeof slug !== 'string' || slug.length === 0) return null
   const { accessToken } = options
-  const headers = buildHeaders(accessToken)
-  const res = await fetch(buildProxyUrl('raw', { slug }), { headers })
-  if (res.status === 404) return null
-  if (!res.ok) {
-    throw new SkillsApiError(
-      `Failed to fetch SKILL.md for "${slug}" (${res.status}).`,
-      res.status,
-    )
-  }
-  const text = await res.text()
-  const parsed = parseFrontmatter(text)
-  if (!parsed) return null
-  const name = typeof parsed.name === 'string' ? parsed.name.trim() : ''
-  const description = typeof parsed.description === 'string' ? parsed.description.trim() : ''
-  if (!name || !description) return null
+  const entries = await fetchCatalog(accessToken)
+  const entry = entries.find((e) => e.slug === slug)
+  if (!entry) return null
+  const { parsed } = await fetchSkillFile(entry.category, slug, accessToken)
+  const meta = extractNameAndDescription(parsed)
+  if (!meta) return null
   return {
     slug,
-    name,
-    description,
+    category: entry.category,
+    name: meta.name,
+    description: meta.description,
     body: typeof parsed.body === 'string' ? parsed.body : '',
-    sourceUrl: `https://github.com/${REPO}/tree/main/${slug}`,
+    sourceUrl: sourceUrlFor(entry.category, slug),
   }
 }

--- a/src/lib/skills.test.js
+++ b/src/lib/skills.test.js
@@ -7,7 +7,8 @@ const PROXY_BASE = `${SUPABASE_URL}/functions/v1/skills`
 const ACCESS_TOKEN = 'test-access-token'
 
 const LIST_URL = `${PROXY_BASE}?op=list`
-const RAW_URL = (slug) => `${PROXY_BASE}?op=raw&slug=${slug}`
+const RAW_URL = (category, slug) =>
+  `${PROXY_BASE}?op=raw&category=${category}&slug=${slug}`
 
 function jsonResponse(body, init = {}) {
   return new Response(JSON.stringify(body), {
@@ -41,19 +42,27 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('listSkills — happy path', () => {
-  it('lists folders, fetches each SKILL.md via the proxy, and returns the slim catalog shape', async () => {
+describe('listSkills — happy path (nested category layout)', () => {
+  it('lists every skill across categories, exposes the category, and points sourceUrl at the category-nested path', async () => {
     fetchMock.mockImplementation(async (url) => {
       if (url === LIST_URL) {
         return jsonResponse([
-          { type: 'dir', name: 'grill-me' },
-          { type: 'dir', name: 'to-prd' },
+          { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+          { slug: 'tdd', category: 'development', path: 'development/tdd/SKILL.md' },
+          {
+            slug: 'to-prd',
+            category: 'project-management',
+            path: 'project-management/to-prd/SKILL.md',
+          },
         ])
       }
-      if (url === RAW_URL('grill-me')) {
+      if (url === RAW_URL('meta', 'grill-me')) {
         return textResponse(frontmatter('grill-me', 'Interview the user'))
       }
-      if (url === RAW_URL('to-prd')) {
+      if (url === RAW_URL('development', 'tdd')) {
+        return textResponse(frontmatter('tdd', 'Test-driven development'))
+      }
+      if (url === RAW_URL('project-management', 'to-prd')) {
         return textResponse(frontmatter('to-prd', 'Turn context into a PRD'))
       }
       throw new Error(`unexpected url: ${url}`)
@@ -64,15 +73,25 @@ describe('listSkills — happy path', () => {
     expect(skills).toEqual([
       {
         slug: 'grill-me',
+        category: 'meta',
         name: 'grill-me',
         description: 'Interview the user',
-        sourceUrl: 'https://github.com/lucasfe/skills/tree/main/grill-me',
+        sourceUrl: 'https://github.com/lucasfe/skills/tree/main/meta/grill-me',
+      },
+      {
+        slug: 'tdd',
+        category: 'development',
+        name: 'tdd',
+        description: 'Test-driven development',
+        sourceUrl: 'https://github.com/lucasfe/skills/tree/main/development/tdd',
       },
       {
         slug: 'to-prd',
+        category: 'project-management',
         name: 'to-prd',
         description: 'Turn context into a PRD',
-        sourceUrl: 'https://github.com/lucasfe/skills/tree/main/to-prd',
+        sourceUrl:
+          'https://github.com/lucasfe/skills/tree/main/project-management/to-prd',
       },
     ])
   })
@@ -101,16 +120,17 @@ describe('listSkills — happy path', () => {
 })
 
 describe('listSkills — filtering', () => {
-  it('drops non-directory entries (e.g. a top-level README.md)', async () => {
+  it('ignores list entries that are missing slug or category', async () => {
     fetchMock.mockImplementation(async (url) => {
       if (url === LIST_URL) {
         return jsonResponse([
-          { type: 'file', name: 'README.md' },
-          { type: 'file', name: 'LICENSE' },
-          { type: 'dir', name: 'tdd' },
+          { slug: 'tdd', category: 'development', path: 'development/tdd/SKILL.md' },
+          { slug: 'no-category', path: 'no-category/SKILL.md' },
+          { category: 'meta' },
+          null,
         ])
       }
-      if (url === RAW_URL('tdd')) {
+      if (url === RAW_URL('development', 'tdd')) {
         return textResponse(frontmatter('tdd', 'Test-driven development'))
       }
       throw new Error(`unexpected url: ${url}`)
@@ -118,23 +138,21 @@ describe('listSkills — filtering', () => {
 
     const skills = await listSkills({ accessToken: ACCESS_TOKEN })
 
-    expect(skills).toHaveLength(1)
-    expect(skills[0].slug).toBe('tdd')
-    expect(fetchMock).not.toHaveBeenCalledWith(RAW_URL('README.md'), expect.anything())
+    expect(skills.map((s) => s.slug)).toEqual(['tdd'])
   })
 
   it('skips a folder without a SKILL.md (404) instead of crashing the catalog', async () => {
     fetchMock.mockImplementation(async (url) => {
       if (url === LIST_URL) {
         return jsonResponse([
-          { type: 'dir', name: 'has-skill' },
-          { type: 'dir', name: 'orphan' },
+          { slug: 'has-skill', category: 'meta', path: 'meta/has-skill/SKILL.md' },
+          { slug: 'orphan', category: 'meta', path: 'meta/orphan/SKILL.md' },
         ])
       }
-      if (url === RAW_URL('has-skill')) {
+      if (url === RAW_URL('meta', 'has-skill')) {
         return textResponse(frontmatter('has-skill', 'A real skill'))
       }
-      if (url === RAW_URL('orphan')) {
+      if (url === RAW_URL('meta', 'orphan')) {
         return new Response('Not Found', { status: 404 })
       }
       throw new Error(`unexpected url: ${url}`)
@@ -149,14 +167,18 @@ describe('listSkills — filtering', () => {
     fetchMock.mockImplementation(async (url) => {
       if (url === LIST_URL) {
         return jsonResponse([
-          { type: 'dir', name: 'good' },
-          { type: 'dir', name: 'no-frontmatter' },
+          { slug: 'good', category: 'meta', path: 'meta/good/SKILL.md' },
+          {
+            slug: 'no-frontmatter',
+            category: 'meta',
+            path: 'meta/no-frontmatter/SKILL.md',
+          },
         ])
       }
-      if (url === RAW_URL('good')) {
+      if (url === RAW_URL('meta', 'good')) {
         return textResponse(frontmatter('good', 'Good skill'))
       }
-      if (url === RAW_URL('no-frontmatter')) {
+      if (url === RAW_URL('meta', 'no-frontmatter')) {
         return textResponse('# just a heading\n\nbody only, no frontmatter')
       }
       throw new Error(`unexpected url: ${url}`)
@@ -171,14 +193,14 @@ describe('listSkills — filtering', () => {
     fetchMock.mockImplementation(async (url) => {
       if (url === LIST_URL) {
         return jsonResponse([
-          { type: 'dir', name: 'no-name' },
-          { type: 'dir', name: 'no-desc' },
+          { slug: 'no-name', category: 'meta', path: 'meta/no-name/SKILL.md' },
+          { slug: 'no-desc', category: 'meta', path: 'meta/no-desc/SKILL.md' },
         ])
       }
-      if (url === RAW_URL('no-name')) {
+      if (url === RAW_URL('meta', 'no-name')) {
         return textResponse('---\ndescription: only a description\n---\nbody')
       }
-      if (url === RAW_URL('no-desc')) {
+      if (url === RAW_URL('meta', 'no-desc')) {
         return textResponse('---\nname: only-a-name\n---\nbody')
       }
       throw new Error(`unexpected url: ${url}`)
@@ -216,7 +238,9 @@ describe('listSkills — error surfacing', () => {
   it('throws a SkillsApiError when an individual SKILL.md returns 403', async () => {
     fetchMock.mockImplementation(async (url) => {
       if (url === LIST_URL) {
-        return jsonResponse([{ type: 'dir', name: 'limited' }])
+        return jsonResponse([
+          { slug: 'limited', category: 'meta', path: 'meta/limited/SKILL.md' },
+        ])
       }
       return new Response('rate limited', { status: 403 })
     })
@@ -235,14 +259,20 @@ describe('listSkills — error surfacing', () => {
   })
 })
 
-describe('getSkill', () => {
+describe('getSkill — nested category layout', () => {
   it('exists as an exported function', () => {
     expect(typeof getSkill).toBe('function')
   })
 
-  it('returns the skill with the rendered body, name, description, slug, and sourceUrl', async () => {
+  it('looks up the category via the catalog, then fetches the SKILL.md and returns the full shape', async () => {
     fetchMock.mockImplementation(async (url) => {
-      if (url === RAW_URL('grill-me')) {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+          { slug: 'tdd', category: 'development', path: 'development/tdd/SKILL.md' },
+        ])
+      }
+      if (url === RAW_URL('meta', 'grill-me')) {
         return textResponse(
           '---\nname: grill-me\ndescription: Interview the user\n---\n# Heading\n\nFull body here.',
         )
@@ -254,17 +284,43 @@ describe('getSkill', () => {
 
     expect(skill).toEqual({
       slug: 'grill-me',
+      category: 'meta',
       name: 'grill-me',
       description: 'Interview the user',
       body: '# Heading\n\nFull body here.',
-      sourceUrl: 'https://github.com/lucasfe/skills/tree/main/grill-me',
+      sourceUrl: 'https://github.com/lucasfe/skills/tree/main/meta/grill-me',
     })
   })
 
-  it('returns null when the slug is missing on the remote (404)', async () => {
-    fetchMock.mockResolvedValue(new Response('Not Found', { status: 404 }))
+  it('returns null when the slug is not in the catalog', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { slug: 'tdd', category: 'development', path: 'development/tdd/SKILL.md' },
+        ])
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
 
     const skill = await getSkill('does-not-exist', { accessToken: ACCESS_TOKEN })
+
+    expect(skill).toBeNull()
+  })
+
+  it('returns null when the SKILL.md vanished between listing and fetching (404)', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { slug: 'gone', category: 'meta', path: 'meta/gone/SKILL.md' },
+        ])
+      }
+      if (url === RAW_URL('meta', 'gone')) {
+        return new Response('Not Found', { status: 404 })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+
+    const skill = await getSkill('gone', { accessToken: ACCESS_TOKEN })
 
     expect(skill).toBeNull()
   })
@@ -277,9 +333,21 @@ describe('getSkill', () => {
   })
 
   it('returns null when SKILL.md exists but has no frontmatter', async () => {
-    fetchMock.mockImplementation(async () =>
-      textResponse('# just a heading\n\nbody only, no frontmatter'),
-    )
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          {
+            slug: 'no-frontmatter',
+            category: 'meta',
+            path: 'meta/no-frontmatter/SKILL.md',
+          },
+        ])
+      }
+      if (url === RAW_URL('meta', 'no-frontmatter')) {
+        return textResponse('# just a heading\n\nbody only, no frontmatter')
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
 
     const skill = await getSkill('no-frontmatter', { accessToken: ACCESS_TOKEN })
 
@@ -287,16 +355,24 @@ describe('getSkill', () => {
   })
 
   it('returns null when the frontmatter is missing name or description', async () => {
-    fetchMock.mockImplementation(async () =>
-      textResponse('---\nname: only-a-name\n---\nbody'),
-    )
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { slug: 'no-desc', category: 'meta', path: 'meta/no-desc/SKILL.md' },
+        ])
+      }
+      if (url === RAW_URL('meta', 'no-desc')) {
+        return textResponse('---\nname: only-a-name\n---\nbody')
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
 
     const skill = await getSkill('no-desc', { accessToken: ACCESS_TOKEN })
 
     expect(skill).toBeNull()
   })
 
-  it('throws a SkillsApiError on 403', async () => {
+  it('throws a SkillsApiError on 403 from the listing', async () => {
     fetchMock.mockResolvedValue(new Response('rate limited', { status: 403 }))
 
     await expect(
@@ -307,8 +383,15 @@ describe('getSkill', () => {
     ).rejects.toMatchObject({ status: 403 })
   })
 
-  it('throws a SkillsApiError on 5xx', async () => {
-    fetchMock.mockResolvedValue(new Response('boom', { status: 503 }))
+  it('throws a SkillsApiError on 5xx from the raw fetch', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (url === LIST_URL) {
+        return jsonResponse([
+          { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+        ])
+      }
+      return new Response('boom', { status: 503 })
+    })
 
     await expect(
       getSkill('grill-me', { accessToken: ACCESS_TOKEN }),

--- a/supabase/functions/skills/index.ts
+++ b/supabase/functions/skills/index.ts
@@ -1,23 +1,33 @@
 // Skills proxy. The catalog repo `lucasfe/skills` is private, so the browser
 // cannot reach it directly. This function injects the existing `GITHUB_TOKEN`
 // secret (already provisioned for the GitHub Issue Creator agent) and forwards
-// requests to the GitHub Contents API. Two operations:
+// requests to the GitHub API.
 //
-//   GET ?op=list                  -> JSON listing of top-level entries
-//   GET ?op=raw&slug=<kebab>      -> raw text of <slug>/SKILL.md
+// Skills live at `<category>/<slug>/SKILL.md` in the catalog repo (e.g.
+// `development/tdd/SKILL.md`). Categories and slugs are discovered from the
+// repo tree — neither is hard-coded here or in the frontend client.
 //
-// The frontend (`src/lib/skills.js`) parses listings and frontmatter — this
-// function stays a thin HTTP forwarder.
+//   GET ?op=list
+//     -> JSON array `{ slug, category, path }[]`. Built from the repo's
+//        recursive Git tree, filtered to entries matching
+//        `<category>/<slug>/SKILL.md`. Hidden categories/slugs (segments
+//        starting with `.`) are skipped.
+//
+//   GET ?op=raw&category=<category>&slug=<slug>
+//     -> Raw text of `<category>/<slug>/SKILL.md`. Both params are required
+//        and validated against the same kebab-case regex.
 //
 // Auth: Supabase verifies the caller's JWT (verify_jwt: true) before this
 // runs, so only signed-in app users can hit the proxy. The repo never needs
 // to be public to make the catalog work.
 
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import { extractSkillEntries } from './skillsTree.ts'
 
 const GITHUB_API = 'https://api.github.com'
 const REPO = 'lucasfe/skills'
-const VALID_SLUG = /^[a-zA-Z0-9_-]{1,80}$/
+const REPO_BRANCH = 'main'
+const VALID_SEGMENT = /^[a-zA-Z0-9_-]{1,80}$/
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -30,6 +40,54 @@ function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+async function handleList(token: string): Promise<Response> {
+  const treeUrl = `${GITHUB_API}/repos/${REPO}/git/trees/${REPO_BRANCH}?recursive=1`
+  const ghRes = await fetch(treeUrl, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'agenthub-skills-proxy',
+    },
+  })
+  if (!ghRes.ok) {
+    const text = await ghRes.text()
+    return new Response(text, {
+      status: ghRes.status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+  let payload: unknown
+  try {
+    payload = await ghRes.json()
+  } catch {
+    return jsonResponse({ error: 'Upstream returned malformed JSON.' }, 502)
+  }
+  const entries = extractSkillEntries(payload)
+  return jsonResponse(entries)
+}
+
+async function handleRaw(
+  token: string,
+  category: string,
+  slug: string,
+): Promise<Response> {
+  const ghRes = await fetch(
+    `${GITHUB_API}/repos/${REPO}/contents/${encodeURIComponent(category)}/${encodeURIComponent(slug)}/SKILL.md`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.raw',
+        'User-Agent': 'agenthub-skills-proxy',
+      },
+    },
+  )
+  const body = await ghRes.text()
+  return new Response(body, {
+    status: ghRes.status,
+    headers: { ...corsHeaders, 'Content-Type': 'text/plain; charset=utf-8' },
   })
 }
 
@@ -53,47 +111,29 @@ Deno.serve(async (req) => {
   const op = url.searchParams.get('op')
 
   if (op === 'list') {
-    const ghRes = await fetch(`${GITHUB_API}/repos/${REPO}/contents`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'agenthub-skills-proxy',
-      },
-    })
-    const body = await ghRes.text()
-    return new Response(body, {
-      status: ghRes.status,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    })
+    return await handleList(token)
   }
 
   if (op === 'raw') {
+    const category = url.searchParams.get('category') || ''
     const slug = url.searchParams.get('slug') || ''
-    if (!VALID_SLUG.test(slug)) {
+    if (!VALID_SEGMENT.test(category) || !VALID_SEGMENT.test(slug)) {
       return jsonResponse(
-        { error: 'Invalid slug. Expected kebab-case alphanumeric.' },
+        {
+          error:
+            'Invalid params. Expected kebab-case alphanumeric for both category and slug.',
+        },
         400,
       )
     }
-    const ghRes = await fetch(
-      `${GITHUB_API}/repos/${REPO}/contents/${encodeURIComponent(slug)}/SKILL.md`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github.raw',
-          'User-Agent': 'agenthub-skills-proxy',
-        },
-      },
-    )
-    const body = await ghRes.text()
-    return new Response(body, {
-      status: ghRes.status,
-      headers: { ...corsHeaders, 'Content-Type': 'text/plain; charset=utf-8' },
-    })
+    return await handleRaw(token, category, slug)
   }
 
   return jsonResponse(
-    { error: 'Unknown op. Use ?op=list or ?op=raw&slug=<slug>.' },
+    {
+      error:
+        'Unknown op. Use ?op=list or ?op=raw&category=<category>&slug=<slug>.',
+    },
     400,
   )
 })

--- a/supabase/functions/skills/skillsTree.test.ts
+++ b/supabase/functions/skills/skillsTree.test.ts
@@ -1,0 +1,122 @@
+import { assertEquals } from 'jsr:@std/assert@1'
+import { extractSkillEntries } from './skillsTree.ts'
+
+Deno.test('extractSkillEntries returns category-nested SKILL.md entries', () => {
+  const tree = {
+    tree: [
+      { path: 'development', type: 'tree' },
+      { path: 'development/tdd', type: 'tree' },
+      { path: 'development/tdd/SKILL.md', type: 'blob' },
+      { path: 'meta', type: 'tree' },
+      { path: 'meta/grill-me', type: 'tree' },
+      { path: 'meta/grill-me/SKILL.md', type: 'blob' },
+      { path: 'project-management', type: 'tree' },
+      { path: 'project-management/to-prd', type: 'tree' },
+      { path: 'project-management/to-prd/SKILL.md', type: 'blob' },
+    ],
+  }
+
+  assertEquals(extractSkillEntries(tree), [
+    { slug: 'tdd', category: 'development', path: 'development/tdd/SKILL.md' },
+    { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+    {
+      slug: 'to-prd',
+      category: 'project-management',
+      path: 'project-management/to-prd/SKILL.md',
+    },
+  ])
+})
+
+Deno.test('extractSkillEntries skips paths that are not exactly <category>/<slug>/SKILL.md', () => {
+  const tree = {
+    tree: [
+      { path: 'SKILL.md', type: 'blob' }, // root-level: skip
+      { path: 'meta/SKILL.md', type: 'blob' }, // 1-level: skip
+      { path: 'meta/grill-me/SKILL.md', type: 'blob' }, // valid
+      { path: 'meta/grill-me/extra/SKILL.md', type: 'blob' }, // 3-level: skip
+      { path: 'meta/grill-me/REFERENCE.md', type: 'blob' }, // wrong filename: skip
+      { path: 'development/tdd/SKILL.md', type: 'blob' }, // valid
+    ],
+  }
+
+  assertEquals(extractSkillEntries(tree), [
+    { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+    { slug: 'tdd', category: 'development', path: 'development/tdd/SKILL.md' },
+  ])
+})
+
+Deno.test('extractSkillEntries skips hidden categories (folder names starting with a dot)', () => {
+  const tree = {
+    tree: [
+      { path: '.claude/settings/SKILL.md', type: 'blob' },
+      { path: '.github/workflows/SKILL.md', type: 'blob' },
+      { path: 'meta/grill-me/SKILL.md', type: 'blob' },
+    ],
+  }
+
+  assertEquals(extractSkillEntries(tree), [
+    { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+  ])
+})
+
+Deno.test('extractSkillEntries skips hidden skill folders (slug starting with a dot)', () => {
+  const tree = {
+    tree: [
+      { path: 'meta/.hidden-skill/SKILL.md', type: 'blob' },
+      { path: 'meta/grill-me/SKILL.md', type: 'blob' },
+    ],
+  }
+
+  assertEquals(extractSkillEntries(tree), [
+    { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+  ])
+})
+
+Deno.test('extractSkillEntries skips non-blob entries (tree, commit, etc.)', () => {
+  const tree = {
+    tree: [
+      { path: 'meta/grill-me/SKILL.md', type: 'tree' }, // wrong type
+      { path: 'meta/tdd/SKILL.md', type: 'blob' },
+    ],
+  }
+
+  assertEquals(extractSkillEntries(tree), [
+    { slug: 'tdd', category: 'meta', path: 'meta/tdd/SKILL.md' },
+  ])
+})
+
+Deno.test('extractSkillEntries returns [] when the tree is missing or malformed', () => {
+  assertEquals(extractSkillEntries(null), [])
+  assertEquals(extractSkillEntries({}), [])
+  assertEquals(extractSkillEntries({ tree: 'not-an-array' }), [])
+  assertEquals(extractSkillEntries({ tree: [] }), [])
+})
+
+Deno.test('extractSkillEntries handles entries with missing path or type defensively', () => {
+  const tree = {
+    tree: [
+      { path: 'meta/grill-me/SKILL.md', type: 'blob' },
+      { path: 'meta/no-type/SKILL.md' },
+      { type: 'blob' },
+      null,
+      'garbage',
+    ],
+  }
+
+  assertEquals(extractSkillEntries(tree), [
+    { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+  ])
+})
+
+Deno.test('extractSkillEntries deduplicates by path defensively', () => {
+  const tree = {
+    tree: [
+      { path: 'meta/grill-me/SKILL.md', type: 'blob' },
+      { path: 'meta/grill-me/SKILL.md', type: 'blob' },
+    ],
+  }
+
+  assertEquals(extractSkillEntries(tree), [
+    { slug: 'grill-me', category: 'meta', path: 'meta/grill-me/SKILL.md' },
+  ])
+})

--- a/supabase/functions/skills/skillsTree.ts
+++ b/supabase/functions/skills/skillsTree.ts
@@ -1,0 +1,49 @@
+// Pure helper for the `skills` Edge Function.
+//
+// Filters a GitHub git/trees recursive response down to the flat catalog
+// shape `{ slug, category, path }[]` the frontend consumes. Skills live at
+// `<category>/<slug>/SKILL.md` in `lucasfe/skills`; anything deeper or
+// shallower, anything not named `SKILL.md`, anything not a blob, and any
+// path segment starting with a dot is skipped. Categories and slugs are
+// discovered, never hard-coded — adding a new category folder is picked up
+// automatically on the next request.
+
+export interface SkillEntry {
+  slug: string
+  category: string
+  path: string
+}
+
+interface TreeNode {
+  path?: unknown
+  type?: unknown
+}
+
+interface TreePayload {
+  tree?: unknown
+}
+
+const SKILL_FILENAME = 'SKILL.md'
+
+export function extractSkillEntries(payload: unknown): SkillEntry[] {
+  const tree = (payload as TreePayload | null)?.tree
+  if (!Array.isArray(tree)) return []
+  const seen = new Set<string>()
+  const out: SkillEntry[] = []
+  for (const node of tree as TreeNode[]) {
+    if (!node || typeof node !== 'object') continue
+    if (node.type !== 'blob') continue
+    if (typeof node.path !== 'string') continue
+    const path = node.path
+    const segments = path.split('/')
+    if (segments.length !== 3) continue
+    const [category, slug, filename] = segments
+    if (filename !== SKILL_FILENAME) continue
+    if (!category || category.startsWith('.')) continue
+    if (!slug || slug.startsWith('.')) continue
+    if (seen.has(path)) continue
+    seen.add(path)
+    out.push({ slug, category, path })
+  }
+  return out
+}


### PR DESCRIPTION
Closes #394

The `lucasfe/skills` catalog repo is being reorganized so skills live at
`<category>/<slug>/SKILL.md` (e.g. `development/tdd/SKILL.md`) instead of
flat at the root. This PR updates the catalog proxy and the frontend
client to discover skills via the GitHub Trees API (recursive) so both
new categories and new skills inside existing categories are picked up
automatically — no slug or category name is hard-coded.

## Changes

- `supabase/functions/skills/index.ts` — `?op=list` now queries
  `/git/trees/main?recursive=1` and returns the flat catalog
  `{ slug, category, path }[]`. `?op=raw` now requires both
  `category` and `slug`. The top-of-file comment documents the new
  contract. Tree filtering is extracted to a pure helper.
- `supabase/functions/skills/skillsTree.ts` — new pure helper
  `extractSkillEntries(payload)`. Filters tree blobs to exactly
  `<category>/<slug>/SKILL.md`, skipping hidden segments (`.claude`,
  `.github`, etc.) and deeper/shallower paths.
- `src/lib/skills.js` — consumes the new list shape and includes
  `category` on each returned skill. `getSkill(slug)` looks the
  category up via the catalog before fetching the SKILL.md.
  `sourceUrl` is now `tree/main/<category>/<slug>`.
- `src/components/SkillCard.jsx`, `src/components/SkillDetailPage.jsx` —
  install command becomes
  `npx degit --mode=git lucasfe/skills/<category>/<slug> ~/.claude/skills/<slug>`.

## TDD
- Tests added/modified:
  - `src/lib/skills.test.js` (rewritten for nested layout)
  - `supabase/functions/skills/skillsTree.test.ts` (new, 8 cases)
  - `src/components/SkillCard.test.jsx` (install + sourceUrl)
  - `src/components/SkillDetailPage.test.jsx` (install + sourceUrl)
- Before implementation (red): 13 frontend tests failed —
  `listSkills`/`getSkill` still requested flat slugs and built old
  sourceUrls; SkillCard/SkillDetailPage built the install command
  without the category.
- After implementation (green): `npm test` → **553/553 frontend tests
  pass**; `npm run test:functions` → **214/214 edge function tests
  pass** (8 new `extractSkillEntries` cases included); `npm run lint`
  → 0 errors.

## Notes
- The new contract is intentionally breaking — the issue calls this
  out (the upstream `lucasfe/skills` reorg is the trigger). Both halves
  of the proxy and both halves of the client flip together in this PR.
- `verify_jwt: true` on the function is unchanged, so the auth gate
  still applies to the new ops.