### PR TITLE
feat: three-tier triage classifier in orchestrator (gated, dark)

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -63,12 +63,24 @@ activation flag.
 The orchestrator first **triages** the issue and scales the team to
 fit it:
 
-- **Trivial / non-behavioral** — pure docs, plain config, or
-  dependency bumps without logic changes. It skips the dev-TDD and QA
-  stages and runs only a light review plus the writer. The boundary is
-  conservative: when in doubt, the issue is treated as substantive.
-- **Substantive** — anything that changes behavior. It runs the full
-  team, in order: dev → QA → review → writer.
+- **Tier 0 / Light — trivial / non-behavioral** — pure docs, plain
+  config, or dependency bumps without logic changes. It skips the
+  dev-TDD and QA stages and runs only a light review plus the writer.
+  The boundary is conservative: when in doubt, the issue is treated as
+  substantive.
+- **Tier 1 / Standard — substantive** — anything that changes
+  behavior. It runs the full team, in order: dev → QA → review →
+  writer.
+- **Tier 2 / Heavy — gated, dark** — the largest issues (multi-file /
+  multi-module scope, audit, refactor, migration, or multi-hypothesis
+  investigation), or any issue carrying the `ralph-heavy` label, which
+  forces Tier 2. This tier is gated behind the `RALPH_HEAVY_TIER` flag
+  and is **off by default**: when the flag is `0` the heavy tier is
+  unavailable and triage falls back to Tier 1. When uncertain the
+  classifier defaults to Tier 1 (never Tier 2 on a guess), and a heavy
+  run that fails to converge degrades to Tier 1 rather than looping.
+  The Tier 2 fan-out roles do not exist yet — the flag and triage
+  signals are the dark-launch foundation.
 
 The specialists each have a single contract:
 
@@ -182,7 +194,7 @@ be committed. Re-running `ralph init` never overwrites it.
 | `AUTO_MERGE`          | `true`                               | v0.1 only supports `true` (manual review mode lands in v0.2).          |
 | `MERGE_POLL_INTERVAL` | `30`                                 | Seconds between `gh pr view` polls while waiting for auto-merge.       |
 | `MERGE_POLL_MAX`      | `40`                                 | Max polls (default = 20 minutes) before giving up on a PR.             |
-| `RALPH_HEAVY_TIER`    | `0`                                  | Per-issue effort tiering (dark-launch foundation). `0` = off; no behavior yet. |
+| `RALPH_HEAVY_TIER`    | `0`                                  | Gates the **Tier 2 / Heavy** triage path (dark-launch foundation). `0` = off (the default): the heavy tier is unavailable and triage falls back to Tier 1. The fan-out roles do not exist yet. |
 
 The config is plain bash; edit it in any editor. On the next
 `ralph start` Ralph notices the change (sha256 mismatch in

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -960,6 +960,209 @@ describe('buildPrompt', () => {
     })
   })
 
+  describe('three-tier triage (Tier-2 Heavy, gated)', () => {
+    function triageSection(out) {
+      const start = out.search(/3b\.\s/)
+      const end = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      return out.slice(start, end === -1 ? undefined : end)
+    }
+
+    it('names three tiers — Light, Standard/Substantive, and Tier 2 / Heavy', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // Tier labels: the existing light/substantive language plus the new heavy tier.
+      expect(section).toMatch(/three tiers?/i)
+      expect(section).toMatch(/light/i)
+      expect(section).toMatch(/substantive/i)
+      expect(section).toMatch(/tier[\s-]*2/i)
+      expect(section).toMatch(/heavy/i)
+    })
+
+    it('lists the Tier-2 trigger signals: multi-file/module scope, audit, refactor, migration, multi-hypothesis investigation', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      expect(section).toMatch(/multi-(file|module)/i)
+      expect(section).toMatch(/audit/i)
+      expect(section).toMatch(/refactor/i)
+      expect(section).toMatch(/migration/i)
+      expect(section).toMatch(/multi-hypothesis/i)
+    })
+
+    it('documents the ralph-heavy label override forcing Tier 2', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      expect(section).toMatch(/ralph-heavy/)
+      // The label FORCES Tier 2.
+      expect(section).toMatch(/ralph-heavy[\s\S]{0,80}(forces?|force)[\s\S]{0,40}tier[\s-]*2/i)
+    })
+
+    it('gates Tier 2 behind the RALPH_HEAVY_TIER flag (off when the flag is 0)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      expect(section).toMatch(/RALPH_HEAVY_TIER/)
+      // Tier 2 is unavailable / off when the flag is 0.
+      expect(section).toMatch(/(off|disabled|unavailable|not available)[\s\S]{0,40}(0|flag)|flag[\s\S]{0,40}0/i)
+    })
+
+    it('includes a degrade-to-Tier-1 instruction for non-convergence (no looping)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      expect(section).toMatch(/(degrade|fall back|fallback|drop back)[\s\S]{0,80}tier[\s-]*1/i)
+      expect(section).toMatch(/converge|non-convergence|fails? to converge/i)
+    })
+
+    it('defaults to Tier 1 when the classifier is uncertain', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // When uncertain, default to Tier 1 (not Tier 2).
+      expect(section).toMatch(/(uncertain|in doubt|unsure)[\s\S]{0,80}tier[\s-]*1/i)
+    })
+
+    it('keeps the three-tier prose inside step 3b and does not strand placeholders under custom env', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '## Stack\nRust' } })
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { RALPH_HEAVY_TIER: '1' },
+        fs: vol,
+      })
+      const section = triageSection(out)
+      expect(section).toMatch(/tier[\s-]*2/i)
+      expect(section).not.toMatch(/\{\{[A-Za-z_]/)
+    })
+
+    it('does not warn on unknown placeholders once the three-tier prose is added', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('three-tier triage — QA hardening', () => {
+    const FULL_ENV = {
+      INSTALL_CMD: 'pnpm install --frozen-lockfile',
+      TEST_CMD: 'cargo test --all',
+      LINT_CMD: 'cargo clippy --strict',
+      MAIN_BRANCH: 'release',
+      DEV_BRANCH: 'integration',
+      PR_TARGET: 'integration',
+      MERGE_STRATEGY: 'merge',
+      MERGE_POLL_INTERVAL: '7',
+      MERGE_POLL_MAX: '99',
+      RALPH_HEAVY_TIER: '2',
+    }
+
+    function triageSection(out) {
+      const start = out.search(/3b\.\s/)
+      const end = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      return out.slice(start, end === -1 ? undefined : end)
+    }
+
+    // The region from the dev dispatch (step 4) to the end. Tier-2 trigger
+    // prose lives ONLY in step 3b; the gated-tier line in the intro header
+    // legitimately references it, but nothing past step 4 should.
+    function afterTriageRegion(out) {
+      const start = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      return out.slice(start)
+    }
+
+    it('confines the Tier-2 trigger prose to step 3b — no leak into the dispatch steps (4 onward)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const after = afterTriageRegion(out)
+      // These tokens are unique to the Tier-2 classifier prose in 3b. If any
+      // appears past step 4, the heavy-tier prose has leaked out of its region.
+      expect(after).not.toMatch(/ralph-heavy/)
+      expect(after).not.toMatch(/multi-hypothesis/i)
+      expect(after).not.toMatch(/multi-(file|module)/i)
+      // And step 3b really does carry them (so the negative above is meaningful).
+      const section = triageSection(out)
+      expect(section).toMatch(/ralph-heavy/)
+      expect(section).toMatch(/multi-hypothesis/i)
+    })
+
+    it('keeps all three tiers and strands no placeholder under a fully-populated custom env (RALPH_HEAVY_TIER=2)', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '## Stack\nRust + cargo' } })
+      const out = buildPrompt({ projectRoot: PROJECT, env: FULL_ENV, fs: vol })
+      const section = triageSection(out)
+      expect(section).toMatch(/tier[\s-]*0/i)
+      expect(section).toMatch(/tier[\s-]*1/i)
+      expect(section).toMatch(/tier[\s-]*2/i)
+      expect(section).toMatch(/light/i)
+      expect(section).toMatch(/substantive/i)
+      expect(section).toMatch(/heavy/i)
+      expect(section).not.toMatch(/\{\{[A-Za-z_]/)
+    })
+
+    it('does not warn under explicit RALPH_HEAVY_TIER=0 and a NON-empty PROMPT.md', () => {
+      const vol = setupFs({
+        projectFiles: { 'PROMPT.md': '## Stack\nRust + cargo\n\nProject notes.' },
+      })
+      const stderr = makeStderr()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { ...FULL_ENV, RALPH_HEAVY_TIER: '0' },
+        fs: vol,
+        stderr,
+      })
+      const section = triageSection(out)
+      expect(section).not.toMatch(/\{\{[A-Za-z_]/)
+      expect(stderr.calls).toHaveLength(0)
+    })
+
+    it('resolves doubt toward the SAFE direction — uncertain maps to Tier 1, and Tier 2-on-a-guess is forbidden', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // Uncertain → Tier 1 (the conservative default), expressed explicitly.
+      expect(section).toMatch(/(uncertain|in doubt|unsure)[\s\S]{0,80}tier[\s-]*1/i)
+      // Guessing UP to Tier 2 must be explicitly prohibited (not just absent).
+      expect(section).toMatch(/never[\s\S]{0,40}tier[\s-]*2[\s\S]{0,20}(guess|doubt|uncertain)|tier[\s-]*2[\s\S]{0,20}(on a )?guess/i)
+      // The unsafe inversion (uncertain → Tier 2) must NOT be present.
+      expect(section).not.toMatch(/(uncertain|in doubt|unsure)[\s\S]{0,40}default[\s\S]{0,20}tier[\s-]*2/i)
+    })
+
+    it('pins the dark-launch invariant: flag 0 means heavy is off AND you fall back to Tier 1 (behavior identical to today)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // Flag 0 → off/unavailable...
+      expect(section).toMatch(/(`0`|flag is `?0`?)[\s\S]{0,80}(off|unavailable|disabled)/i)
+      // ...and the explicit fall-back-to-Tier-1 behavior under that flag.
+      // Tolerate the prose wrap ("fall\n     back to Tier 1").
+      expect(section).toMatch(/fall\s+back[\s\S]{0,40}tier[\s-]*1/i)
+    })
+
+    it('ties the ralph-heavy override to the flag being on (the forced Tier 2 is conditional, not absolute)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // The override forces Tier 2...
+      expect(section).toMatch(/ralph-heavy[\s\S]{0,120}forces?[\s\S]{0,40}tier[\s-]*2/i)
+      // ...but is qualified by the flag being on (subject to / when the flag is on).
+      expect(section).toMatch(/(subject to|provided|when|if)[\s\S]{0,30}flag[\s\S]{0,20}(being )?on|flag[\s\S]{0,20}(being )?on/i)
+    })
+
+    it('preserves the legacy light-path skip semantics: Tier 0 skips dev-TDD AND QA but still runs review + writer', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = triageSection(out)
+      // The three-tier rewrite must not silently drop the light path's skip
+      // semantics that the legacy two-path tests rely on.
+      expect(section).toMatch(/skip dev-TDD and QA|skip.+dev.TDD.+QA/i)
+      expect(section).toMatch(/steps?\s+4\s+and\s+4b/i)
+      expect(section).toMatch(/light review/i)
+      expect(section).toMatch(/writer/i)
+      expect(section).toMatch(/steps?\s+4c.+4d|4c.+4d/i)
+    })
+  })
+
   describe('issue selection query', () => {
     function selectQuery(out) {
       const match = out.match(/gh issue list[^\n]*--search '([^']+)'/)

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -13,13 +13,15 @@ composed into this template below as they land; the **dev specialist** (step
 4c), and the **tech writer specialist** (step 4d) are wired in. You also
 triage each issue and scale the team to fit it (step 3b): trivial,
 non-behavioral changes take a light path, while substantive changes run the
-full team.
+full team. A third **Tier 2 / Heavy** path exists for the largest issues, but
+it is gated behind the `{{RALPH_HEAVY_TIER}}` flag and is off by default.
 
 Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
 operations.
 
-Current effort tier: `{{RALPH_HEAVY_TIER}}` (0 = off; this is a dark-launch
-flag with no behavior yet).
+Current effort tier: `{{RALPH_HEAVY_TIER}}` (0 = off). This flag gates the
+Tier 2 / Heavy path in step 3b: when it is `0` the heavy tier is unavailable
+and triage uses only Tier 0 (Light) and Tier 1 (Standard).
 
 ## Required sequence
 
@@ -39,22 +41,37 @@ flag with no behavior yet).
 
 3b. **Triage and scale the team**: before dispatching, classify the issue and
    scale the team to fit it. Read the issue and the files it implies, then pick
-   one of two paths:
-   - **Trivial / non-behavioral** — the change has no behavioral impact on code:
-     pure docs, plain config, or dependency bumps without logic changes.
-     Skip dev-TDD and QA (steps 4 and 4b) and run only a **light review** plus
-     the writer (steps 4c, 4d). "Light" means the same reviewer (step 4c), just
-     over a docs/config-only diff with no QA augmentation to weigh. Note "TDD
-     skipped (trivial)" for the PR body.
-   - **Substantive** — anything that changes behavior: source code, logic, or any
-     change you cannot prove is purely cosmetic. Run the **full team** — dev,
-     QA, review, writer (steps 4 through 4d).
+   one of three tiers. Two are always available; the third is gated:
+   - **Tier 0 / Light — trivial / non-behavioral** — the change has no
+     behavioral impact on code: pure docs, plain config, or dependency bumps
+     without logic changes. Skip dev-TDD and QA (steps 4 and 4b) and run only a
+     **light review** plus the writer (steps 4c, 4d). "Light" means the same
+     reviewer (step 4c), just over a docs/config-only diff with no QA
+     augmentation to weigh. Note "TDD skipped (trivial)" for the PR body.
+   - **Tier 1 / Standard — substantive** — anything that changes behavior:
+     source code, logic, or any change you cannot prove is purely cosmetic. Run
+     the **full team** — dev, QA, review, writer (steps 4 through 4d).
+   - **Tier 2 / Heavy — gated, dark** — the largest issues: changes whose scope
+     spans many files or modules (multi-file / multi-module scope), broad
+     **audit** work, large **refactor** efforts, schema or data **migration**,
+     or a **multi-hypothesis** investigation where the root cause is unknown and
+     several leads must be explored. Tier 2 is gated behind the
+     `RALPH_HEAVY_TIER` flag (see the effort-tier line above): when the flag is
+     `0` (the default) the heavy tier is **off / unavailable** and you must fall
+     back to Tier 1. When Tier 2
+     is active and a heavy run **fails to converge** (does not reach green or
+     keeps churning), **degrade to Tier 1** and finish there rather than looping.
 
-   Keep the trivial boundary **conservative**: when in doubt, treat the issue as
-   substantive and run the full team. Config that carries logic (build/test
-   wiring, CI behavior, anything the code reads at runtime) is **not** plain
-   config — it is substantive. Only classify as trivial when the change provably
-   cannot alter behavior.
+   **`ralph-heavy` label override**: if the issue carries the `ralph-heavy`
+   label, that **forces Tier 2** (subject to the flag being on). Absent that
+   label, classify by the signals above; when the classifier is **uncertain**,
+   default to **Tier 1** (never Tier 2 on a guess).
+
+   Keep the tier boundaries **conservative**: when in doubt, treat the issue as
+   substantive and run the full team (Tier 1). Config that carries logic
+   (build/test wiring, CI behavior, anything the code reads at runtime) is
+   **not** plain config — it is substantive. Only classify as trivial when the
+   change provably cannot alter behavior.
 
 4. **Resolve via the dev specialist**: dispatch a context-isolated
    subagent in the **dev** role (see "Dev specialist" below) with the

--- a/packages/ralph/templates/ralph.config.sh
+++ b/packages/ralph/templates/ralph.config.sh
@@ -19,6 +19,7 @@ AUTO_MERGE="true"
 MERGE_POLL_INTERVAL=30
 MERGE_POLL_MAX=40
 
-# Per-issue effort tiering (dark-launch foundation). 0 = off; nothing
-# behaves differently yet.
+# Per-issue effort tiering (dark-launch foundation). Gates the Tier 2 /
+# Heavy triage path. 0 = off (the default): the heavy tier is unavailable
+# and triage falls back to Tier 1, so behavior is unchanged.
 RALPH_HEAVY_TIER=0


### PR DESCRIPTION
Closes #480

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js` (new `describe('three-tier triage (Tier-2 Heavy, gated)', ...)` block, 7 tests)
- Before implementation (red): the 7 new tests failed for the right reason — the `triageSection` slice still held only the two-path "Trivial / Substantive" prose; no `tier 2` / `heavy` / `ralph-heavy` / `RALPH_HEAVY_TIER`-gating / degrade-to-Tier-1 / uncertain→Tier-1 text existed yet. (433 passed / 7 failed; failures were missing-prose, not import/typo errors.)
- After implementation (green): all 447 ralph-package tests pass; all 553 root tests pass. No existing triage/QA-hardening assertions regressed.

Implementation: rewrote step 3b of `packages/ralph/templates/prompt-team.md` from two paths to three tiers — Tier 0 / Light (former trivial, semantics unchanged: skips dev-TDD + QA, runs light review + writer), Tier 1 / Standard (former substantive, full team, unchanged), and a new Tier 2 / Heavy gated behind `RALPH_HEAVY_TIER` (off at `0` → fall back to Tier 1), with trigger signals (multi-file/module scope, audit, refactor, migration, multi-hypothesis), a `ralph-heavy` label override (forces Tier 2, subject to the flag), an uncertain→Tier-1 default, and a degrade-to-Tier-1 rule on non-convergence. No fan-out roles (explorer / reviewer panel) added — reachable in prose only, per scope (#481/#482). The `ralph-heavy` GitHub label was created in the repo. `build-prompt.js` needed no change (the `RALPH_HEAVY_TIER` interpolation already exists).

## QA scenarios added
New `describe('three-tier triage — QA hardening', ...)` block (7 tests) in `packages/ralph/lib/build-prompt.test.js`:
- Region confinement — Tier-2 tokens (`ralph-heavy`, `multi-hypothesis`, `multi-file`) do not leak past step 4 (with a positive counter-assert that 3b carries them).
- All three tiers present and no stranded `{{...}}` under a fully-populated custom env (`RALPH_HEAVY_TIER=2`).
- No stderr warning under explicit `RALPH_HEAVY_TIER=0` + non-empty PROMPT.md.
- Safe-direction adversarial: uncertain → Tier 1, Tier-2-on-a-guess explicitly forbidden, unsafe inversion (uncertain → Tier 2) absent.
- Dark-launch invariant pinned: flag `0` → heavy off + fall back to Tier 1 (behavior identical to today).
- `ralph-heavy` override tied to the flag being on (conditional, not absolute).
- Legacy light-path skip semantics preserved (Tier 0 skips dev-TDD + QA, runs review + writer).

No blocking bugs found — the prose held up under adversarial probing.

## Review verdict
APPROVE. Reviewer found the change maintainable, correctly scoped, and dark-launch-safe: clean three-tier delineation (not case-by-case accretion), unambiguous dark-launch invariant + conservative default + degrade rule, deterministic non-brittle composition tests, legacy two-path semantics preserved, no scope creep (no explorer/reviewer-panel prose from #481/#482). No blocking findings. Non-blocking notes only (minor test overlap with the legacy light-path test; one loose-but-safe regex) — no action required.

## Docs updated
- `packages/ralph/README.md` — triage section rewritten from two paths to the three-tier list; `RALPH_HEAVY_TIER` row in the config table updated to state it gates the Tier 2 / Heavy path (`0` = off → falls back to Tier 1; fan-out roles do not exist yet).
- `packages/ralph/templates/ralph.config.sh` — corrected the `RALPH_HEAVY_TIER` comment to reflect it now gates the Tier 2 / Heavy path (default `0` preserved).

## Notes
Shipped dark: with `RALPH_HEAVY_TIER=0` (the default) nothing reaches Tier 2 and behavior is identical to today. The fan-out roles (explorer subagents, 3-reviewer panel) land in follow-ups #481/#482. Blocker #479 (the `RALPH_HEAVY_TIER` flag + `buildPrompt` interpolation) is already merged into `dev`.