### PR TITLE
feat: add Ralph QA specialist role (augment-after-green, block-until-green)

### DIFF
--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -13,6 +13,7 @@ export function buildPrompt({
   const fs = fsImpl ?? { existsSync, readFileSync }
   const orchestratorTemplate = fs.readFileSync(templatePath('prompt-team.md'), 'utf8')
   const devRole = fs.readFileSync(templatePath('roles/dev.md'), 'utf8').toString()
+  const qaRole = fs.readFileSync(templatePath('roles/qa.md'), 'utf8').toString()
   const projectPromptPath = join(projectRoot, 'PROMPT.md')
   const projectPrompt = fs.existsSync(projectPromptPath)
     ? fs.readFileSync(projectPromptPath, 'utf8').toString()
@@ -30,9 +31,12 @@ export function buildPrompt({
     PROJECT_ROOT: projectRoot,
     PROJECT_PROMPT: projectPrompt,
   }
-  // Compose the dev role into the template before interpolation so the role's
-  // own {{TEST_CMD}}/{{LINT_CMD}} placeholders resolve in the same pass.
-  const composed = orchestratorTemplate.replace('{{ROLE_DEV}}', () => devRole)
+  // Compose the specialist roles into the template before interpolation so
+  // each role's own {{TEST_CMD}}/{{LINT_CMD}} placeholders resolve in the same
+  // pass.
+  const composed = orchestratorTemplate
+    .replace('{{ROLE_DEV}}', () => devRole)
+    .replace('{{ROLE_QA}}', () => qaRole)
   return interpolate(composed, vars, { stderr })
 }
 

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -21,10 +21,12 @@ function makeStderr() {
 function setupFs({ projectFiles = {} } = {}) {
   const orchestratorTemplate = readFileSync(templatePath('prompt-team.md'), 'utf8')
   const devRole = readFileSync(templatePath('roles/dev.md'), 'utf8')
+  const qaRole = readFileSync(templatePath('roles/qa.md'), 'utf8')
   const vol = Volume.fromJSON({}, '/')
   vol.mkdirSync(templatePath('roles'), { recursive: true })
   vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
   vol.writeFileSync(templatePath('roles/dev.md'), devRole)
+  vol.writeFileSync(templatePath('roles/qa.md'), qaRole)
   vol.mkdirSync(PROJECT, { recursive: true })
   for (const [k, v] of Object.entries(projectFiles)) {
     vol.writeFileSync(join(PROJECT, k), v)
@@ -214,6 +216,54 @@ describe('buildPrompt', () => {
     })
 
     it('does not warn on unknown placeholders once the dev role is composed', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('QA specialist role composition', () => {
+    it('composes the QA role into the rendered prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/##+ .*QA/i)
+    })
+
+    it('describes QA augmenting the suite after the dev suite is green', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/augment/i)
+      expect(out).toMatch(/after.+green|green.+suite/i)
+      expect(out).toMatch(/edge.case/i)
+      expect(out).toMatch(/adversarial/i)
+    })
+
+    it('renders the QA role after the dev role (ordering reflects QA-after-green)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const devIdx = out.search(/##+ .*Dev specialist/i)
+      const qaIdx = out.search(/##+ .*QA specialist/i)
+      expect(devIdx).toBeGreaterThan(-1)
+      expect(qaIdx).toBeGreaterThan(-1)
+      expect(qaIdx).toBeGreaterThan(devIdx)
+    })
+
+    it('states that QA-found bugs block until green (go back to the dev to fix)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/block until green/i)
+      expect(out).toMatch(/back to the dev|return.+dev|hand.+back/i)
+    })
+
+    it('reaffirms the give-up backstop as the bound on the block-until-green loop', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/breaks 3 times in a row/)
+      expect(out).toMatch(/CLAUDE_GIVE_UP/)
+    })
+
+    it('does not warn on unknown placeholders once the QA role is composed', () => {
       const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
       const stderr = makeStderr()
       buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -9,8 +9,9 @@ context-isolated subagents are available via the Task/Agent tool in this
 headless run, and each returns a structured result you pass forward
 explicitly — outputs do not leak between dispatches. Specialist roles are
 composed into this template below as they land; the **dev specialist** (step
-4) is wired in. Remaining roles (triage, QA, review, docs) arrive in later
-slices; until each lands you carry that part of the flow yourself.
+4) and the **QA specialist** (step 4b) are wired in. Remaining roles (triage,
+review, docs) arrive in later slices; until each lands you carry that part of
+the flow yourself.
 
 Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
 operations.
@@ -42,6 +43,18 @@ operations.
    `CLAUDE.md`.
 
 {{ROLE_DEV}}
+
+4b. **Harden via the QA specialist**: once the dev's suite is green,
+   dispatch a context-isolated subagent in the **QA** role (see "QA
+   specialist" below) with the issue, the dev's diff, and the tests the
+   dev added. QA augments the green suite with edge-case and adversarial
+   tests. QA-found bugs **block until green**: hand any failing QA test
+   back to the dev to fix, then return to QA to re-run `{{TEST_CMD}}`,
+   until the dev's tests plus QA's augmentation are all green. The
+   give-up backstop below still bounds this loop. Add QA's new test
+   paths to the list you paste into the PR body in step 7.
+
+{{ROLE_QA}}
 
 5. **Validate locally**: run `{{TEST_CMD}}` and `{{LINT_CMD}}` (skip
    the empty ones). If they fail, fix and re-run. Repeat up to 3 times;

--- a/packages/ralph/templates/roles/qa.md
+++ b/packages/ralph/templates/roles/qa.md
@@ -1,0 +1,40 @@
+## QA specialist
+
+The QA specialist is the adversary who hardens the dev's work. It runs as a
+context-isolated subagent dispatched by the orchestrator **after** the dev's
+suite is green — never before. QA receives the issue, the dev's diff, and the
+list of tests the dev added, and its job is to find what the dev's happy-path
+tests missed.
+
+### Augment after green
+
+QA does **not** rewrite the dev's tests or re-implement the fix. It *augments*
+the green suite with new tests the dev did not write:
+
+- **Edge cases** — empty inputs, boundary values, missing/optional fields,
+  large or malformed data, the off-by-one and the null nobody handled.
+- **Adversarial scenarios** — inputs chosen to break the implementation:
+  unexpected types, concurrent or out-of-order operations, error paths,
+  and the "what happens when this dependency fails" cases.
+
+Place new tests next to their source per the repo's suite conventions, matching
+the naming and structure already present. Run `{{TEST_CMD}}` and record which
+new tests pass and which expose a bug.
+
+### Block until green
+
+QA-discovered bugs **block until green**. A failing QA test is not a QA problem
+to paper over — it is a defect in the dev's implementation. The orchestrator
+hands the failing test(s) **back to the dev** to fix; the dev makes the minimum
+change to turn them green (red → green → refactor still applies), then control
+returns to QA to re-run `{{TEST_CMD}}`. This loop repeats until the full
+suite — the dev's tests plus QA's augmentation — is green. The issue does not
+advance to commit/PR while a QA test is red.
+
+### Backstop
+
+Block-until-green is bounded, not infinite. The orchestrator's hard give-up
+backstop still governs the loop: if `{{TEST_CMD}}` or `{{LINT_CMD}}` breaks 3
+times in a row, declare CLAUDE_GIVE_UP and the issue is marked failed. This
+ensures a genuinely intractable bug ends as a reported failure rather than an
+endless dev ↔ QA hand-off.


### PR DESCRIPTION
Closes #423

## TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js` (new "QA specialist role composition" suite, 6 cases; `setupFs` now seeds `roles/qa.md`)
- Before implementation (red): the new QA suite failed with `ENOENT roles/qa.md` (30 failures) — the QA role template and its composition seam did not exist.
- After implementation (green): all 346 tests pass.

## What changed
- New `packages/ralph/templates/roles/qa.md` — QA specialist contract: augment the dev's green suite with edge-case + adversarial tests, QA-found bugs **block until green** (handed back to the dev to fix), bounded by the existing CLAUDE_GIVE_UP backstop.
- `templates/prompt-team.md` — added step 4b (QA runs after the dev's green suite) and the `{{ROLE_QA}}` composition seam after `{{ROLE_DEV}}`, so ordering reflects QA-after-green.
- `lib/build-prompt.js` — reads `roles/qa.md` and composes it via `{{ROLE_QA}}`.

## Acceptance criteria
- [x] `roles/qa.md` describes augment-after-green with edge-case/adversarial scenarios.
- [x] QA runs after the dev's green suite (ordering reflected in the rendered prompt).
- [x] Rendered-content tests assert QA augments after green and QA-found bugs block until green.
- [x] The give-up backstop is reaffirmed as the bound on the block-until-green loop.