### PR TITLE
feat: Ralph team-mode triage-and-scale + per-role PR body

### DIFF
--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -520,6 +520,327 @@ describe('buildPrompt', () => {
     })
   })
 
+  describe('triage-and-scale', () => {
+    it('instructs the orchestrator to classify/triage each issue before dispatching', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/triage|classif/i)
+      expect(out).toMatch(/scale.+team|team.+(size|scales)/i)
+    })
+
+    it('routes trivial / non-behavioral changes (pure docs, plain config, dependency bumps) to a light path', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/trivial/i)
+      expect(out).toMatch(/pure docs/i)
+      expect(out).toMatch(/plain config/i)
+      expect(out).toMatch(/dependency bump/i)
+    })
+
+    it('skips the dev-TDD and QA phases for trivial issues, running only a light review plus the writer', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/skip.+(dev.TDD|TDD).+(and )?QA|skip.+QA/i)
+      expect(out).toMatch(/light review/i)
+      expect(out).toMatch(/writer/i)
+    })
+
+    it('runs the full team for substantive changes', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/substantive/i)
+      expect(out).toMatch(/full team/i)
+    })
+
+    it('keeps the trivial boundary conservative — config that carries logic is treated as substantive', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/conservative/i)
+      expect(out).toMatch(/config.+logic|logic.+config/i)
+      expect(out).toMatch(/substantive/i)
+    })
+
+    it('places the triage/scale step before the dev dispatch (step 4)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const triageIdx = out.search(/triage|classif/i)
+      const devDispatchIdx = out.search(/4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      expect(triageIdx).toBeGreaterThan(-1)
+      expect(devDispatchIdx).toBeGreaterThan(-1)
+      expect(triageIdx).toBeLessThan(devDispatchIdx)
+    })
+
+    it('does not warn on unknown placeholders once the triage/scale section is added', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('per-role PR body', () => {
+    it('adds a Dev/TDD section to the PR body template', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/## Dev\/TDD/)
+    })
+
+    it('adds a QA scenarios section to the PR body template', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/## QA scenarios/i)
+    })
+
+    it('adds a Review verdict section that flags unresolved concerns when the round limit was hit', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/## Review verdict/i)
+      expect(out).toMatch(/unresolved/i)
+      expect(out).toMatch(/round limit|2-round limit|round.limit/i)
+    })
+
+    it('adds a Docs updated section to the PR body template', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/## Docs updated/i)
+    })
+
+    it('retains a single per-issue log (no per-role logs)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/single per-issue log/i)
+      expect(out).toMatch(/no per-role log/i)
+    })
+
+    it('orders the per-role PR-body sections Dev/TDD → QA → Review → Docs', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const devIdx = out.search(/## Dev\/TDD/)
+      const qaIdx = out.search(/## QA scenarios/i)
+      const reviewIdx = out.search(/## Review verdict/i)
+      const docsIdx = out.search(/## Docs updated/i)
+      expect(devIdx).toBeGreaterThan(-1)
+      expect(qaIdx).toBeGreaterThan(devIdx)
+      expect(reviewIdx).toBeGreaterThan(qaIdx)
+      expect(docsIdx).toBeGreaterThan(reviewIdx)
+    })
+
+    it('keeps the per-role PR-body sections inside the Open PR step', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const openPrIdx = out.search(/\bOpen PR\b/)
+      const devIdx = out.search(/## Dev\/TDD/)
+      expect(openPrIdx).toBeGreaterThan(-1)
+      expect(devIdx).toBeGreaterThan(openPrIdx)
+    })
+
+    it('does not warn on unknown placeholders once the per-role PR body is added', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('triage-and-scale — QA hardening', () => {
+    const FULL_ENV = {
+      INSTALL_CMD: 'pnpm install --frozen-lockfile',
+      TEST_CMD: 'cargo test --all',
+      LINT_CMD: 'cargo clippy --strict',
+      MAIN_BRANCH: 'release',
+      DEV_BRANCH: 'integration',
+      PR_TARGET: 'integration',
+      MERGE_STRATEGY: 'merge',
+      MERGE_POLL_INTERVAL: '7',
+      MERGE_POLL_MAX: '99',
+    }
+
+    function triageSection(out) {
+      const start = out.search(/3b\.\s/)
+      const end = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      return out.slice(start, end === -1 ? undefined : end)
+    }
+
+    it('survives interpolation with custom env — no leftover {{...}} in the triage section', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '## Stack\nRust' } })
+      const out = buildPrompt({ projectRoot: PROJECT, env: FULL_ENV, fs: vol })
+      const section = triageSection(out)
+      expect(section).toMatch(/triage/i)
+      // The prose is static, but the whole prompt must not strand any
+      // placeholder under a fully-populated env.
+      expect(section).not.toMatch(/\{\{[A-Za-z_]/)
+    })
+
+    it('places step 3b strictly AFTER "Prepare branch" (step 3) and BEFORE the dev dispatch (step 4)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const prepareIdx = out.search(/3\.\s+\*\*Prepare branch\*\*/)
+      const triageIdx = out.search(/3b\.\s+\*\*Triage and scale/i)
+      const devDispatchIdx = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      expect(prepareIdx).toBeGreaterThan(-1)
+      expect(triageIdx).toBeGreaterThan(-1)
+      expect(devDispatchIdx).toBeGreaterThan(-1)
+      expect(triageIdx).toBeGreaterThan(prepareIdx)
+      expect(triageIdx).toBeLessThan(devDispatchIdx)
+    })
+
+    it('places step 3b before every downstream dispatch step (4, 4b, 4c, 4d)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const triageIdx = out.search(/3b\.\s+\*\*Triage and scale/i)
+      const step4Idx = out.search(/\n4\.\s+\*\*Resolve via the dev/)
+      const step4bIdx = out.search(/\b4b\.\s+\*\*Harden via the QA/)
+      const step4cIdx = out.search(/\b4c\.\s+\*\*Review via the code reviewer/)
+      const step4dIdx = out.search(/\b4d\.\s+\*\*Document via the tech writer/)
+      for (const idx of [step4Idx, step4bIdx, step4cIdx, step4dIdx]) {
+        expect(idx).toBeGreaterThan(-1)
+        expect(triageIdx).toBeLessThan(idx)
+      }
+    })
+
+    it('states the conservative direction: when in doubt, treat as substantive (not merely that both words appear)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // The boundary must resolve doubt TOWARD substantive, not the reverse.
+      // Tolerate the prose wrap between the two phrases (newline + indent).
+      expect(section).toMatch(/when in doubt[\s\S]{0,60}substantive/i)
+    })
+
+    it('ties runtime-read / logic-carrying config explicitly to "substantive", not trivial', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // Config that the code reads at runtime / carries logic must be called
+      // out as substantive (i.e. NOT plain config).
+      expect(section).toMatch(/config.+(carries )?logic[\s\S]{0,160}substantive/i)
+      expect(section).toMatch(/runtime/i)
+    })
+
+    it('keeps the trivial light path explicit: skips dev-TDD AND QA, but still runs review + writer', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // Skips steps 4 and 4b (dev-TDD + QA)...
+      expect(section).toMatch(/skip.+dev.TDD.+QA|skip.+TDD.+QA/i)
+      expect(section).toMatch(/steps?\s+4\s+and\s+4b/i)
+      // ...but still runs the review (4c) and writer (4d).
+      expect(section).toMatch(/light review/i)
+      expect(section).toMatch(/4c.+4d|steps?\s+4c.+4d/i)
+      expect(section).toMatch(/writer/i)
+    })
+
+    it('does not warn under a NON-empty PROMPT.md and a fully-populated custom env', () => {
+      const vol = setupFs({
+        projectFiles: { 'PROMPT.md': '## Stack\nRust + cargo\n\nSome project notes.' },
+      })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: FULL_ENV, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('per-role PR body — QA hardening', () => {
+    function prBodySection(out) {
+      const start = out.search(/Closes #N/)
+      const end = out.search(/## Notes/)
+      return out.slice(start, end)
+    }
+
+    it('places all four per-role sections between "Closes #N" and "## Notes"', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const closesIdx = out.search(/Closes #N/)
+      const notesIdx = out.search(/## Notes/)
+      expect(closesIdx).toBeGreaterThan(-1)
+      expect(notesIdx).toBeGreaterThan(closesIdx)
+      const section = prBodySection(out)
+      expect(section).toMatch(/## Dev\/TDD/)
+      expect(section).toMatch(/## QA scenarios/)
+      expect(section).toMatch(/## Review verdict/)
+      expect(section).toMatch(/## Docs updated/)
+    })
+
+    it('places the PR-body template after the "Open PR" step heading', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const openPrIdx = out.search(/\*\*Open PR\*\*/)
+      const closesIdx = out.search(/Closes #N/)
+      expect(openPrIdx).toBeGreaterThan(-1)
+      expect(closesIdx).toBeGreaterThan(openPrIdx)
+    })
+
+    it('renders exactly one of each per-role heading (no accidental duplication)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect((out.match(/## Dev\/TDD/g) || []).length).toBe(1)
+      expect((out.match(/## QA scenarios added/g) || []).length).toBe(1)
+      expect((out.match(/## Review verdict/g) || []).length).toBe(1)
+      expect((out.match(/## Docs updated/g) || []).length).toBe(1)
+    })
+
+    it('replaced the old standalone "## TDD" heading with "## Dev/TDD" (no bare ## TDD left)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // The renamed section must not leave a bare "## TDD" line behind.
+      expect(out).not.toMatch(/^\s*## TDD\s*$/m)
+    })
+
+    it('ties the TDD-skipped PR-body instruction to the triage step (3b), not the old step 4', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // The skip instruction must reference triage / step 3b as the trigger.
+      expect(out).toMatch(/skipped per the triage in step 3b|skipped.+triage.+3b/i)
+      // And it must replace the Dev/TDD section (the renamed one), plus mark QA skipped.
+      expect(out).toMatch(/replace the Dev\/TDD section/i)
+      expect(out).toMatch(/QA scenarios section with.+Skipped/i)
+    })
+
+    it('survives interpolation with custom env — no leftover {{...}} in the Open-PR / PR-body region', () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { PR_TARGET: 'integration', MERGE_STRATEGY: 'merge' },
+        fs: vol,
+      })
+      const start = out.search(/\*\*Open PR\*\*/)
+      const end = out.search(/## Absolute restrictions/)
+      const region = out.slice(start, end)
+      expect(region).toContain('--base integration')
+      expect(region).not.toMatch(/\{\{[A-Za-z_]/)
+    })
+
+    it('keeps the unresolved-concern warning block tied to the Review verdict section', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // After the 2-round limit, concerns are flagged in Review verdict AND a
+      // warning block is prepended.
+      expect(out).toMatch(/flag them in the Review verdict section/i)
+      expect(out).toMatch(/\[!WARNING\]/)
+      expect(out).toMatch(/Unresolved review concerns/i)
+    })
+
+    it('does not warn under a NON-empty PROMPT.md and a fully-populated custom env', () => {
+      const vol = setupFs({
+        projectFiles: { 'PROMPT.md': '## Stack\nGo + go test\n\nNotes here.' },
+      })
+      const stderr = makeStderr()
+      buildPrompt({
+        projectRoot: PROJECT,
+        env: {
+          INSTALL_CMD: 'go mod download',
+          TEST_CMD: 'go test ./...',
+          LINT_CMD: 'golangci-lint run',
+          PR_TARGET: 'dev',
+          MERGE_STRATEGY: 'rebase',
+        },
+        fs: vol,
+        stderr,
+      })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
   describe('issue selection query', () => {
     function selectQuery(out) {
       const match = out.match(/gh issue list[^\n]*--search '([^']+)'/)

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -10,9 +10,10 @@ headless run, and each returns a structured result you pass forward
 explicitly — outputs do not leak between dispatches. Specialist roles are
 composed into this template below as they land; the **dev specialist** (step
 4), the **QA specialist** (step 4b), the **code reviewer specialist** (step
-4c), and the **tech writer specialist** (step 4d) are wired in. Remaining roles
-(triage) arrive in later slices; until each lands you carry that part of the
-flow yourself.
+4c), and the **tech writer specialist** (step 4d) are wired in. You also
+triage each issue and scale the team to fit it (step 3b): trivial,
+non-behavioral changes take a light path, while substantive changes run the
+full team.
 
 Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
 operations.
@@ -32,6 +33,25 @@ operations.
 2. **Mark in progress**: `gh issue edit N --add-label claude-working`
 
 3. **Prepare branch**: `git checkout {{DEV_BRANCH}} && git pull && git checkout -b issue-N`
+
+3b. **Triage and scale the team**: before dispatching, classify the issue and
+   scale the team to fit it. Read the issue and the files it implies, then pick
+   one of two paths:
+   - **Trivial / non-behavioral** — the change has no behavioral impact on code:
+     pure docs, plain config, or dependency bumps without logic changes.
+     Skip dev-TDD and QA (steps 4 and 4b) and run only a **light review** plus
+     the writer (steps 4c, 4d). "Light" means the same reviewer (step 4c), just
+     over a docs/config-only diff with no QA augmentation to weigh. Note "TDD
+     skipped (trivial)" for the PR body.
+   - **Substantive** — anything that changes behavior: source code, logic, or any
+     change you cannot prove is purely cosmetic. Run the **full team** — dev,
+     QA, review, writer (steps 4 through 4d).
+
+   Keep the trivial boundary **conservative**: when in doubt, treat the issue as
+   substantive and run the full team. Config that carries logic (build/test
+   wiring, CI behavior, anything the code reads at runtime) is **not** plain
+   config — it is substantive. Only classify as trivial when the change provably
+   cannot alter behavior.
 
 4. **Resolve via the dev specialist**: dispatch a context-isolated
    subagent in the **dev** role (see "Dev specialist" below) with the
@@ -94,20 +114,36 @@ operations.
    ```
    Closes #N
 
-   ## TDD
+   ## Dev/TDD
    - Tests added/modified: <relative file paths>
    - Before implementation (red): <failing test names + summary of failure>
    - After implementation (green): <suite result, e.g. "all 143 tests pass">
+
+   ## QA scenarios added
+   - <edge-case / adversarial scenarios QA added, and the test paths>
+
+   ## Review verdict
+   - <reviewer's verdict and any blocking findings resolved this round>
+
+   ## Docs updated
+   - <documentation files the writer updated, or "none — diff implied no doc change">
 
    ## Notes
    <anything else worth flagging for review>
    ```
 
-   If TDD was skipped per step 4, replace the TDD block with `## TDD\n- Skipped: <reason — must be docs/config/dep-bump only>`.
+   Each section carries one role's output — Dev/TDD from step 4, QA scenarios
+   from step 4b, Review verdict from step 4c, Docs updated from step 4d. Retain
+   a **single per-issue log** (`logs/ralph-issue-N.log`) for the whole team run;
+   there are **no per-role logs**.
+
+   If TDD was skipped per the triage in step 3b, replace the Dev/TDD section
+   body with `- Skipped: <reason — must be docs/config/dep-bump only>` and the
+   QA scenarios section with `- Skipped (trivial — light path)`.
 
    If the code reviewer's concerns were still unresolved after the 2-round
-   limit (step 4c), prepend a prominent warning block to the PR body flagging
-   the unresolved review concerns so a human is pulled in:
+   limit (step 4c), flag them in the Review verdict section and prepend a
+   prominent warning block to the PR body so a human is pulled in:
 
    ```
    > [!WARNING]


### PR DESCRIPTION
Closes #426

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js`
- Before implementation (red): new `triage-and-scale` and `per-role PR body` describe blocks failed for the right reason — the rendered template had no triage/scale prose (no `trivial`/`pure docs`/`plain config`/`dependency bump`/`conservative`/`full team` text) and the PR-body template carried only a single `## TDD`/`## Notes` block (no `## Dev/TDD`, `## QA scenarios added`, `## Review verdict`, `## Docs updated`, no single-per-issue-log statement). 12 of 15 new assertions failed; ordering tests returned `-1`.
- After implementation (green): all 399 tests pass (21 files), up from a 369 baseline.

## QA scenarios added
- `packages/ralph/lib/build-prompt.test.js` — `triage-and-scale — QA hardening` and `per-role PR body — QA hardening` describe blocks (15 tests). Coverage: interpolation safety (no leftover `{{...}}`/`{{ROLE_*}}` in the triage and Open-PR regions under custom env); no-warn invariant under a non-empty PROMPT.md and fully-populated env; step 3b ordered strictly after step 3 and before every downstream dispatch (4/4b/4c/4d); conservative-boundary *direction* ("when in doubt → substantive", runtime-read/logic config = substantive); skip-path coherence (skips dev-TDD AND QA, still runs review + writer; TDD-skip instruction references step 3b); per-role sections placed between `Closes #N` and `## Notes` and after `Open PR`; exactly one of each per-role heading; the old bare `## TDD` heading fully replaced by `## Dev/TDD`; unresolved-concern warning tied to the Review verdict section. All 15 pass — no implementation defect exposed.

## Review verdict
- APPROVED (pre-PR maintainability gate, 1 round). No blocking findings. Voice/structure consistent with existing role sections and step numbering; no contradiction between new step 3b and steps 4/4b/4c/4d; tests pin meaningful content (not brittle whitespace matching). One non-blocking clarity nit — "light review" was introduced but undefined — was resolved by adding a clause to step 3b clarifying it means the same reviewer (4c) over a docs/config-only diff with no QA augmentation. No unresolved concerns; round limit not hit.

## Docs updated
- none — the diff touched only the orchestrator template (source of truth) and its tests. The writer surveyed `packages/ralph/README.md`, `packages/ralph/docs/team-mode-spike.md`, repo `README.md`, `CLAUDE.md`, `docs/ai-dev-team.md`, `docs/releasing.md`, `docs/features.md`, and the `build-prompt.js` header; no living doc enumerates the orchestrator's numbered steps or per-role PR-body template in a way this change renders stale.

## Notes
- Pure prompt-template + rendering change in the `packages/ralph/` npm package (in scope: the issue is explicitly about `buildPrompt` and team-mode). No new `{{...}}` placeholder introduced (plain prose only), so `build-prompt.js` needed no change and the no-warn invariant holds.
- Existing step anchors (`4c.`, `4d.`, `5. **Validate locally**`, `Open PR`, the never-touch verbatim block, absolute-restrictions block) left intact; the triage step is numbered `3b` to avoid renumbering.
- Validation: `npm test` (packages/ralph) → 399 passed; `npm run lint` (root) → 0 errors (26 pre-existing warnings in unrelated `src/` files).