### PR TITLE
feat: add RALPH_HEAVY_TIER config flag + buildPrompt interpolation (dark-launch foundation)

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -182,6 +182,7 @@ be committed. Re-running `ralph init` never overwrites it.
 | `AUTO_MERGE`          | `true`                               | v0.1 only supports `true` (manual review mode lands in v0.2).          |
 | `MERGE_POLL_INTERVAL` | `30`                                 | Seconds between `gh pr view` polls while waiting for auto-merge.       |
 | `MERGE_POLL_MAX`      | `40`                                 | Max polls (default = 20 minutes) before giving up on a PR.             |
+| `RALPH_HEAVY_TIER`    | `0`                                  | Per-issue effort tiering (dark-launch foundation). `0` = off; no behavior yet. |
 
 The config is plain bash; edit it in any editor. On the next
 `ralph start` Ralph notices the change (sha256 mismatch in

--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -30,6 +30,7 @@ export function buildPrompt({
     MERGE_STRATEGY: env.MERGE_STRATEGY ?? 'squash',
     MERGE_POLL_INTERVAL: env.MERGE_POLL_INTERVAL ?? '30',
     MERGE_POLL_MAX: env.MERGE_POLL_MAX ?? '40',
+    RALPH_HEAVY_TIER: env.RALPH_HEAVY_TIER ?? '0',
     PROJECT_ROOT: projectRoot,
     PROJECT_PROMPT: projectPrompt,
   }

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -841,6 +841,125 @@ describe('buildPrompt', () => {
     })
   })
 
+  describe('RALPH_HEAVY_TIER (dark-launch foundation)', () => {
+    it('interpolates the default RALPH_HEAVY_TIER value (0) into the composed prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).not.toContain('{{RALPH_HEAVY_TIER}}')
+      expect(out).toMatch(/effort tier[^\n]*0/i)
+    })
+
+    it('interpolates a custom RALPH_HEAVY_TIER value from env', () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { RALPH_HEAVY_TIER: '1' },
+        fs: vol,
+      })
+      expect(out).not.toContain('{{RALPH_HEAVY_TIER}}')
+      expect(out).toMatch(/effort tier[^\n]*1/i)
+    })
+
+    it('does not warn on the RALPH_HEAVY_TIER placeholder', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('RALPH_HEAVY_TIER — QA hardening (edge / adversarial)', () => {
+    function tierLine(out) {
+      const m = out.match(/Current effort tier:[^\n]*/)
+      return m ? m[0] : null
+    }
+
+    it('fully replaces {{RALPH_HEAVY_TIER}} — no placeholder survives anywhere', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // Mirror the "no leftover composition placeholder" hardening tests.
+      expect(out).not.toContain('{{RALPH_HEAVY_TIER}}')
+      expect((out.match(/\{\{RALPH_HEAVY_TIER\}\}/g) || []).length).toBe(0)
+    })
+
+    it('renders the resolved tier value exactly once (no duplication)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // The template carries a single "Current effort tier:" line; the value
+      // must appear once as a backtick-wrapped resolved value.
+      expect((out.match(/Current effort tier:/g) || []).length).toBe(1)
+      expect((out.match(/Current effort tier: `0`/g) || []).length).toBe(1)
+    })
+
+    it("treats env value '0' explicitly the same as the default", () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { RALPH_HEAVY_TIER: '0' },
+        fs: vol,
+      })
+      expect(out).not.toContain('{{RALPH_HEAVY_TIER}}')
+      expect(tierLine(out)).toContain('`0`')
+    })
+
+    it("interpolates a non-default value '2'", () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { RALPH_HEAVY_TIER: '2' },
+        fs: vol,
+      })
+      expect(out).not.toContain('{{RALPH_HEAVY_TIER}}')
+      expect(tierLine(out)).toContain('`2`')
+    })
+
+    it("pins the real behavior for an empty-string env value: ?? only catches null/undefined, so '' passes through as an empty resolved value", () => {
+      const vol = setupFs()
+      const stderr = makeStderr()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { RALPH_HEAVY_TIER: '' },
+        fs: vol,
+        stderr,
+      })
+      // The placeholder is still fully replaced (interpolate resolves a known
+      // key to its value regardless of emptiness).
+      expect(out).not.toContain('{{RALPH_HEAVY_TIER}}')
+      // Documented quirk: `?? '0'` does NOT default an empty string, so the
+      // tier renders as an empty value between the backticks, not `0`.
+      expect(tierLine(out)).toContain('Current effort tier: ``')
+      expect(tierLine(out)).not.toContain('`0`')
+      // No warning — the key is present in vars, just empty.
+      expect(stderr.calls).toHaveLength(0)
+    })
+
+    it('does not re-interpolate a literal {{RALPH_HEAVY_TIER}} embedded in the project PROMPT.md (single-pass) and emits no warning', () => {
+      // Adversarial: the project's own PROMPT.md cites the literal token. It is
+      // injected as the value of {{PROJECT_PROMPT}} in interpolate's single
+      // pass, so replacement values are NOT re-scanned. Mirror the existing
+      // {{ROLE_WRITER}} adversarial test.
+      const projectPrompt =
+        '## Stack\nOur docs literally cite {{RALPH_HEAVY_TIER}} as a flag.'
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': projectPrompt } })
+      const stderr = makeStderr()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { RALPH_HEAVY_TIER: '1' },
+        fs: vol,
+        stderr,
+      })
+      // The orchestrator's own tier line resolved to the env value.
+      expect(tierLine(out)).toContain('`1`')
+      // The project's literal text survives verbatim — not re-interpolated.
+      expect(out).toContain(projectPrompt)
+      // Exactly one {{RALPH_HEAVY_TIER}} survives: the one inside PROMPT.md.
+      // The orchestrator's own slot was filled.
+      expect((out.match(/\{\{RALPH_HEAVY_TIER\}\}/g) || []).length).toBe(1)
+      // The stray token in PROMPT.md does not trigger a warning.
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
   describe('issue selection query', () => {
     function selectQuery(out) {
       const match = out.match(/gh issue list[^\n]*--search '([^']+)'/)

--- a/packages/ralph/lib/init.test.js
+++ b/packages/ralph/lib/init.test.js
@@ -115,6 +115,44 @@ describe('initCommand — empty dir', () => {
     expect(cfg).toContain('AUTO_MERGE="true"')
     expect(cfg).toContain('MERGE_POLL_INTERVAL=30')
     expect(cfg).toContain('MERGE_POLL_MAX=40')
+    expect(cfg).toContain('RALPH_HEAVY_TIER=0')
+  })
+})
+
+describe('initCommand — RALPH_HEAVY_TIER default (QA hardening)', () => {
+  it('ships RALPH_HEAVY_TIER=0 on a custom (npm) stack too — the literal survives interpolation unchanged', async () => {
+    const { vol, run } = setup({
+      files: { [`${PROJECT}/package.json`]: '{}' },
+    })
+    const result = await run()
+    expect(result.stack).toBe('npm')
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    // The line is a literal default, not a {{...}} placeholder, so it must
+    // pass through init's interpolation pass verbatim regardless of stack.
+    expect(cfg).toContain('RALPH_HEAVY_TIER=0')
+    expect(occurrences(cfg, 'RALPH_HEAVY_TIER=0')).toBe(1)
+    expect(cfg).not.toContain('{{RALPH_HEAVY_TIER}}')
+  })
+
+  it('does not clobber a user-tweaked RALPH_HEAVY_TIER on re-run', async () => {
+    const { vol, run } = setup()
+    await run()
+    const original = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    const tweaked = original.replace('RALPH_HEAVY_TIER=0', 'RALPH_HEAVY_TIER=1')
+    expect(tweaked).toContain('RALPH_HEAVY_TIER=1')
+    vol.writeFileSync(`${PROJECT}/ralph.config.sh`, tweaked)
+
+    const stdout2 = makeStream()
+    await initCommand({
+      cwd: PROJECT,
+      stdout: stdout2,
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+    })
+    // Re-running init must not overwrite the user's tweaked value.
+    expect(vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')).toBe(tweaked)
+    expect(stdout2.output()).toContain('ralph.config.sh already exists')
   })
 })
 

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -18,6 +18,9 @@ full team.
 Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
 operations.
 
+Current effort tier: `{{RALPH_HEAVY_TIER}}` (0 = off; this is a dark-launch
+flag with no behavior yet).
+
 ## Required sequence
 
 0. **Ensure dependencies**: run `{{INSTALL_CMD}}` (skip if empty).

--- a/packages/ralph/templates/ralph.config.sh
+++ b/packages/ralph/templates/ralph.config.sh
@@ -18,3 +18,7 @@ MERGE_STRATEGY="squash"
 AUTO_MERGE="true"
 MERGE_POLL_INTERVAL=30
 MERGE_POLL_MAX=40
+
+# Per-issue effort tiering (dark-launch foundation). 0 = off; nothing
+# behaves differently yet.
+RALPH_HEAVY_TIER=0


### PR DESCRIPTION
Closes #479

Dark-launch foundation for per-issue effort tiering: a single config flag plumbed end-to-end (config template → `buildPrompt` interpolation → composed prompt → tests), defaulting off so nothing behaves differently yet. Pure plumbing — no tier logic, no fan-out.

## Dev/TDD
- Tests added/modified:
  - `packages/ralph/lib/build-prompt.test.js` — new `RALPH_HEAVY_TIER` describe block (default `0` interpolates, custom env value interpolates, no unknown-placeholder warning)
  - `packages/ralph/lib/init.test.js` — asserts the generated `ralph.config.sh` ships `RALPH_HEAVY_TIER=0`
- Before implementation (red): the three new assertions failed for the right reason — the `{{RALPH_HEAVY_TIER}}` placeholder/value was genuinely absent from the composed prompt, and the literal `RALPH_HEAVY_TIER=0` was missing from the generated config.
- After implementation (green): all 432 tests in the Ralph package pass.
- Implementation: added literal `RALPH_HEAVY_TIER=0` to `templates/ralph.config.sh`, a `{{RALPH_HEAVY_TIER}}` line to `templates/prompt-team.md`, and `RALPH_HEAVY_TIER: env.RALPH_HEAVY_TIER ?? '0'` to the `vars` object in `lib/build-prompt.js`. `buildPrompt`'s interface is unchanged.

## QA scenarios added
- `packages/ralph/lib/build-prompt.test.js` (6 tests): full placeholder replacement (no leftover token anywhere, even under a fully-populated custom env); resolved value renders exactly once (no duplication); explicit `'0'` equals the default; non-default `'2'` interpolates; empty-string env value pinned (`??` only catches null/undefined, so `''` passes through as empty — documented quirk, not a bug); adversarial PROMPT.md containing a literal `{{RALPH_HEAVY_TIER}}` is not re-interpolated (single-pass) and emits no warning.
- `packages/ralph/lib/init.test.js` (2 tests): the literal default survives the init interpolation pass on a custom (npm) stack; re-running init does not clobber a user-tweaked value.
- All QA tests pass; no defects found, nothing returned to the dev.

## Review verdict
- APPROVE. Maintainability gate passed on the first round, no blocking findings. `RALPH_HEAVY_TIER` is grouped correctly with the env-defaulted `vars` entries; config comment and prompt wording are consistent and honest (both state "no behavior yet"); the empty-string quirk matches the exact idiom of every sibling var (`?? default`), so it is consistent rather than a defect. No new indirection or conditionals.

## Docs updated
- `packages/ralph/README.md` — added a `RALPH_HEAVY_TIER` row to the Configuration reference table (default `0`, "Per-issue effort tiering (dark-launch foundation). `0` = off; no behavior yet."). Writer found no other doc target the diff implied.

## Notes
- `npm test` (Ralph package): 432 passed. `npm run lint`: 0 errors (26 pre-existing warnings in unrelated `src/` app files). `npm run build`: succeeds.
- Triage: classified **substantive** (the flag is read at runtime via `buildPrompt`), so the full team ran (dev → QA → review → writer).