### PR TITLE
feat: add Ralph code reviewer role (pre-PR gate, 2-round loop-back, caveat flag)

### DIFF
--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -14,6 +14,7 @@ export function buildPrompt({
   const orchestratorTemplate = fs.readFileSync(templatePath('prompt-team.md'), 'utf8')
   const devRole = fs.readFileSync(templatePath('roles/dev.md'), 'utf8').toString()
   const qaRole = fs.readFileSync(templatePath('roles/qa.md'), 'utf8').toString()
+  const reviewerRole = fs.readFileSync(templatePath('roles/reviewer.md'), 'utf8').toString()
   const projectPromptPath = join(projectRoot, 'PROMPT.md')
   const projectPrompt = fs.existsSync(projectPromptPath)
     ? fs.readFileSync(projectPromptPath, 'utf8').toString()
@@ -37,6 +38,7 @@ export function buildPrompt({
   const composed = orchestratorTemplate
     .replace('{{ROLE_DEV}}', () => devRole)
     .replace('{{ROLE_QA}}', () => qaRole)
+    .replace('{{ROLE_REVIEW}}', () => reviewerRole)
   return interpolate(composed, vars, { stderr })
 }
 

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -22,11 +22,13 @@ function setupFs({ projectFiles = {} } = {}) {
   const orchestratorTemplate = readFileSync(templatePath('prompt-team.md'), 'utf8')
   const devRole = readFileSync(templatePath('roles/dev.md'), 'utf8')
   const qaRole = readFileSync(templatePath('roles/qa.md'), 'utf8')
+  const reviewerRole = readFileSync(templatePath('roles/reviewer.md'), 'utf8')
   const vol = Volume.fromJSON({}, '/')
   vol.mkdirSync(templatePath('roles'), { recursive: true })
   vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
   vol.writeFileSync(templatePath('roles/dev.md'), devRole)
   vol.writeFileSync(templatePath('roles/qa.md'), qaRole)
+  vol.writeFileSync(templatePath('roles/reviewer.md'), reviewerRole)
   vol.mkdirSync(PROJECT, { recursive: true })
   for (const [k, v] of Object.entries(projectFiles)) {
     vol.writeFileSync(join(PROJECT, k), v)
@@ -264,6 +266,80 @@ describe('buildPrompt', () => {
     })
 
     it('does not warn on unknown placeholders once the QA role is composed', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('reviewer specialist role composition', () => {
+    it('composes the reviewer role into the rendered prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/##+ .*review/i)
+    })
+
+    it('carries a Ralph-authored maintainability standard with nothing vendored or fetched', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/Ralph.authored/i)
+      expect(out).toMatch(/no.+(vendor|third-party|fetch)/i)
+    })
+
+    it('includes the oversized-file guard, anti-spaghetti, abstraction-quality, and prefer-deleting-indirection rules', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/oversized.file|file.+too (large|big|long)/i)
+      expect(out).toMatch(/spaghetti|ad.hoc conditional/i)
+      expect(out).toMatch(/abstraction/i)
+      expect(out).toMatch(/delet.+indirection/i)
+    })
+
+    it('refuses to approve on behavior alone', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/not.+approv.+behavior|behavior.+(seems|alone)/i)
+    })
+
+    it('gates before the PR is opened (reviewer content precedes the Open PR step)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const reviewerIdx = out.search(/##+ .*Code reviewer specialist/i)
+      const openPrIdx = out.search(/\bOpen PR\b/)
+      expect(reviewerIdx).toBeGreaterThan(-1)
+      expect(openPrIdx).toBeGreaterThan(-1)
+      expect(reviewerIdx).toBeLessThan(openPrIdx)
+      expect(out).toMatch(/pre.PR|before.+PR/i)
+    })
+
+    it('renders the reviewer role after the QA role', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const qaIdx = out.search(/##+ .*QA specialist/i)
+      const reviewerIdx = out.search(/##+ .*Code reviewer specialist/i)
+      expect(qaIdx).toBeGreaterThan(-1)
+      expect(reviewerIdx).toBeGreaterThan(-1)
+      expect(reviewerIdx).toBeGreaterThan(qaIdx)
+    })
+
+    it('loops blocking findings back to the dev, bounded to a maximum of 2 rounds', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/back to the dev|return.+dev|hand.+back/i)
+      expect(out).toMatch(/(maximum|max|up to|at most).{0,12}2 rounds/i)
+    })
+
+    it('opens the PR anyway after the round limit with a prominent warning in the PR body', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/open.+PR anyway|PR is opened anyway/i)
+      expect(out).toMatch(/warning/i)
+      expect(out).toMatch(/PR (body|description)/i)
+      expect(out).toMatch(/unresolved/i)
+    })
+
+    it('does not warn on unknown placeholders once the reviewer role is composed', () => {
       const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
       const stderr = makeStderr()
       buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -9,9 +9,9 @@ context-isolated subagents are available via the Task/Agent tool in this
 headless run, and each returns a structured result you pass forward
 explicitly — outputs do not leak between dispatches. Specialist roles are
 composed into this template below as they land; the **dev specialist** (step
-4) and the **QA specialist** (step 4b) are wired in. Remaining roles (triage,
-review, docs) arrive in later slices; until each lands you carry that part of
-the flow yourself.
+4), the **QA specialist** (step 4b), and the **code reviewer specialist** (step
+4c) are wired in. Remaining roles (triage, docs) arrive in later slices; until
+each lands you carry that part of the flow yourself.
 
 Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
 operations.
@@ -56,6 +56,19 @@ operations.
 
 {{ROLE_QA}}
 
+4c. **Review via the code reviewer specialist**: once QA's suite is green but
+   **before** any PR is opened, dispatch a context-isolated subagent in the
+   **code reviewer** role (see "Code reviewer specialist" below) with the
+   issue, the dev's diff, and the full test set. The reviewer applies the
+   Ralph-authored maintainability standard and gates the change pre-PR. Blocking
+   findings loop **back to the dev** to fix, then return to the reviewer to
+   re-check — bounded to a **maximum of 2 rounds**. If concerns remain unresolved
+   after 2 rounds, do **not** loop further: open the PR anyway in step 7 and add
+   the prominent warning block to the PR body so a human is pulled in. The
+   give-up backstop below still bounds this loop.
+
+{{ROLE_REVIEW}}
+
 5. **Validate locally**: run `{{TEST_CMD}}` and `{{LINT_CMD}}` (skip
    the empty ones). If they fail, fix and re-run. Repeat up to 3 times;
    if they still fail, go to "Failed".
@@ -77,6 +90,17 @@ operations.
    ```
 
    If TDD was skipped per step 4, replace the TDD block with `## TDD\n- Skipped: <reason — must be docs/config/dep-bump only>`.
+
+   If the code reviewer's concerns were still unresolved after the 2-round
+   limit (step 4c), prepend a prominent warning block to the PR body flagging
+   the unresolved review concerns so a human is pulled in:
+
+   ```
+   > [!WARNING]
+   > **Unresolved review concerns** — the reviewer and dev did not converge
+   > within the 2-round limit. A human must judge the following before merge:
+   > <list each unresolved blocking finding>
+   ```
 
 8. **Auto-merge + wait**:
    - `gh pr merge <pr> --auto --{{MERGE_STRATEGY}} --delete-branch`

--- a/packages/ralph/templates/roles/reviewer.md
+++ b/packages/ralph/templates/roles/reviewer.md
@@ -1,0 +1,50 @@
+## Code reviewer specialist
+
+The code reviewer is the maintainability gate. It runs as a context-isolated
+subagent dispatched by the orchestrator **after** QA's suite is green but
+**before** the PR is opened — it is a pre-PR gate, not a post-merge cleanup.
+The reviewer receives the issue, the dev's diff, and the full set of tests
+(the dev's plus QA's augmentation). Its job is to judge whether the change is
+maintainable, not merely whether it works.
+
+### Ralph-authored maintainability standard
+
+The standard below is **Ralph-authored**. Nothing here is vendored from a
+third-party skill or file, and nothing is fetched at runtime — the contract
+travels with this template and is applied as-is.
+
+Review the diff against these rules:
+
+- **Oversized-file guard** — flag files that have grown too large or too long
+  to reason about. A file that does too many things should be split along its
+  natural seams; size is a smell that hides missing boundaries.
+- **Anti-spaghetti / anti-ad-hoc-conditional** — reject tangled control flow
+  and ad-hoc conditionals bolted on to patch a symptom. Branching that grows
+  case-by-case instead of expressing a clear rule is a defect, even when the
+  tests pass.
+- **Abstraction quality** — abstractions must earn their keep: a clear name, a
+  single responsibility, and a boundary that hides real complexity. A wrong or
+  leaky abstraction is worse than none.
+- **Prefer deleting indirection over adding it** — when a layer, wrapper, or
+  indirection does not pay for itself, remove it rather than adding another on
+  top. The simplest design that satisfies the tests wins.
+- **Do not approve on behavior alone** — code must **not** be approved because
+  its "behavior seems correct" or the suite is green. Green tests are the floor,
+  not the bar. Maintainability — readability, structure, and the rules above —
+  must also hold before the change is approved.
+
+### Pre-PR gate and 2-round loop-back
+
+The reviewer gates **before** the PR exists. Blocking findings are not paper
+notes appended to a PR — they go **back to the dev** to fix, then control
+returns to the reviewer to re-check the diff and re-run `{{TEST_CMD}}` and
+`{{LINT_CMD}}`. This loop is bounded to a **maximum of 2 rounds**: the dev gets
+at most two passes to resolve blocking findings before the gate stops looping.
+
+### Caveat flag after the round limit
+
+If blocking findings remain after the 2-round limit, the bots have failed to
+converge — so pull in a human rather than loop forever. Open the PR **anyway**,
+but flag it: the PR body gets a **prominent warning block** listing the
+unresolved review concerns, so a reviewer knows exactly where the bots could
+not agree and what still needs human judgment.


### PR DESCRIPTION
Closes #424

## TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js` (new `reviewer specialist role composition` suite, 8 cases; `setupFs` now seeds `roles/reviewer.md`)
- Before implementation (red): the whole `build-prompt.test.js` file failed with `ENOENT ... roles/reviewer.md` raised in the shared `setupFs` helper (39 failures) — the reviewer role template and its `{{ROLE_REVIEW}}` composition seam did not exist yet. The 8 new reviewer assertions were among the failures.
- After implementation (green): all 355 Ralph-package tests pass (21 files). Repo-root `npm run lint`: 0 errors (26 pre-existing warnings in unrelated `src/` files; none in touched files).

## What changed
- New `packages/ralph/templates/roles/reviewer.md` — the Ralph-authored code reviewer contract: a maintainability standard (oversized-file guard, anti-spaghetti / anti-ad-hoc-conditional, abstraction quality, prefer deleting indirection, "do not approve on behavior alone"), explicitly **not** vendored from a third party and **not** fetched at runtime. It gates **pre-PR** (after QA green, before the PR exists), loops blocking findings back to the dev bounded to a **maximum of 2 rounds**, and after the limit opens the PR anyway with a prominent warning block flagging unresolved concerns.
- `templates/prompt-team.md` — updated the intro (now lists dev + QA + code reviewer as wired-in), added step `4c` (reviewer pre-PR gate + 2-round loop-back + caveat-flag) and the `{{ROLE_REVIEW}}` seam after `{{ROLE_QA}}` / before step 7, and added the `> [!WARNING]` unresolved-concerns block to the step-7 PR-body template.
- `lib/build-prompt.js` — reads `roles/reviewer.md` and composes it via `{{ROLE_REVIEW}}`.

## Acceptance criteria
- [x] `roles/reviewer.md` exists with the Ralph-authored maintainability standard (no vendored file, no runtime fetch).
- [x] Standard includes oversized-file guard, anti-spaghetti rule, abstraction-quality checks, and "do not approve on behavior alone".
- [x] The reviewer gates before the PR is opened (ordering asserted: reviewer heading precedes the Open PR step).
- [x] Blocking findings loop back to the dev, bounded to a maximum of 2 rounds.
- [x] After the round limit, the PR is opened with unresolved concerns flagged by a prominent warning in the PR body.
- [x] Rendered-content tests assert all of the above.

## Notes
- Resolves the prior blocker: #423 (QA role) is merged/closed.
- Mirrors the established dev/QA role composition seam exactly (ESM, 2-space indent, no semicolons, arrow-fn `.replace(..., () => role)` to avoid `$`-pattern interpretation).