### PR TITLE
feat: Tier-2 explorer fan-out + inline synthesis (understand phase)

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -79,11 +79,25 @@ fit it:
   unavailable and triage falls back to Tier 1. When uncertain the
   classifier defaults to Tier 1 (never Tier 2 on a guess), and a heavy
   run that fails to converge degrades to Tier 1 rather than looping.
-  The Tier 2 fan-out roles do not exist yet — the flag and triage
-  signals are the dark-launch foundation.
+  When the flag is on, a Tier-2 run adds an **understand phase** before
+  the dev: it fans out **three** read-only explorers chasing competing
+  hypotheses, then an inline synthesizer collapses their structured
+  returns into one plan handed to the dev as **plan + issue** (see the
+  explorer in the roster below).
 
 The specialists each have a single contract:
 
+0. **Explorer** *(Tier 2 only)* — a **read-only** hypothesis
+   investigator that runs in the understand phase, before the dev. On a
+   heavy run the orchestrator dispatches **three** explorers in
+   parallel, each chasing a **different, competing hypothesis** about
+   the root cause or right approach. An explorer reads, searches, and
+   reasons — it never writes or edits a file — and ends with a
+   structured return (hypothesis, verdict, evidence, proposed approach,
+   risks). An inline **synthesizer** (a named seam in the orchestrator,
+   not a subagent) collapses the three returns into one plan, handed to
+   the dev as **plan + issue**. On Tier 0 / Tier 1 this phase is skipped
+   and the dev receives the issue alone.
 1. **Dev** — turns the issue into working, tested code through a
    strict **TDD red → green → refactor** loop. *Red:* write a failing
    test that captures the issue's expected behavior and confirm it
@@ -194,7 +208,7 @@ be committed. Re-running `ralph init` never overwrites it.
 | `AUTO_MERGE`          | `true`                               | v0.1 only supports `true` (manual review mode lands in v0.2).          |
 | `MERGE_POLL_INTERVAL` | `30`                                 | Seconds between `gh pr view` polls while waiting for auto-merge.       |
 | `MERGE_POLL_MAX`      | `40`                                 | Max polls (default = 20 minutes) before giving up on a PR.             |
-| `RALPH_HEAVY_TIER`    | `0`                                  | Gates the **Tier 2 / Heavy** triage path (dark-launch foundation). `0` = off (the default): the heavy tier is unavailable and triage falls back to Tier 1. The fan-out roles do not exist yet. |
+| `RALPH_HEAVY_TIER`    | `0`                                  | Gates the **Tier 2 / Heavy** triage path. `0` = off (the default): the heavy tier is unavailable and triage falls back to Tier 1. When on, a Tier-2 run adds the explorer fan-out + inline synthesis understand phase before the dev. |
 
 The config is plain bash; edit it in any editor. On the next
 `ralph start` Ralph notices the change (sha256 mismatch in

--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -16,6 +16,7 @@ export function buildPrompt({
   const qaRole = fs.readFileSync(templatePath('roles/qa.md'), 'utf8').toString()
   const reviewerRole = fs.readFileSync(templatePath('roles/reviewer.md'), 'utf8').toString()
   const writerRole = fs.readFileSync(templatePath('roles/writer.md'), 'utf8').toString()
+  const explorerRole = fs.readFileSync(templatePath('roles/explorer.md'), 'utf8').toString()
   const projectPromptPath = join(projectRoot, 'PROMPT.md')
   const projectPrompt = fs.existsSync(projectPromptPath)
     ? fs.readFileSync(projectPromptPath, 'utf8').toString()
@@ -42,6 +43,7 @@ export function buildPrompt({
     .replace('{{ROLE_QA}}', () => qaRole)
     .replace('{{ROLE_REVIEW}}', () => reviewerRole)
     .replace('{{ROLE_WRITER}}', () => writerRole)
+    .replace('{{ROLE_EXPLORER}}', () => explorerRole)
   return interpolate(composed, vars, { stderr })
 }
 

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -24,6 +24,7 @@ function setupFs({ projectFiles = {} } = {}) {
   const qaRole = readFileSync(templatePath('roles/qa.md'), 'utf8')
   const reviewerRole = readFileSync(templatePath('roles/reviewer.md'), 'utf8')
   const writerRole = readFileSync(templatePath('roles/writer.md'), 'utf8')
+  const explorerRole = readFileSync(templatePath('roles/explorer.md'), 'utf8')
   const vol = Volume.fromJSON({}, '/')
   vol.mkdirSync(templatePath('roles'), { recursive: true })
   vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
@@ -31,6 +32,7 @@ function setupFs({ projectFiles = {} } = {}) {
   vol.writeFileSync(templatePath('roles/qa.md'), qaRole)
   vol.writeFileSync(templatePath('roles/reviewer.md'), reviewerRole)
   vol.writeFileSync(templatePath('roles/writer.md'), writerRole)
+  vol.writeFileSync(templatePath('roles/explorer.md'), explorerRole)
   vol.mkdirSync(PROJECT, { recursive: true })
   for (const [k, v] of Object.entries(projectFiles)) {
     vol.writeFileSync(join(PROJECT, k), v)
@@ -1160,6 +1162,324 @@ describe('buildPrompt', () => {
       expect(section).toMatch(/light review/i)
       expect(section).toMatch(/writer/i)
       expect(section).toMatch(/steps?\s+4c.+4d|4c.+4d/i)
+    })
+  })
+
+  describe('explorer specialist role composition', () => {
+    it('composes the explorer role into the rendered prompt', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toMatch(/##+ .*Explorer/i)
+    })
+
+    it('frames the explorer as a read-only hypothesis investigator', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const start = out.search(/##+ .*Explorer/i)
+      const section = out.slice(start)
+      expect(section).toMatch(/read-only/i)
+      expect(section).toMatch(/hypothesis/i)
+      // It investigates / reads but does not write code.
+      expect(section).toMatch(/investigat/i)
+      expect(section).toMatch(/(does not|never|no).+(write|edit|modif)/i)
+    })
+
+    it('requires the explorer to produce a structured return', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const start = out.search(/##+ .*Explorer/i)
+      const section = out.slice(start)
+      expect(section).toMatch(/structured return/i)
+    })
+
+    it('fully replaces the {{ROLE_EXPLORER}} placeholder (none left in output)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).not.toContain('{{ROLE_EXPLORER}}')
+    })
+
+    it('leaves no unreplaced {{ROLE_*}} composition placeholder anywhere in the output', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).not.toMatch(/\{\{ROLE_/)
+    })
+
+    it('does not warn on unknown placeholders once the explorer role is composed', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('Tier-2 explorer fan-out + inline synthesis', () => {
+    function understandSection(out) {
+      const start = out.search(/##+ .*Tier 2[^\n]*understand/i)
+      const end = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      return out.slice(start, end === -1 ? undefined : end)
+    }
+
+    it('dispatches exactly three explorers on a Tier-2 run', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      // Fixed fan-out width of 3.
+      expect(section).toMatch(/(three|3)\s+explorer/i)
+    })
+
+    it('gives the three explorers competing / different hypotheses', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      expect(section).toMatch(/competing|different|distinct/i)
+      expect(section).toMatch(/hypothes/i)
+    })
+
+    it('runs the explorers read-only (no writes during the understand phase)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      expect(section).toMatch(/read-only/i)
+    })
+
+    it('has a named, sectioned synthesizer seam run inline by the orchestrator', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // A named, reviewable seam — the Synthesizer — distinct from the explorers.
+      expect(out).toMatch(/##+ .*Synthesiz/i)
+      const section = understandSection(out)
+      expect(section).toMatch(/synthesiz/i)
+      // Runs inline in the orchestrator, not as a separate subagent dispatch.
+      expect(section).toMatch(/inline/i)
+    })
+
+    it('synthesizes the three explorer returns into a single plan', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      expect(section).toMatch(/(single|one)\s+plan/i)
+    })
+
+    it('hands the synthesized plan plus the issue to the dev (dev contract unchanged)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      // On Tier 2 the dev receives the synthesized plan + issue.
+      expect(section).toMatch(/plan\s*\+\s*issue|plan and (the )?issue/i)
+    })
+
+    it('keeps the dev step-4 contract intact: the dev still receives the issue title and body', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // The existing dev dispatch contract must remain verbatim.
+      expect(out).toMatch(/4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      expect(out).toMatch(/issue title and body/i)
+    })
+
+    it('places the Tier-2 understand phase after triage (3b) and before the dev dispatch (step 4)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const triageIdx = out.search(/3b\.\s+\*\*Triage and scale/i)
+      const understandIdx = out.search(/##+ .*Tier 2[^\n]*understand/i)
+      const devDispatchIdx = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      expect(triageIdx).toBeGreaterThan(-1)
+      expect(understandIdx).toBeGreaterThan(-1)
+      expect(devDispatchIdx).toBeGreaterThan(-1)
+      expect(understandIdx).toBeGreaterThan(triageIdx)
+      expect(understandIdx).toBeLessThan(devDispatchIdx)
+    })
+
+    it('does not warn on unknown placeholders once the Tier-2 understand phase is added', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('Tier-2 explorer fan-out — QA hardening', () => {
+    const FULL_ENV = {
+      INSTALL_CMD: 'pnpm install --frozen-lockfile',
+      TEST_CMD: 'cargo test --all',
+      LINT_CMD: 'cargo clippy --strict',
+      MAIN_BRANCH: 'release',
+      DEV_BRANCH: 'integration',
+      PR_TARGET: 'integration',
+      MERGE_STRATEGY: 'merge',
+      MERGE_POLL_INTERVAL: '7',
+      MERGE_POLL_MAX: '99',
+      RALPH_HEAVY_TIER: '2',
+    }
+
+    function understandSection(out) {
+      const start = out.search(/##+ .*Tier 2[^\n]*understand/i)
+      const end = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      return out.slice(start, end === -1 ? undefined : end)
+    }
+
+    // Everything from the dev dispatch (step 4) to the end of the prompt. The
+    // understand-phase prose lives ONLY between triage (3b) and step 4; if any
+    // of its unique tokens appears here, the section has leaked downstream.
+    function afterDevDispatch(out) {
+      const start = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      return out.slice(start)
+    }
+
+    // Everything BEFORE the triage step (3b). The understand phase sits after
+    // triage, so its tokens must not appear in the header/select/branch prose.
+    // (The intro header legitimately mentions the gated heavy tier, so scope the
+    // negative assertions to the understand-phase-unique tokens.)
+    function beforeTriage(out) {
+      const end = out.search(/3b\.\s/)
+      return out.slice(0, end)
+    }
+
+    // 1. Region confinement — understand-phase tokens must not leak past step 4.
+    it('confines the understand-phase prose to the region between triage (3b) and dev dispatch (step 4)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const after = afterDevDispatch(out)
+      // Tokens unique to the understand phase must NOT appear after step 4.
+      // ("explorer"/"Synthesizer seam"/"competing hypothes" are the unique
+      // understand-phase markers; {{RALPH_HEAVY_TIER}} / a Tier-2 header mention
+      // are legitimate elsewhere and are deliberately not asserted against.)
+      expect(after).not.toMatch(/Synthesizer seam/i)
+      expect(after).not.toMatch(/competing[\s-]*hypothes/i)
+      expect(after).not.toMatch(/explorer/i)
+      // The understand phase comes after triage, so its tokens must not appear
+      // before step 3b either.
+      const before = beforeTriage(out)
+      expect(before).not.toMatch(/Synthesizer seam/i)
+      expect(before).not.toMatch(/competing[\s-]*hypothes/i)
+      expect(before).not.toMatch(/explorer/i)
+      // And the understand section really does carry them (so the negatives bite).
+      const section = understandSection(out)
+      expect(section).toMatch(/explorer/i)
+      expect(section).toMatch(/competing|distinct/i)
+    })
+
+    // 2. Custom-env survival — no stranded placeholder, no stderr warning.
+    it('strands no {{...}} placeholder in the understand section under a fully-populated custom env (RALPH_HEAVY_TIER=2) and a NON-empty PROMPT.md', () => {
+      const vol = setupFs({
+        projectFiles: { 'PROMPT.md': '## Stack\nRust + cargo\n\nProject notes.' },
+      })
+      const stderr = makeStderr()
+      const out = buildPrompt({ projectRoot: PROJECT, env: FULL_ENV, fs: vol, stderr })
+      const section = understandSection(out)
+      expect(section).toMatch(/explorer/i)
+      // No leftover placeholder anywhere in the understand section.
+      expect(section).not.toMatch(/\{\{[A-Za-z_]/)
+      // And the whole composition stays warning-free under the custom env.
+      expect(stderr.calls).toHaveLength(0)
+    })
+
+    // 2b. The explorer role section itself interpolates any cmd placeholders it
+    //     carries; if it carries none, there must simply be no leftovers.
+    it('leaves no {{TEST_CMD}}/{{LINT_CMD}} placeholder in the explorer role section under a custom env', () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { TEST_CMD: 'cargo test --all', LINT_CMD: 'cargo clippy --strict' },
+        fs: vol,
+      })
+      const start = out.search(/##+ .*Explorer specialist/i)
+      const end = out.search(/##+ .*Synthesizer seam/i)
+      const explorerSection = out.slice(start, end === -1 ? undefined : end)
+      expect(explorerSection).not.toContain('{{TEST_CMD}}')
+      expect(explorerSection).not.toContain('{{LINT_CMD}}')
+      expect(explorerSection).not.toMatch(/\{\{[A-Za-z_]/)
+    })
+
+    // 3. Exactly three, not "at least" — no contradictory width.
+    it('pins the fan-out to exactly three with no contradictory width mentioned', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      expect(section).toMatch(/(three|3)\s+explorer/i)
+      // No alternative widths that would contradict the fixed 3.
+      expect(section).not.toMatch(/(two|five|4|5|6)\s+explorer/i)
+      expect(section).not.toMatch(/explorers?\s+\(.*\b(2|4|5)\b/i)
+      // No "at least"/"up to" hedging that would let it drift to a variable count.
+      expect(section).not.toMatch(/(at least|up to|as many as|one or more)\s+(three|3)?\s*explorer/i)
+    })
+
+    it('frames the width-of-three as fixed/deliberate, not a cost ceiling (guards against a future variable count)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      // The "fixed / deliberate, not a cost ceiling" framing must be present so a
+      // future edit can't silently turn 3 into a tunable knob.
+      expect(section).toMatch(/fixed/i)
+      expect(section).toMatch(/not a cost ceiling|deliberate/i)
+    })
+
+    // 4. Synthesizer is inline, NOT a subagent dispatch.
+    it('frames the synthesizer as inline in the orchestrator and explicitly NOT a subagent dispatch', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      // Inline / in the orchestrator.
+      expect(section).toMatch(/synthesiz/i)
+      expect(section).toMatch(/inline/i)
+      expect(section).toMatch(/orchestrator/i)
+      // Explicitly NOT dispatched as a subagent (the subtle correctness point).
+      expect(section).toMatch(/not[\s\S]{0,40}(a )?(separate )?subagent|no subagent/i)
+    })
+
+    it('distinguishes the synthesizer (inline) from the explorers (context-isolated subagents)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = understandSection(out)
+      // Explorers ARE context-isolated subagents...
+      expect(section).toMatch(/context-isolated\s+subagent/i)
+      // ...while the synthesizer is the inline seam, not a dispatch. Both framings
+      // must coexist in the same section so the contrast is explicit.
+      expect(section).toMatch(/inline/i)
+    })
+
+    // 5. Dev contract truly unchanged on Tier 0/1.
+    it('keeps the dev step-4 dispatch text "issue title and body" verbatim and scopes "plan + issue" to the understand phase', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // Step 4's own contract is unchanged: dev receives the issue title and body.
+      expect(out).toMatch(/4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      const step4Start = out.search(/\n4\.\s+\*\*Resolve via the dev specialist\*\*/)
+      const step4bStart = out.search(/\n4b\.\s+\*\*Harden via the QA/)
+      const step4 = out.slice(step4Start, step4bStart === -1 ? undefined : step4bStart)
+      expect(step4).toMatch(/issue title and body/i)
+      // The "plan + issue" handoff must NOT be bolted onto step 4 itself.
+      expect(step4).not.toMatch(/plan\s*\+\s*issue/i)
+      // It lives in the Tier-2 understand phase instead.
+      const section = understandSection(out)
+      expect(section).toMatch(/plan\s*\+\s*issue|plan and (the )?issue/i)
+    })
+
+    // 6. Structured-return adversarial — explicit enumerated fields.
+    it('enumerates the explorer structured-return fields by name (a free-form return cannot pass)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const start = out.search(/##+ .*Explorer specialist/i)
+      const end = out.search(/##+ .*Synthesizer seam/i)
+      const explorerSection = out.slice(start, end === -1 ? undefined : end)
+      expect(explorerSection).toMatch(/structured return/i)
+      // The stable field names the synthesizer relies on.
+      expect(explorerSection).toMatch(/\bHypothesis\b/)
+      expect(explorerSection).toMatch(/\bVerdict\b/)
+      expect(explorerSection).toMatch(/\bEvidence\b/)
+      expect(explorerSection).toMatch(/Proposed approach/i)
+      expect(explorerSection).toMatch(/Risks/i)
+    })
+
+    // 7. Explorer role renders after triage and exactly once (no duplication).
+    it('renders the Explorer specialist heading exactly once and after the triage step (3b)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const headings = out.match(/##+ .*Explorer specialist/gi) || []
+      expect(headings.length).toBe(1)
+      const triageIdx = out.search(/3b\.\s+\*\*Triage and scale/i)
+      const explorerIdx = out.search(/##+ .*Explorer specialist/i)
+      expect(triageIdx).toBeGreaterThan(-1)
+      expect(explorerIdx).toBeGreaterThan(triageIdx)
     })
   })
 

--- a/packages/ralph/lib/solo-mode-retired.qa.test.js
+++ b/packages/ralph/lib/solo-mode-retired.qa.test.js
@@ -16,7 +16,13 @@ import { templatePath, TEMPLATES_DIR } from './paths.js'
 const PROJECT = '/project'
 
 // The four role source files that get composed into the orchestrator.
-const ROLE_FILES = ['roles/dev.md', 'roles/qa.md', 'roles/reviewer.md', 'roles/writer.md']
+const ROLE_FILES = [
+  'roles/dev.md',
+  'roles/qa.md',
+  'roles/reviewer.md',
+  'roles/writer.md',
+  'roles/explorer.md',
+]
 const ALL_SOURCE_TEMPLATES = ['prompt-team.md', ...ROLE_FILES]
 
 // Same memfs mirror the dev's guard / build-prompt.test.js use.

--- a/packages/ralph/lib/solo-mode-retired.test.js
+++ b/packages/ralph/lib/solo-mode-retired.test.js
@@ -20,6 +20,7 @@ function setupFs() {
   const qaRole = readFileSync(templatePath('roles/qa.md'), 'utf8')
   const reviewerRole = readFileSync(templatePath('roles/reviewer.md'), 'utf8')
   const writerRole = readFileSync(templatePath('roles/writer.md'), 'utf8')
+  const explorerRole = readFileSync(templatePath('roles/explorer.md'), 'utf8')
   const vol = Volume.fromJSON({}, '/')
   vol.mkdirSync(templatePath('roles'), { recursive: true })
   vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
@@ -27,6 +28,7 @@ function setupFs() {
   vol.writeFileSync(templatePath('roles/qa.md'), qaRole)
   vol.writeFileSync(templatePath('roles/reviewer.md'), reviewerRole)
   vol.writeFileSync(templatePath('roles/writer.md'), writerRole)
+  vol.writeFileSync(templatePath('roles/explorer.md'), explorerRole)
   vol.mkdirSync(PROJECT, { recursive: true })
   return vol
 }

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -73,6 +73,58 @@ and triage uses only Tier 0 (Light) and Tier 1 (Standard).
    **not** plain config — it is substantive. Only classify as trivial when the
    change provably cannot alter behavior.
 
+## Tier 2 / Heavy — understand phase (explorer fan-out + inline synthesis)
+
+This phase runs **only on a Tier-2 run** (selected in step 3b, gated behind the
+`{{RALPH_HEAVY_TIER}}` flag). It sits **after** triage (step 3b) and **before**
+the dev dispatch (step 4). On Tier 0 / Tier 1 it is skipped entirely and the dev
+step-4 contract is unchanged.
+
+When Tier 2 is active, **understand before you build**:
+
+1. **Explorer fan-out (read-only)**: dispatch **exactly three** context-isolated
+   subagents in the **explorer** role (see "Explorer specialist" below). The
+   fan-out width is fixed at **3** — not a cost ceiling, but a deliberate choice
+   that avoids unreliable pre-read scope estimation. Hand each explorer a
+   **different, competing hypothesis** about the issue's root cause or the right
+   approach, so the three cover **distinct** leads rather than three takes on the
+   same guess. Explorers run strictly **read-only**: they investigate and report,
+   they never write or edit a file during the understand phase. Each returns the
+   structured return defined in its role.
+
+2. **Synthesizer (inline, named seam)**: the orchestrator runs the synthesizer
+   **inline** — it is **not** a separate subagent dispatch, but an explicit,
+   named, reviewable seam in this loop (see "Synthesizer seam" below). It
+   collapses the **three** explorer structured returns into a **single plan**:
+   the confirmed hypothesis (or the best-supported approach), the concrete change
+   it implies, the files in scope, and the risks the explorers surfaced.
+
+3. **Hand off to the dev**: on a Tier-2 run the dev (step 4) receives the
+   synthesized **plan + issue** instead of the issue alone. The dev's own
+   contract is otherwise unchanged — it still resolves through the strict
+   red → green → refactor loop. On Tier 0 / Tier 1 the dev receives the issue
+   title and body exactly as before.
+
+{{ROLE_EXPLORER}}
+
+### Synthesizer seam
+
+The synthesizer is the named, inline step that turns the three explorer returns
+into the one plan handed to the dev. It runs in the orchestrator itself (no
+subagent), reads each explorer's structured return, and:
+
+- **Reconciles verdicts** — prefers a `confirmed` hypothesis backed by concrete
+  evidence; when explorers disagree, it weighs the evidence rather than voting.
+- **Merges evidence** — unions the file paths, call sites, and risks the three
+  explorers surfaced into one scoped picture.
+- **Emits a single plan** — one ordered, actionable plan (approach, files in
+  scope, test strategy, risks) — the artifact handed to the dev as **plan +
+  issue** in step 4.
+
+Keeping the synthesizer an explicit, sectioned seam (rather than ad-hoc prose)
+makes the Tier-2 decision reviewable: the plan the dev acts on is traceable back
+to the three competing hypotheses it came from.
+
 4. **Resolve via the dev specialist**: dispatch a context-isolated
    subagent in the **dev** role (see "Dev specialist" below) with the
    issue title and body. The dev infers its persona from the issue and

--- a/packages/ralph/templates/roles/explorer.md
+++ b/packages/ralph/templates/roles/explorer.md
@@ -1,0 +1,36 @@
+## Explorer specialist
+
+The explorer is a **read-only** hypothesis investigator. On a Tier 2 / Heavy run
+the orchestrator dispatches three explorers in parallel as context-isolated
+subagents during the **understand** phase, each chasing a **different**
+hypothesis about the issue's root cause or the right approach. An explorer's job
+is to investigate the codebase and report what it found — never to change it.
+
+### Read-only investigation
+
+An explorer reads, searches, and reasons; it **does not write, edit, or modify**
+any file. It uses Read/Grep/search to chase its assigned hypothesis through the
+repo, confirming or refuting it with concrete evidence (file paths, line
+references, existing tests, call sites). It runs no destructive commands and
+produces no diff. The fix comes later — from the dev, after synthesis.
+
+Each of the three explorers is handed a **distinct, competing hypothesis** so the
+fan-out covers different leads rather than three takes on the same guess. An
+explorer that disproves its own hypothesis reports *that* — a refuted lead is a
+useful return, not a failure.
+
+### Structured return
+
+Every explorer ends with a **structured return** the orchestrator can synthesize
+mechanically. Return exactly these fields:
+
+- **Hypothesis** — the lead this explorer was assigned, restated.
+- **Verdict** — `confirmed`, `refuted`, or `partial`, with the evidence.
+- **Evidence** — the concrete file paths, line references, and call sites found.
+- **Proposed approach** — if confirmed, the change this implies (still no code
+  written); if refuted, what it rules out.
+- **Risks / unknowns** — anything the explorer could not resolve read-only.
+
+The orchestrator's inline synthesizer collapses the three structured returns into
+a single plan; a vague or free-form return cannot be synthesized, so keep the
+fields explicit.


### PR DESCRIPTION
Closes #481

Adds the Tier-2 "understand" phase to the Ralph orchestrator: when a heavy run is selected (gated behind `RALPH_HEAVY_TIER`, off by default), it fans out **3 read-only explorers** on competing hypotheses, then an **inline, named synthesizer seam** collapses their structured returns into a single plan handed to the dev as **plan + issue**. The dev's step-4 contract is unchanged.

## Dev/TDD
- Tests added/modified:
  - `packages/ralph/lib/build-prompt.test.js` — new `explorer specialist role composition` + `Tier-2 explorer fan-out + inline synthesis` describe blocks; `setupFs()` extended to register `roles/explorer.md`.
  - `packages/ralph/lib/solo-mode-retired.test.js` — `setupFs()` extended to write `explorer.md` (buildPrompt now reads it).
  - `packages/ralph/lib/solo-mode-retired.qa.test.js` — `roles/explorer.md` added to the composed-role fixture list.
- New non-test files: `packages/ralph/templates/roles/explorer.md` (read-only hypothesis investigator with a structured return).
- Before implementation (red): the 10 new dev tests failed for the right reason — `## Explorer` heading absent, the Tier-2 understand-phase prose did not exist in `prompt-team.md`, and the `{{ROLE_EXPLORER}}` slot was unresolved. (The "dev step-4 contract intact" test passed in red — proving no regression to the existing dispatch text.)
- After implementation (green): all `packages/ralph` tests pass.

## QA scenarios added
QA augmented the green suite with 10 adversarial/edge tests (`Tier-2 explorer fan-out — QA hardening` in `build-prompt.test.js`):
- region confinement — understand-phase tokens (`explorer`, `Synthesizer seam`, `competing hypothes`) must live only between step 3b and step 4, never leaking past the dev dispatch;
- custom-env survival — no stranded `{{...}}` placeholder and no stderr warning under a fully-populated env (`RALPH_HEAVY_TIER=2`) + non-empty PROMPT.md;
- fan-out pinned to exactly **3** with no contradictory width (`two`/`five`/`at least`/`up to` rejected), and the "fixed, not a cost ceiling" framing asserted;
- synthesizer is **inline, not a subagent dispatch** — contrasted against explorers being context-isolated subagents;
- dev contract truly unchanged — step-4 still says "issue title and body" verbatim; "plan + issue" is scoped to the understand phase;
- structured-return fields enumerated by name (Hypothesis / Verdict / Evidence / Proposed approach / Risks);
- Explorer heading rendered exactly once, after triage.
- No blocking bugs found.

## Review verdict
- APPROVE (round 1, no blocking findings). The reviewer confirmed the explorer is composed in `build-prompt.js` byte-for-byte like dev/qa/reviewer/writer (no special-casing), the prose matches the existing voice, both `solo-mode-retired` helpers were updated consistently so they won't silently rot, the tests assert the real contract (exactly-3, inline-not-subagent, dev-contract-unchanged, region confinement) rather than trivial string matches, and the synthesizer removes an unnecessary dispatch layer rather than adding indirection. One non-blocking nit (role-slot placement asymmetry) judged defensible.

## Docs updated
- `packages/ralph/README.md` — three edits: replaced the "Tier 2 fan-out roles do not exist yet" dark-launch note with a description of the understand phase; added an **Explorer (Tier 2 only)** entry to the specialist roster; updated the `RALPH_HEAVY_TIER` config-reference row. `docs/team-mode-spike.md` and `CHANGELOG.md` (release-please-managed) left untouched as the diff implied no change there.

## Notes
- Validation: `packages/ralph` `npm test` → **474 passed (474)**; root `npm run lint` → **0 errors** (26 pre-existing warnings in unrelated `src/` React files); root `npm run build` → succeeds.
- Tier 2 ships gated and dark (`RALPH_HEAVY_TIER` defaults to `0`), so default behavior is unchanged — this run itself executed on Tier 1.