### PR TITLE
docs: record headless subagent dispatch spike finding (#420)

### DIFF
--- a/packages/ralph/docs/team-mode-spike.md
+++ b/packages/ralph/docs/team-mode-spike.md
@@ -1,0 +1,41 @@
+# Spike: headless subagent dispatch (issue #420)
+
+**Parent PRD:** #419 — Ralph team mode.
+
+**Question:** Can an orchestrator running inside `claude -p --dangerously-skip-permissions`
+(the exact mode Ralph uses per issue) dispatch real, context-isolated subagents via the
+Task/Agent tool and get structured results back? The entire team-mode pipeline
+(Triage → Dev → QA → Review → Tech Writer) depends on this.
+
+## Verdict
+
+**Works.** Real Task/Agent-tool subagent dispatch is available and reliable in headless
+mode. The team pipeline will use **real subagents** per role. The sequential
+persona-switching fallback (#419 stories 27–28) is **not needed** and is held in reserve
+only if a future runtime change removes the capability.
+
+## How it was verified
+
+The spike was run from inside an actual Ralph invocation — i.e. a live
+`claude -p --dangerously-skip-permissions` process resolving this very issue — so the test
+environment is identical to production, not a simulation.
+
+| Check | Method | Result |
+|---|---|---|
+| Subagent runs at all | Dispatched a subagent told to return structured JSON | Ran; returned valid JSON |
+| Returns a structured result | Asked for a fixed JSON shape incl. a computed value (`6 * 7`) and a token | `computed: 42`, `secret_token: RALPH-SPIKE-OK-420` — exact |
+| Context is isolated | Asked the subagent what context it received | Confirmed it got only its own prompt, not the parent conversation |
+| Subagents can use tools | Second subagent ran `node -e "console.log(2**10)"` via Bash | `tool_worked: true`, `bash_output: 1024` |
+| Each dispatch is independent | Asked the second subagent if it knew the first's secret token | `knows_previous_subagent: false` — no cross-contamination |
+
+## Implications for the build
+
+- The orchestrator template dispatches one real subagent per role, each with a fresh
+  isolated context and a structured return contract.
+- Subagents can read files and run commands (tests, lint, git), which the Dev/QA/Review
+  roles require.
+- Results do not leak between dispatches, so role outputs must be passed forward
+  explicitly by the orchestrator (e.g. dev's diff handed to QA/Review) rather than assumed
+  to be shared.
+- No `solo`-vs-`team` toggle and no persona-switching branch are required in the shipped
+  templates.


### PR DESCRIPTION
Closes #420

## Spike outcome

Verified that **real Task/Agent-tool subagent dispatch works** inside `claude -p --dangerously-skip-permissions` (Ralph's headless per-issue mode). The team-mode pipeline (#419) will use real subagents per role; the sequential persona-switching fallback is not needed.

The test was run from inside a live Ralph invocation, so the environment matched production exactly. Two subagents were dispatched:
1. Returned a structured JSON result with a correct computed value and confirmed it received only its own prompt (isolated context).
2. Successfully used the Bash tool and confirmed it had no memory of the first subagent (independent dispatches).

## Changes

- Adds `packages/ralph/docs/team-mode-spike.md` recording the verdict, method, and design implications.

The full finding is also posted as a comment on #420 (per acceptance criteria).

## Validation

- `npm run lint` — 0 errors (pre-existing warnings only)
- ralph package `npm test` — 328 passed
- Docs-only change; no behavior altered.