### PR TITLE
feat: add Ralph dev specialist role (inferred persona + TDD)

### DIFF
--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -12,6 +12,7 @@ export function buildPrompt({
 } = {}) {
   const fs = fsImpl ?? { existsSync, readFileSync }
   const orchestratorTemplate = fs.readFileSync(templatePath('prompt-team.md'), 'utf8')
+  const devRole = fs.readFileSync(templatePath('roles/dev.md'), 'utf8').toString()
   const projectPromptPath = join(projectRoot, 'PROMPT.md')
   const projectPrompt = fs.existsSync(projectPromptPath)
     ? fs.readFileSync(projectPromptPath, 'utf8').toString()
@@ -29,7 +30,10 @@ export function buildPrompt({
     PROJECT_ROOT: projectRoot,
     PROJECT_PROMPT: projectPrompt,
   }
-  return interpolate(orchestratorTemplate, vars, { stderr })
+  // Compose the dev role into the template before interpolation so the role's
+  // own {{TEST_CMD}}/{{LINT_CMD}} placeholders resolve in the same pass.
+  const composed = orchestratorTemplate.replace('{{ROLE_DEV}}', () => devRole)
+  return interpolate(composed, vars, { stderr })
 }
 
 const invokedAsScript =

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -20,9 +20,11 @@ function makeStderr() {
 
 function setupFs({ projectFiles = {} } = {}) {
   const orchestratorTemplate = readFileSync(templatePath('prompt-team.md'), 'utf8')
+  const devRole = readFileSync(templatePath('roles/dev.md'), 'utf8')
   const vol = Volume.fromJSON({}, '/')
-  vol.mkdirSync(templatePath(''), { recursive: true })
+  vol.mkdirSync(templatePath('roles'), { recursive: true })
   vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
+  vol.writeFileSync(templatePath('roles/dev.md'), devRole)
   vol.mkdirSync(PROJECT, { recursive: true })
   for (const [k, v] of Object.entries(projectFiles)) {
     vol.writeFileSync(join(PROJECT, k), v)
@@ -168,6 +170,50 @@ describe('buildPrompt', () => {
     })
 
     it('does not warn on unknown placeholders for the orchestrator template', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('dev specialist role composition', () => {
+    it('composes the dev role into the rendered prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/##+ .*Dev(eloper)?/i)
+    })
+
+    it('infers the dev persona from the issue and stack rather than a fixed role name', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/infer/i)
+      expect(out).toMatch(/stack/i)
+      // Persona is not hard-coded to one language/framework.
+      expect(out).toMatch(/persona/i)
+    })
+
+    it('carries the TDD red → green → refactor contract in the dev role', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/red.{0,3}green.{0,3}refactor/i)
+    })
+
+    it('tells the dev to write a failing test first and confirm it fails for the right reason', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/write.+failing.+test/i)
+      expect(out).toMatch(/confirm.+fail/i)
+    })
+
+    it('preserves the repeated-test-failure give-up backstop alongside the dev role', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/breaks 3 times in a row/)
+      expect(out).toMatch(/CLAUDE_GIVE_UP/)
+    })
+
+    it('does not warn on unknown placeholders once the dev role is composed', () => {
       const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
       const stderr = makeStderr()
       buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -7,9 +7,10 @@ invoke you again for the next issue.
 You act as the **orchestrator** for a team of specialized agents. Real,
 context-isolated subagents are available via the Task/Agent tool in this
 headless run, and each returns a structured result you pass forward
-explicitly — outputs do not leak between dispatches. Specialist roles
-(triage, dev, QA, review, docs) are composed into this template in later
-slices; until then you carry the full flow below yourself.
+explicitly — outputs do not leak between dispatches. Specialist roles are
+composed into this template below as they land; the **dev specialist** (step
+4) is wired in. Remaining roles (triage, QA, review, docs) arrive in later
+slices; until each lands you carry that part of the flow yourself.
 
 Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
 operations.
@@ -30,24 +31,17 @@ operations.
 
 3. **Prepare branch**: `git checkout {{DEV_BRANCH}} && git pull && git checkout -b issue-N`
 
-4. **Resolve via TDD**: read the issue title and body, then follow the
-   red → green → refactor loop. Tests come first, always.
-   1. **Red**: write a failing test that captures the expected behavior
-      described by the issue's acceptance criteria. Run `{{TEST_CMD}}`
-      and confirm the new test fails for the right reason — the
-      behavior is not yet implemented.
-   2. **Green**: implement the minimum code required to make the new
-      test pass. Run `{{TEST_CMD}}` again and confirm every test passes.
-   3. **Refactor**: tighten names, remove duplication, and improve the
-      design while keeping the suite green.
+4. **Resolve via the dev specialist**: dispatch a context-isolated
+   subagent in the **dev** role (see "Dev specialist" below) with the
+   issue title and body. The dev infers its persona from the issue and
+   the repo's detected stack and resolves the issue through the strict
+   red → green → refactor loop — tests come first, always. Have it
+   return the test file paths it added or modified and the before/after
+   suite results, which you paste into the PR body in step 7. The dev
+   uses Read/Edit/Write as needed and follows the conventions in
+   `CLAUDE.md`.
 
-   Record the test file paths you added or modified and the
-   before/after suite results — you will paste them into the PR body in
-   step 7. Skip TDD only for changes with zero behavioral impact on
-   code: pure documentation edits, plain configuration tweaks, or
-   dependency bumps without logic changes. When you skip, explain why
-   in the PR body. Use Read/Edit/Write as needed and follow the
-   conventions in `CLAUDE.md`.
+{{ROLE_DEV}}
 
 5. **Validate locally**: run `{{TEST_CMD}}` and `{{LINT_CMD}}` (skip
    the empty ones). If they fail, fix and re-run. Repeat up to 3 times;

--- a/packages/ralph/templates/roles/dev.md
+++ b/packages/ralph/templates/roles/dev.md
@@ -1,0 +1,51 @@
+## Dev specialist
+
+The dev is the specialist who turns an issue into working, tested code. It
+runs as a context-isolated subagent dispatched by the orchestrator (step 4),
+receiving only the issue and the repo it can read — its output is the diff and
+a structured summary handed back for QA and review.
+
+### Inferred persona
+
+There is **no fixed roster and no repo-declared role name.** Infer the dev
+persona for *this* issue from two signals:
+
+1. **The issue text** — what subsystem, behavior, or bug the title and body
+   describe.
+2. **The repo's detected stack** — the languages, frameworks, test runner, and
+   conventions actually present in the project (e.g. `CLAUDE.md`, manifests,
+   existing tests).
+
+Adopt the persona that best fits — a React component author for a UI bug, an
+edge-function/Deno engineer for a Supabase change, a CLI/Node engineer for
+tooling — and follow that stack's idioms. The persona is a lens, not a label:
+match the surrounding code's naming, structure, and test conventions rather
+than imposing a generic style.
+
+### TDD: red → green → refactor
+
+The dev resolves the issue through a strict test-driven loop. Tests come
+first, always.
+
+1. **Red** — write a failing test that captures the behavior described by the
+   issue's acceptance criteria. Place it next to its source per the repo's
+   suite conventions. Run `{{TEST_CMD}}` and **confirm the new test fails for
+   the right reason** — the behavior is genuinely not implemented yet, not a
+   typo, a missing import, or a wrong path.
+2. **Green** — implement the *minimum* code required to make the new test
+   pass. Run `{{TEST_CMD}}` again and confirm every test passes.
+3. **Refactor** — tighten names, remove duplication, and improve the design
+   while keeping the suite green. Re-run `{{TEST_CMD}}` after refactoring.
+
+Record the test file paths added or modified and the before/after suite
+results — the orchestrator pastes these into the PR body. Skip TDD only for
+changes with zero behavioral impact on code: pure documentation edits, plain
+configuration tweaks, or dependency bumps without logic changes; when skipped,
+explain why.
+
+### Backstop
+
+The dev does not loop forever. The orchestrator's hard bound still applies: if
+`{{TEST_CMD}}` or `{{LINT_CMD}}` breaks 3 times in a row, declare
+CLAUDE_GIVE_UP and the issue is marked failed. Getting stuck is an outcome to
+report, not to hide.


### PR DESCRIPTION
Closes #422

Part of Ralph team mode (parent #419). Adds the **dev specialist** as a composable role template and wires it into the orchestrator pipeline.

## What changed
- **New `templates/roles/dev.md`** — describes an *inferred-from-stack* dev persona (no fixed roster, no repo-declared role name) and the strict red → green → refactor TDD loop: write a failing test first, confirm it fails for the right reason, implement the minimum to pass, then refactor while green. Preserves the repeated-test-failure (`breaks 3 times in a row` → `CLAUDE_GIVE_UP`) backstop.
- **`buildPrompt` composes the dev role** into the rendered team prompt via a new `{{ROLE_DEV}}` seam. The role is spliced in *before* interpolation so its own `{{TEST_CMD}}`/`{{LINT_CMD}}` placeholders resolve in the same pass.
- **`templates/prompt-team.md`** — step 4 now dispatches a context-isolated dev subagent and references the composed role; the orchestrator preamble notes the dev role is wired in.

## TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js`
- Before implementation (red): the new `dev specialist role composition` describe block (and `setupFs` seeding `roles/dev.md`) failed with `ENOENT … roles/dev.md` — 24 failing.
- After implementation (green): created `roles/dev.md` + wired `buildPrompt`; full `packages/ralph` suite passes — **340 tests pass**. `npm run lint` clean (0 errors).

New tests assert: dev role is composed in, persona is inferred (not a fixed role name), TDD red→green→refactor present, write-a-failing-test-first / confirm-it-fails present, and the give-up backstop is preserved.