### PR TITLE
feat!: retire Ralph solo mode + regression guard + README/CHANGELOG rewrite

### DIFF
--- a/packages/ralph/CHANGELOG.md
+++ b/packages/ralph/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `@lucasfe/ralph` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING: Ralph solo mode is permanently retired.** Team mode is
+  now the only mode of operation — there is no activation flag to opt
+  in or out. Every issue is resolved by the orchestrated team of
+  specialists (dev → QA → review → writer, scaled by triage); the
+  single-agent TDD loop now lives inside the dev role. The solo
+  orchestrator template (`prompt-base.md`) has been removed, and a
+  regression guard locks the retirement in so it cannot be silently
+  reintroduced. Shipped as a breaking change (`feat!:`).
+
 ## [0.5.0-rc.1](https://github.com/lucasfe/agenthub/compare/ralph-v0.4.0-rc.1...ralph-v0.5.0-rc.1) (2026-04-30)
 
 

--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -55,23 +55,61 @@ detach with `Ctrl+B` then `D`, or tail per-issue logs in
 
 ## How Ralph resolves issues
 
-Every iteration follows a **TDD red → green → refactor** loop, baked
-into the prompt Claude receives:
+Each iteration runs a **team** of context-isolated specialists,
+coordinated by an orchestrator that processes one issue end-to-end.
+Solo mode has been retired: team mode is the only mode, with no
+activation flag.
 
-1. **Red** — write a failing test that captures the issue's expected
-   behavior, then run `TEST_CMD` and confirm it fails for the right
-   reason (the behavior is not yet implemented).
-2. **Green** — implement the minimum code that makes the new test pass,
-   then run `TEST_CMD` again and confirm every test passes.
-3. **Refactor** — tighten names, remove duplication, and improve the
-   design while keeping the suite green.
+The orchestrator first **triages** the issue and scales the team to
+fit it:
+
+- **Trivial / non-behavioral** — pure docs, plain config, or
+  dependency bumps without logic changes. It skips the dev-TDD and QA
+  stages and runs only a light review plus the writer. The boundary is
+  conservative: when in doubt, the issue is treated as substantive.
+- **Substantive** — anything that changes behavior. It runs the full
+  team, in order: dev → QA → review → writer.
+
+The specialists each have a single contract:
+
+1. **Dev** — turns the issue into working, tested code through a
+   strict **TDD red → green → refactor** loop. *Red:* write a failing
+   test that captures the issue's expected behavior and confirm it
+   fails for the right reason. *Green:* implement the minimum code that
+   makes it pass and confirm the whole suite is green. *Refactor:*
+   tighten names and remove duplication while keeping it green. The dev
+   infers its persona from the issue and the repo's detected stack, and
+   skips TDD only for changes with zero behavioral impact.
+2. **QA** — runs only after the dev's suite is green, and *augments*
+   (never rewrites) it with edge-case and adversarial tests. A failing
+   QA test is treated as a defect and **blocks until green**: it goes
+   back to the dev to fix, then control returns to QA to re-run the
+   suite, until everything passes.
+3. **Reviewer** — a **pre-PR gate**, run after QA is green but before
+   any PR is opened. It judges maintainability (oversized files,
+   tangled control flow, weak abstractions, needless indirection), not
+   just whether the code works. Blocking findings loop **back to the
+   dev** and then back to the reviewer, bounded to a **maximum of 2
+   rounds**. If concerns remain after the round limit, the loop stops
+   and a human is pulled in via the caveat flag (below).
+4. **Writer** — runs after the review gate passes. It inspects the
+   diff and **infers** which docs the change implies (README,
+   `CLAUDE.md`/`AGENTS.md`, `docs/` pages, inline docstrings),
+   updating only those — it writes no tests and introduces no new
+   behavior.
 
 The new/updated tests and the implementation land in the same commit
-so the TDD pair is reviewable together. The PR body documents the
-TDD steps (tests added, failing names before, green suite result
-after). TDD is skipped only for changes with zero behavioral impact:
-pure documentation, plain configuration, or dependency bumps without
-logic changes — and the skip is justified in the PR body.
+so the TDD pair is reviewable together. The PR body carries one
+section per role: Dev/TDD (tests added, red names before, green suite
+after), QA scenarios, Review verdict, and Docs updated. When TDD is
+skipped per triage, the Dev/TDD and QA sections record the skip and
+its justification.
+
+When the reviewer and dev do **not** converge within the 2-round
+limit, the PR is opened **anyway** with a **caveat flag** — a
+prominent unresolved-concerns warning block prepended to the PR body
+listing each blocking finding, so a human knows exactly what still
+needs judgment before merge.
 
 ## Scheduling Ralph (macOS launchd)
 

--- a/packages/ralph/lib/solo-mode-retired.qa.test.js
+++ b/packages/ralph/lib/solo-mode-retired.qa.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { buildPrompt } from './build-prompt.js'
+import { templatePath, TEMPLATES_DIR } from './paths.js'
+
+// QA augmentation for issue #427 (solo mode retired). The dev's guard
+// (solo-mode-retired.test.js) locks the RENDERED prompt and the
+// `build-prompt.js` SOURCE. These adversarial tests close the gaps a future
+// refactor could slip through while still passing that guard:
+//   - the on-disk SOURCE templates themselves carrying solo prose,
+//   - a role file being DROPPED (off-by-one toward a thinner/solo-like flow),
+//   - the `prompt-base.md` path guard pointing somewhere it could never exist,
+//     making the guard vacuously true.
+
+const PROJECT = '/project'
+
+// The four role source files that get composed into the orchestrator.
+const ROLE_FILES = ['roles/dev.md', 'roles/qa.md', 'roles/reviewer.md', 'roles/writer.md']
+const ALL_SOURCE_TEMPLATES = ['prompt-team.md', ...ROLE_FILES]
+
+// Same memfs mirror the dev's guard / build-prompt.test.js use.
+function setupFs() {
+  const vol = Volume.fromJSON({}, '/')
+  vol.mkdirSync(templatePath('roles'), { recursive: true })
+  vol.writeFileSync(templatePath('prompt-team.md'), readFileSync(templatePath('prompt-team.md'), 'utf8'))
+  for (const role of ROLE_FILES) {
+    vol.writeFileSync(templatePath(role), readFileSync(templatePath(role), 'utf8'))
+  }
+  vol.mkdirSync(PROJECT, { recursive: true })
+  return vol
+}
+
+describe('solo mode retired — QA augmentation (#427)', () => {
+  describe('on-disk source templates carry no solo markers', () => {
+    // The dev guards the rendered prompt and build-prompt.js. But a refactor
+    // could reintroduce a "solo mode" toggle / persona-switch directly into a
+    // SOURCE template. Most would surface in the render, but pinning the
+    // source-of-truth files directly catches prose that lands in a section the
+    // render check happens not to inspect, and is independent of the
+    // composition logic.
+    it.each(ALL_SOURCE_TEMPLATES)('%s has no solo-mode toggle or solo prose', (name) => {
+      const src = readFileSync(templatePath(name), 'utf8')
+      expect(src).not.toMatch(/solo[\s_-]*mode/i)
+      expect(src).not.toMatch(/solo[\s_-]*vs[\s_-]*team|team[\s_-]*vs[\s_-]*solo/i)
+      expect(src).not.toMatch(/\bsolo\b/i)
+      expect(src).not.toMatch(/prompt-base/i)
+    })
+  })
+
+  describe('the prompt-base.md guard is meaningful, not vacuous', () => {
+    it('resolves prompt-base.md INTO the real templates dir', () => {
+      // If templatePath('prompt-base.md') resolved somewhere it could never
+      // exist, the dev's `existsSync(...) === false` assertion would pass
+      // vacuously. Pin that it points at the same dir that DOES hold the live
+      // templates, so the absence check is real.
+      const basePath = templatePath('prompt-base.md')
+      expect(basePath.startsWith(TEMPLATES_DIR)).toBe(true)
+      // Sanity anchor: a sibling that genuinely exists resolves the same way
+      // and is present, proving the dir is the live templates dir.
+      expect(existsSync(templatePath('prompt-team.md'))).toBe(true)
+    })
+
+    it('ships no solo orchestrator as a sibling under the templates dir', () => {
+      // Broader than the dev's single prompt-base.md filename check: scan the
+      // whole templates dir for any solo-flavored orchestrator file.
+      const entries = readdirSync(TEMPLATES_DIR)
+      expect(entries).not.toContain('prompt-base.md')
+      expect(entries.filter((e) => /solo/i.test(e))).toEqual([])
+    })
+  })
+
+  describe('team-completeness: a dropped role fails loudly (no silent thinning)', () => {
+    // The dev asserts all 4 roles ARE present when the render succeeds, but
+    // that says nothing about what happens if a role file is removed. A
+    // refactor that drops, say, the QA role must NOT degrade to a thinner,
+    // solo-like single-pass prompt — it must fail loudly.
+    it.each(ROLE_FILES)('throws if %s is missing rather than rendering a thinner prompt', (missing) => {
+      const vol = setupFs()
+      vol.unlinkSync(templatePath(missing))
+      expect(() => buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })).toThrow()
+    })
+
+    it('leaves no unfilled {{ROLE_*}} slot AND keeps all four headings (off-by-one guard)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // No composition placeholder survives...
+      expect(out).not.toMatch(/\{\{ROLE_[A-Z]+\}\}/)
+      // ...and exactly the four specialist headings are present (a dropped
+      // role can't hide behind a still-passing render).
+      const headings = ['Dev specialist', 'QA specialist', 'Code reviewer specialist', 'Tech writer specialist']
+      for (const h of headings) expect(out).toContain(`## ${h}`)
+    })
+  })
+
+  describe('the broad /\\bsolo\\b/i intent is pinned (not accidentally loosened)', () => {
+    // The dev flagged /\bsolo\b/i as possibly too broad. Judgment: it is the
+    // right strictness here — "solo" is never a benign domain term in this
+    // team-only orchestrator, so any future occurrence is a regression. Pin
+    // both directions so the intent is explicit and the check can't be quietly
+    // weakened: the live render is clean, and an injected "solo" IS caught.
+    it('the live rendered prompt is clean under the broad word-boundary check', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).not.toMatch(/\bsolo\b/i)
+    })
+
+    it('the broad check actually catches a reintroduced solo mode in a role file', () => {
+      const vol = setupFs()
+      // Simulate a refactor sneaking solo prose into a composed role.
+      vol.writeFileSync(
+        templatePath('roles/dev.md'),
+        `## Dev specialist\n\nFall back to **Solo mode** when no team is available.\n`,
+      )
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/\bsolo\b/i)
+    })
+  })
+})

--- a/packages/ralph/lib/solo-mode-retired.test.js
+++ b/packages/ralph/lib/solo-mode-retired.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { existsSync, readFileSync } from 'node:fs'
+import { buildPrompt } from './build-prompt.js'
+import { templatePath } from './paths.js'
+
+// Regression guard for issue #427: solo mode is permanently retired. The solo
+// orchestrator template (`prompt-base.md`) and any solo-only code path were
+// removed in favor of the team orchestrator (`prompt-team.md`). This guard
+// locks that in so a future refactor cannot silently restore solo mode, and
+// asserts the surviving safety/"what-survives-an-update" contract stays intact.
+
+const PROJECT = '/project'
+
+// Mirror build-prompt.test.js's memfs setup so the rendered prompt under test
+// is built from the real on-disk templates.
+function setupFs() {
+  const orchestratorTemplate = readFileSync(templatePath('prompt-team.md'), 'utf8')
+  const devRole = readFileSync(templatePath('roles/dev.md'), 'utf8')
+  const qaRole = readFileSync(templatePath('roles/qa.md'), 'utf8')
+  const reviewerRole = readFileSync(templatePath('roles/reviewer.md'), 'utf8')
+  const writerRole = readFileSync(templatePath('roles/writer.md'), 'utf8')
+  const vol = Volume.fromJSON({}, '/')
+  vol.mkdirSync(templatePath('roles'), { recursive: true })
+  vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
+  vol.writeFileSync(templatePath('roles/dev.md'), devRole)
+  vol.writeFileSync(templatePath('roles/qa.md'), qaRole)
+  vol.writeFileSync(templatePath('roles/reviewer.md'), reviewerRole)
+  vol.writeFileSync(templatePath('roles/writer.md'), writerRole)
+  vol.mkdirSync(PROJECT, { recursive: true })
+  return vol
+}
+
+describe('solo mode is retired (regression guard for #427)', () => {
+  describe('solo is gone', () => {
+    it('does not ship the solo orchestrator template (prompt-base.md) on disk', () => {
+      // Checked against the REAL filesystem, not memfs: the retired template
+      // must never reappear in the package.
+      expect(existsSync(templatePath('prompt-base.md'))).toBe(false)
+    })
+
+    it('renders no reference to a solo template in the prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).not.toMatch(/prompt-base/i)
+    })
+
+    it('carries no solo-vs-team mode toggle or solo activation flag', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // No solo/team mode switch, persona-switching branch, or "solo mode" prose.
+      expect(out).not.toMatch(/solo[\s_-]*mode/i)
+      expect(out).not.toMatch(/solo[\s_-]*vs[\s_-]*team|team[\s_-]*vs[\s_-]*solo/i)
+      expect(out).not.toMatch(/\bsolo\b/i)
+    })
+
+    it('does not read prompt-base.md from build-prompt.js source', () => {
+      const src = readFileSync(new URL('./build-prompt.js', import.meta.url), 'utf8')
+      expect(src).not.toMatch(/prompt-base/i)
+      expect(src).not.toMatch(/\bsolo\b/i)
+    })
+  })
+
+  describe('team contract is present', () => {
+    it('renders the team orchestrator as the prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain('# Ralph Loop — Team orchestrator')
+    })
+
+    it('composes all four specialist roles (Dev, QA, Code reviewer, Tech writer)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain('## Dev specialist')
+      expect(out).toContain('## QA specialist')
+      expect(out).toContain('## Code reviewer specialist')
+      expect(out).toContain('## Tech writer specialist')
+      // No composition slot left dangling — every {{ROLE_*}} was filled.
+      expect(out).not.toMatch(/\{\{ROLE_/)
+    })
+  })
+
+  describe('safety guarantees / what-survives-an-update contract intact', () => {
+    it('preserves the never-touch file list verbatim', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain(
+        "NEVER touch: `.env*`, `.git/`, `node_modules/`, `dist/`, `logs/`,\n  `ralph.sh`, `start-ralph.sh`, `PROMPT.md`, `ralph.config.sh`,\n  `.claude/`.",
+      )
+    })
+
+    it('preserves the absolute restrictions (force-push, direct push, manual merge/close)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain('NEVER `git push --force` or `git push -f`.')
+      expect(out).toMatch(/NEVER push directly to/)
+      expect(out).toMatch(/NEVER merge PRs directly/)
+      expect(out).toMatch(/NEVER close issues manually/)
+    })
+  })
+})


### PR DESCRIPTION
Closes #427

Retires Ralph **solo mode** permanently — team mode is now the only mode, with no activation flag. The solo orchestrator template (`prompt-base.md`) was already removed in an earlier slice; this change **locks the retirement in** with a regression guard and brings the docs in line.

## Dev/TDD
- Tests added: `packages/ralph/lib/solo-mode-retired.test.js` (8 tests)
- Red (proof the guard bites): temporarily reintroduced the retired behavior — (A) created a dummy `templates/prompt-base.md` → on-disk guard failed `expected true to be false`; (B) appended solo prose to `prompt-team.md` → on-disk + `/prompt-base/i` + `/solo[\s_-]*mode/i` guards failed. Both reverted; guard confirmed to fail for the right reason.
- Green: full `packages/ralph` suite green. No production code change was needed — the solo template and any solo-only path were already gone; `build-prompt.js` reads only `prompt-team.md` + the four role files.

## QA scenarios
- Tests added: `packages/ralph/lib/solo-mode-retired.qa.test.js` (14 tests)
- Augmentations (all green, no defect handed back):
  - On-disk **source templates** (`prompt-team.md` + 4 roles) each asserted free of solo markers — closes the gap that the dev guard only inspects the rendered prompt + `build-prompt.js` source.
  - **Anti-vacuity**: `templatePath('prompt-base.md')` resolves *into* the real templates dir (so `existsSync === false` isn't vacuously true); whole-dir scan for any solo-flavored orchestrator sibling.
  - **Dropped-role / team-completeness**: `buildPrompt` throws (fails loudly) if any one role file is missing — a refactor can't silently degrade to a thinner, solo-like single-pass prompt.
  - **Broad `/\bsolo\b/i` intent pinned** in both directions: live render is clean; an injected "Solo mode" line IS caught.

## Review verdict
- **APPROVE** (pre-PR maintainability gate). No blocking findings; converged in 1 round. Reviewer verified every guard genuinely bites (real-FS `existsSync`, the `/\bsolo\b/i` breadth, and the "throws if role missing" tests), confirmed the two files are cleanly complementary rather than redundant, and judged the test-local `setupFs` duplication acceptable per repo convention. Minor non-blocking nits only (one overlapping `prompt-base.md` assertion line, layered solo regexes subsumed by the word-boundary check).

## Docs updated
- `packages/ralph/README.md` — rewrote **"How Ralph resolves issues"** from the solo-only TDD loop to the accurate team pipeline: triage-and-scale (trivial/light vs substantive/full team), the dev/QA/review/writer contracts, the pre-PR gate (back-to-dev loop, max 2 rounds), and the caveat flag (PR opens anyway after the round limit with a prominent unresolved-concerns warning). The TDD red→green→refactor description is preserved inside the dev role. "What survives an update" left untouched.
- `packages/ralph/CHANGELOG.md` — added an `## [Unreleased]` **BREAKING** prose entry describing the retirement (placed before the release-please-owned entries so it won't be clobbered).

## Notes
- Framed as `feat!:` — a minor bump under the repo's 0.x release-please rules.
- All existing safety guarantees and the "what survives an update" file contract remain intact (asserted by the guard's never-touch + absolute-restrictions checks).
- Local validation: `packages/ralph` suite **421 passed (23 files)**; `npm run lint` **0 errors** (26 pre-existing warnings in unrelated `src/` files).
