### PR TITLE
feat: add Ralph tech writer role (infer touched docs from diff)

### DIFF
--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -15,6 +15,7 @@ export function buildPrompt({
   const devRole = fs.readFileSync(templatePath('roles/dev.md'), 'utf8').toString()
   const qaRole = fs.readFileSync(templatePath('roles/qa.md'), 'utf8').toString()
   const reviewerRole = fs.readFileSync(templatePath('roles/reviewer.md'), 'utf8').toString()
+  const writerRole = fs.readFileSync(templatePath('roles/writer.md'), 'utf8').toString()
   const projectPromptPath = join(projectRoot, 'PROMPT.md')
   const projectPrompt = fs.existsSync(projectPromptPath)
     ? fs.readFileSync(projectPromptPath, 'utf8').toString()
@@ -39,6 +40,7 @@ export function buildPrompt({
     .replace('{{ROLE_DEV}}', () => devRole)
     .replace('{{ROLE_QA}}', () => qaRole)
     .replace('{{ROLE_REVIEW}}', () => reviewerRole)
+    .replace('{{ROLE_WRITER}}', () => writerRole)
   return interpolate(composed, vars, { stderr })
 }
 

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -23,12 +23,14 @@ function setupFs({ projectFiles = {} } = {}) {
   const devRole = readFileSync(templatePath('roles/dev.md'), 'utf8')
   const qaRole = readFileSync(templatePath('roles/qa.md'), 'utf8')
   const reviewerRole = readFileSync(templatePath('roles/reviewer.md'), 'utf8')
+  const writerRole = readFileSync(templatePath('roles/writer.md'), 'utf8')
   const vol = Volume.fromJSON({}, '/')
   vol.mkdirSync(templatePath('roles'), { recursive: true })
   vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
   vol.writeFileSync(templatePath('roles/dev.md'), devRole)
   vol.writeFileSync(templatePath('roles/qa.md'), qaRole)
   vol.writeFileSync(templatePath('roles/reviewer.md'), reviewerRole)
+  vol.writeFileSync(templatePath('roles/writer.md'), writerRole)
   vol.mkdirSync(PROJECT, { recursive: true })
   for (const [k, v] of Object.entries(projectFiles)) {
     vol.writeFileSync(join(PROJECT, k), v)
@@ -343,6 +345,177 @@ describe('buildPrompt', () => {
       const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
       const stderr = makeStderr()
       buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('writer specialist role composition', () => {
+    it('composes the writer role into the rendered prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/##+ .*(tech )?writer/i)
+    })
+
+    it('discovers documentation targets from the diff rather than from configuration', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/infer|discover/i)
+      expect(out).toMatch(/diff/i)
+      expect(out).toMatch(/not.+configur|rather than.+configur|without.+configur/i)
+    })
+
+    it('mentions the kinds of docs it discovers (README, CLAUDE.md/AGENTS.md, docs/, docstrings)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/README/)
+      expect(out).toMatch(/AGENTS\.md/)
+      expect(out).toMatch(/docs\//)
+      expect(out).toMatch(/docstring/i)
+    })
+
+    it('respects the never-touch list (CLAUDE.md editable; PROMPT.md / ralph.config.sh / .claude/ off-limits)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const writerStart = out.search(/##+ .*(tech )?writer/i)
+      const writerSection = out.slice(writerStart)
+      expect(writerSection).toMatch(/CLAUDE\.md.+(editable|not on the|allowed)/i)
+      expect(writerSection).toMatch(/PROMPT\.md/)
+      expect(writerSection).toMatch(/ralph\.config\.sh/)
+      expect(writerSection).toMatch(/\.claude\//)
+    })
+
+    it('renders the writer role after the reviewer role (writer runs after the review gate)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const reviewerIdx = out.search(/##+ .*Code reviewer specialist/i)
+      const writerIdx = out.search(/##+ .*(tech )?writer specialist/i)
+      expect(reviewerIdx).toBeGreaterThan(-1)
+      expect(writerIdx).toBeGreaterThan(-1)
+      expect(writerIdx).toBeGreaterThan(reviewerIdx)
+    })
+
+    it("places the writer's step 4d before the Validate locally / Open PR steps", () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const writerIdx = out.search(/##+ .*(tech )?writer specialist/i)
+      const validateIdx = out.search(/Validate locally/)
+      const openPrIdx = out.search(/\bOpen PR\b/)
+      expect(writerIdx).toBeGreaterThan(-1)
+      expect(validateIdx).toBeGreaterThan(-1)
+      expect(openPrIdx).toBeGreaterThan(-1)
+      expect(writerIdx).toBeLessThan(validateIdx)
+      expect(writerIdx).toBeLessThan(openPrIdx)
+    })
+
+    it('does not warn on unknown placeholders once the writer role is composed', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('writer specialist role composition — adversarial edge cases', () => {
+    it('fully replaces the {{ROLE_WRITER}} placeholder (none left in the composed template)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // The dev's "no stderr warning" test is indirect; assert the literal
+      // composition placeholder is actually gone from the rendered prompt.
+      expect(out).not.toContain('{{ROLE_WRITER}}')
+    })
+
+    it('leaves no unreplaced {{ROLE_*}} composition placeholder anywhere in the output', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // Catches a future role added to the template but not wired into
+      // build-prompt.js (it would survive composition as a dangling {{ROLE_…}}).
+      expect(out).not.toMatch(/\{\{ROLE_/)
+    })
+
+    it('orders the writer strictly after the dev, QA, and reviewer roles', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const devIdx = out.search(/##+ .*Dev specialist/i)
+      const qaIdx = out.search(/##+ .*QA specialist/i)
+      const reviewerIdx = out.search(/##+ .*Code reviewer specialist/i)
+      const writerIdx = out.search(/##+ .*(tech )?writer specialist/i)
+      expect(devIdx).toBeGreaterThan(-1)
+      expect(qaIdx).toBeGreaterThan(-1)
+      expect(reviewerIdx).toBeGreaterThan(-1)
+      expect(writerIdx).toBeGreaterThan(-1)
+      expect(writerIdx).toBeGreaterThan(devIdx)
+      expect(writerIdx).toBeGreaterThan(qaIdx)
+      expect(writerIdx).toBeGreaterThan(reviewerIdx)
+    })
+
+    it('places the step "4d" marker after the reviewer step and before step 5 "Validate locally"', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const step4dIdx = out.search(/\b4d\.\s/)
+      const reviewerStepIdx = out.search(/\b4c\.\s/)
+      const validateIdx = out.search(/5\.\s+\*\*Validate locally\*\*/)
+      expect(step4dIdx).toBeGreaterThan(-1)
+      expect(reviewerStepIdx).toBeGreaterThan(-1)
+      expect(validateIdx).toBeGreaterThan(-1)
+      expect(step4dIdx).toBeGreaterThan(reviewerStepIdx)
+      expect(step4dIdx).toBeLessThan(validateIdx)
+    })
+
+    it('presents CLAUDE.md / AGENTS.md / README as editable, not forbidden', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const writerStart = out.search(/##+ .*(tech )?writer specialist/i)
+      const writerSection = out.slice(writerStart)
+      // Inverse of the dev's "off-limits names appear" test: the editable docs
+      // must be explicitly framed as editable / fair game, never as off-limits.
+      expect(writerSection).toMatch(/CLAUDE\.md`?\*? is editable/i)
+      expect(writerSection).toMatch(/`AGENTS\.md`.*are likewise fair game|fair game/i)
+      // CLAUDE.md must not be described as never-touch / off-limits here.
+      expect(writerSection).not.toMatch(/CLAUDE\.md[^\n]*never touch/i)
+      expect(writerSection).not.toMatch(/CLAUDE\.md[^\n]*off-limits/i)
+    })
+
+    it('interpolates {{TEST_CMD}} / {{LINT_CMD}} inside the writer section', () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { TEST_CMD: 'cargo test --all', LINT_CMD: 'cargo clippy --strict' },
+        fs: vol,
+      })
+      const writerStart = out.search(/##+ .*(tech )?writer specialist/i)
+      const writerSection = out.slice(writerStart)
+      expect(writerSection).toContain('cargo test --all')
+      expect(writerSection).toContain('cargo clippy --strict')
+      expect(writerSection).not.toContain('{{TEST_CMD}}')
+      expect(writerSection).not.toContain('{{LINT_CMD}}')
+    })
+
+    it("does not clobber, corrupt, or re-template a project PROMPT.md that contains a literal {{ROLE_WRITER}}", () => {
+      // Adversarial: the project's own PROMPT.md mentions the literal
+      // {{ROLE_WRITER}} and {{TEST_CMD}}. PROMPT.md is injected as the value of
+      // {{PROJECT_PROMPT}} during interpolate's single pass, so replacement
+      // values are NOT re-scanned. Pin the real behavior: the writer role still
+      // composes correctly, the project's literal text survives verbatim, and
+      // composition neither throws nor emits a warning.
+      const projectPrompt =
+        '## Stack\nOur docs literally cite {{ROLE_WRITER}} and run {{TEST_CMD}} ourselves.'
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': projectPrompt } })
+      const stderr = makeStderr()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { TEST_CMD: 'pytest -q' },
+        fs: vol,
+        stderr,
+      })
+      // Writer role still composed correctly (not clobbered by the stray token).
+      expect(out).toContain('## Tech writer specialist')
+      // The project's literal text is preserved verbatim — not re-interpolated.
+      expect(out).toContain(projectPrompt)
+      // Exactly one {{ROLE_WRITER}} survives: the one inside PROMPT.md, the
+      // composition slot itself was filled.
+      expect((out.match(/\{\{ROLE_WRITER\}\}/g) || []).length).toBe(1)
+      // The stray token in PROMPT.md does not trigger an interpolate warning,
+      // because injected replacement values are not re-scanned.
       expect(stderr.calls).toHaveLength(0)
     })
   })

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -9,9 +9,10 @@ context-isolated subagents are available via the Task/Agent tool in this
 headless run, and each returns a structured result you pass forward
 explicitly — outputs do not leak between dispatches. Specialist roles are
 composed into this template below as they land; the **dev specialist** (step
-4), the **QA specialist** (step 4b), and the **code reviewer specialist** (step
-4c) are wired in. Remaining roles (triage, docs) arrive in later slices; until
-each lands you carry that part of the flow yourself.
+4), the **QA specialist** (step 4b), the **code reviewer specialist** (step
+4c), and the **tech writer specialist** (step 4d) are wired in. Remaining roles
+(triage) arrive in later slices; until each lands you carry that part of the
+flow yourself.
 
 Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
 operations.
@@ -68,6 +69,19 @@ operations.
    give-up backstop below still bounds this loop.
 
 {{ROLE_REVIEW}}
+
+4d. **Document via the tech writer specialist**: once the review gate has
+   passed, dispatch a context-isolated subagent in the **tech writer** role
+   (see "Tech writer specialist" below) with the issue and the dev's diff. The
+   writer inspects the diff and **discovers** which documentation the change
+   implies — README, `CLAUDE.md`/`AGENTS.md`, `docs/` files, inline
+   docstrings — updating targets inferred from the diff rather than from
+   configuration, so it works on any repo. It respects the never-touch list:
+   `CLAUDE.md` is editable, but `PROMPT.md`, `ralph.config.sh`, and `.claude/`
+   remain off-limits. Add the doc files it updated to the list you paste into
+   the PR body in step 7.
+
+{{ROLE_WRITER}}
 
 5. **Validate locally**: run `{{TEST_CMD}}` and `{{LINT_CMD}}` (skip
    the empty ones). If they fail, fix and re-run. Repeat up to 3 times;

--- a/packages/ralph/templates/roles/writer.md
+++ b/packages/ralph/templates/roles/writer.md
@@ -1,0 +1,48 @@
+## Tech writer specialist
+
+The tech writer keeps the documentation honest. It runs as a context-isolated
+subagent dispatched by the orchestrator **after** the review gate has passed —
+the code is green and approved, and the writer's job is to make the docs match
+what the change actually did. It receives the issue and the dev's code diff, and
+returns the list of documentation files it updated for the PR body.
+
+### Discover doc targets from the diff, not from configuration
+
+There is **no configured doc map and no repo-declared list of files to touch.**
+The writer **infers** which documentation a change implies by inspecting the
+code diff itself, so it works on any repo without setup. Read the diff, then
+discover and update whichever docs the change implies:
+
+- **README** — when the change alters setup, usage, commands, or the project's
+  surface a reader sees first.
+- **CLAUDE.md / AGENTS.md** — when the change shifts conventions, steering
+  rules, or guidance that an AI assistant working on the repo must follow.
+- **`docs/` files** — when the change touches a subsystem that has its own
+  reference page under `docs/`.
+- **Inline docstrings / comments** — when a function, module, or public API the
+  diff edited now describes itself incorrectly.
+
+Only update docs the diff actually implies. Do not invent documentation for
+behavior the change did not introduce, and do not rewrite docs the diff leaves
+untouched. Discovery is driven by the diff, **not** by configuration.
+
+### Respect the never-touch list
+
+The writer edits documentation, but the orchestrator's never-touch list still
+binds it. In particular:
+
+- **`CLAUDE.md` is editable** — it is **not on the** never-touch list, so the
+  writer may update it when the diff implies a convention or guidance change.
+  (`AGENTS.md`, `README`, and `docs/` files are likewise fair game.)
+- **`PROMPT.md`, `ralph.config.sh`, and `.claude/` remain off-limits** — the
+  writer must **never** touch these, along with the rest of the never-touch
+  list (`.env*`, `.git/`, `node_modules/`, `dist/`, `logs/`, `ralph.sh`,
+  `start-ralph.sh`). These govern the loop itself, not the project's docs.
+
+### No tests, no new behavior
+
+Documentation edits carry zero behavioral impact on code, so the writer does
+not write tests for them. After updating docs it re-runs `{{TEST_CMD}}` and
+`{{LINT_CMD}}` (skipping the empty ones) only to confirm the doc edits did not
+break the green suite, then hands the updated file list back to the
+orchestrator for the PR body.


### PR DESCRIPTION
Closes #425

## TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js`
- Before implementation (red): the new `writer specialist role composition` tests failed because `{{ROLE_WRITER}}` was not composed into the rendered prompt — e.g. `composes the writer role into the rendered prompt` (writer heading absent), `mentions the kinds of docs it discovers` (README not found), `respects the never-touch list` (writer section empty), and the ordering tests (writer heading index `-1`). All failed on missing composed content, not typos/paths — the correct red.
- After implementation (green): all 369 tests pass in `packages/ralph` (21 files); repo-root `npm run lint` reports 0 errors (26 pre-existing warnings in unrelated `src/` files).

## What changed
- **`packages/ralph/templates/roles/writer.md`** (new) — `## Tech writer specialist` role: runs after the review gate, discovers documentation targets (README, CLAUDE.md/AGENTS.md, `docs/`, inline docstrings) **from the diff rather than from configuration** so it works on any repo, and respects the never-touch list (`CLAUDE.md` editable; `PROMPT.md`, `ralph.config.sh`, `.claude/` off-limits). Docs-only edits carry no behavioral impact, so the writer writes no tests.
- **`packages/ralph/lib/build-prompt.js`** — reads `roles/writer.md` and composes `{{ROLE_WRITER}}` after `{{ROLE_REVIEW}}`, mirroring the existing per-role wiring.
- **`packages/ralph/templates/prompt-team.md`** — new **step 4d** orchestration paragraph + `{{ROLE_WRITER}}` placeholder, placed after the reviewer (4c) and before step 5 (Validate locally). Intro updated to list the tech writer as wired; remaining roles reduced to "(triage)".

## Team-mode flow
Resolved through the Ralph specialist team: **dev** (TDD red→green→refactor) → **QA** (7 adversarial/edge-case tests added — exactly-once placeholder replacement, no leftover `{{ROLE_*}}`, full ordering, inverse never-touch framing, `{{TEST_CMD}}`/`{{LINT_CMD}}` interpolation, adversarial PROMPT.md pin; no defects found) → **reviewer** (APPROVE, no blocking findings; explicit per-role wiring kept as the established idiom) → **tech writer** (inspected the diff; no prose docs imply an update — consistent with the prior three role-addition PRs #440/#447/#456, which likewise touched only the role templates).

## Notes
- This issue was blocked by #424 (reviewer role), whose code is already merged on `dev` (commit ff7e6e0) and is in `pending-merge` — the blocker is satisfied.
- Modifying `packages/ralph/**` is permitted here because the issue is explicitly about the Ralph package.