### PR TITLE
feat: add Ralph team-prompt orchestrator skeleton + composition seam

### DIFF
--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -11,7 +11,7 @@ export function buildPrompt({
   stderr = process.stderr,
 } = {}) {
   const fs = fsImpl ?? { existsSync, readFileSync }
-  const baseTemplate = fs.readFileSync(templatePath('prompt-base.md'), 'utf8')
+  const orchestratorTemplate = fs.readFileSync(templatePath('prompt-team.md'), 'utf8')
   const projectPromptPath = join(projectRoot, 'PROMPT.md')
   const projectPrompt = fs.existsSync(projectPromptPath)
     ? fs.readFileSync(projectPromptPath, 'utf8').toString()
@@ -29,7 +29,7 @@ export function buildPrompt({
     PROJECT_ROOT: projectRoot,
     PROJECT_PROMPT: projectPrompt,
   }
-  return interpolate(baseTemplate, vars, { stderr })
+  return interpolate(orchestratorTemplate, vars, { stderr })
 }
 
 const invokedAsScript =

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -19,10 +19,10 @@ function makeStderr() {
 }
 
 function setupFs({ projectFiles = {} } = {}) {
-  const baseTemplate = readFileSync(templatePath('prompt-base.md'), 'utf8')
+  const orchestratorTemplate = readFileSync(templatePath('prompt-team.md'), 'utf8')
   const vol = Volume.fromJSON({}, '/')
   vol.mkdirSync(templatePath(''), { recursive: true })
-  vol.writeFileSync(templatePath('prompt-base.md'), baseTemplate)
+  vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
   vol.mkdirSync(PROJECT, { recursive: true })
   for (const [k, v] of Object.entries(projectFiles)) {
     vol.writeFileSync(join(PROJECT, k), v)
@@ -31,7 +31,7 @@ function setupFs({ projectFiles = {} } = {}) {
 }
 
 describe('buildPrompt', () => {
-  it('substitutes the runtime placeholders from env into prompt-base', () => {
+  it('substitutes the runtime placeholders from env into the orchestrator template', () => {
     const vol = setupFs({ projectFiles: { 'PROMPT.md': '## Stack\nFoo' } })
     const out = buildPrompt({
       projectRoot: PROJECT,
@@ -120,6 +120,58 @@ describe('buildPrompt', () => {
       const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
       expect(out).toMatch(/skip.+TDD|TDD.+(only|skip)/i)
       expect(out).toMatch(/docs|documentation|config/i)
+    })
+  })
+
+  describe('team orchestrator composition', () => {
+    it('composes the orchestrator template into the rendered prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain('# Ralph Loop — Team orchestrator')
+      expect(out).toMatch(/orchestrator/i)
+    })
+
+    it('describes dispatching context-isolated subagents via the Task/Agent tool', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/Task\/Agent tool/)
+      expect(out).toMatch(/isolated|context-isolated/i)
+    })
+
+    it('appends PROMPT.md after the orchestrator template, with no leftover placeholder', () => {
+      const vol = setupFs({
+        projectFiles: { 'PROMPT.md': '## Stack\nReact + Vite' },
+      })
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain('## Stack\nReact + Vite')
+      expect(out.indexOf('## Stack\nReact + Vite')).toBeGreaterThan(
+        out.indexOf('# Ralph Loop — Team orchestrator'),
+      )
+      expect(out).not.toContain('{{PROJECT_PROMPT}}')
+    })
+
+    it('preserves the never-touch file list verbatim', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain(
+        "NEVER touch: `.env*`, `.git/`, `node_modules/`, `dist/`, `logs/`,\n  `ralph.sh`, `start-ralph.sh`, `PROMPT.md`, `ralph.config.sh`,\n  `.claude/`.",
+      )
+    })
+
+    it('preserves the absolute restrictions (force-push, direct push, manual merge/close)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain('NEVER `git push --force` or `git push -f`.')
+      expect(out).toMatch(/NEVER push directly to/)
+      expect(out).toMatch(/NEVER merge PRs directly/)
+      expect(out).toMatch(/NEVER close issues manually/)
+    })
+
+    it('does not warn on unknown placeholders for the orchestrator template', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
     })
   })
 

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -1,8 +1,15 @@
-# Ralph Loop — Resolve next GitHub issue
+# Ralph Loop — Team orchestrator
 
 You are an autonomous agent in an issue-resolution loop. Each invocation
 processes ONE issue end-to-end. When done, exit. The outer bash will
 invoke you again for the next issue.
+
+You act as the **orchestrator** for a team of specialized agents. Real,
+context-isolated subagents are available via the Task/Agent tool in this
+headless run, and each returns a structured result you pass forward
+explicitly — outputs do not leak between dispatches. Specialist roles
+(triage, dev, QA, review, docs) are composed into this template in later
+slices; until then you carry the full flow below yourself.
 
 Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
 operations.

--- a/packages/ralph/templates/ralph.config.sh
+++ b/packages/ralph/templates/ralph.config.sh
@@ -2,8 +2,8 @@
 # `ralph init` will not overwrite this file.
 
 # Commands Ralph runs locally before opening a PR. Empty string means
-# "skip" (or, for INSTALL_CMD, the value the prompt-base will ask Claude
-# to figure out at runtime).
+# "skip" (or, for INSTALL_CMD, the value the orchestrator prompt will ask
+# Claude to figure out at runtime).
 INSTALL_CMD="{{INSTALL_CMD}}"
 TEST_CMD="{{TEST_CMD}}"
 LINT_CMD="{{LINT_CMD}}"


### PR DESCRIPTION
Closes #421

First slice of Ralph team mode (parent #419). Introduces the composition seam without any specialist roles yet — the rendered prompt is the existing solo end-to-end flow re-expressed through a new orchestrator template.

## What changed
- **New `templates/prompt-team.md`** — orchestrator template carrying the full existing flow (select → branch → TDD → validate → commit → PR → auto-merge + wait → label). Reuses every existing `{{VARS}}` placeholder verbatim, preserves all absolute restrictions and the never-touch file list unchanged, and adds an orchestrator preamble whose subagent-dispatch wording follows the spike decision (#420): real, context-isolated Task/Agent-tool subagents.
- **`buildPrompt` now composes the orchestrator template** (`prompt-team.md`) instead of `prompt-base.md`, keeping its same dependency-injected interface (project root, env, fs, stderr → rendered string) and appending the project's `PROMPT.md` as before.
- **Removed the now-orphaned `prompt-base.md`** (solo mode is being retired per #419) and updated the stale `ralph.config.sh` comment that referenced it.

## TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js`
- Before implementation (red): the new `team orchestrator composition` describe block (and the existing suite, once `setupFs` seeded `prompt-team.md`) failed with `ENOENT … prompt-base.md` because `buildPrompt` still read the old template — 18 failing.
- After implementation (green): switched `buildPrompt` to read `prompt-team.md`; full `packages/ralph` suite passes — **334 tests pass**.

New tests cover: orchestrator template is composed in, Task/Agent context-isolated subagent wording is present, `PROMPT.md` is appended after the template with no leftover `{{PROJECT_PROMPT}}`, the never-touch list and absolute restrictions are preserved verbatim, and no unknown-placeholder warnings are emitted. Existing issue-selection exclusions (`claude-working`, `claude-failed`, `do-not-ralph`, `pending-merge`) remain asserted.

## Notes
- `npm run lint` at the repo root: 0 errors (26 pre-existing warnings in `src/`, unrelated to this change).