### PR TITLE
feat: Tier-2 reviewer panel verify gate (3 diverse lenses, majority block)

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -83,7 +83,11 @@ fit it:
   the dev: it fans out **three** read-only explorers chasing competing
   hypotheses, then an inline synthesizer collapses their structured
   returns into one plan handed to the dev as **plan + issue** (see the
-  explorer in the roster below).
+  explorer in the roster below). A Tier-2 run also adds a **verify
+  phase** after the single-reviewer gate and before the PR opens: an
+  **adversarial panel of three reviewers** (correctness / security /
+  maintainability lenses) blocks the diff only on a **majority — 2 of 3**
+  (see the reviewer contract below).
 
 The specialists each have a single contract:
 
@@ -117,7 +121,16 @@ The specialists each have a single contract:
    just whether the code works. Blocking findings loop **back to the
    dev** and then back to the reviewer, bounded to a **maximum of 2
    rounds**. If concerns remain after the round limit, the loop stops
-   and a human is pulled in via the caveat flag (below).
+   and a human is pulled in via the caveat flag (below). On a **Tier 2**
+   run this single pass is replaced by an **adversarial panel of three
+   reviewers** in a **verify phase**: the same reviewer contract is
+   reused three times with **distinct lenses** (correctness, security,
+   and the step-4c maintainability standard as the maintainability
+   lens), and the diff is blocked only on a **majority — 2 of 3** (a lone
+   objection is recorded but does not gate the PR). The panel keeps the
+   same 2-round bound; on non-convergence the PR opens anyway with the
+   same caveat flag, identical to Tier 1. On Tier 0 / Tier 1 the panel is
+   skipped and the single-reviewer gate above is left unchanged.
 4. **Writer** — runs after the review gate passes. It inspects the
    diff and **infers** which docs the change implies (README,
    `CLAUDE.md`/`AGENTS.md`, `docs/` pages, inline docstrings),
@@ -208,7 +221,7 @@ be committed. Re-running `ralph init` never overwrites it.
 | `AUTO_MERGE`          | `true`                               | v0.1 only supports `true` (manual review mode lands in v0.2).          |
 | `MERGE_POLL_INTERVAL` | `30`                                 | Seconds between `gh pr view` polls while waiting for auto-merge.       |
 | `MERGE_POLL_MAX`      | `40`                                 | Max polls (default = 20 minutes) before giving up on a PR.             |
-| `RALPH_HEAVY_TIER`    | `0`                                  | Gates the **Tier 2 / Heavy** triage path. `0` = off (the default): the heavy tier is unavailable and triage falls back to Tier 1. When on, a Tier-2 run adds the explorer fan-out + inline synthesis understand phase before the dev. |
+| `RALPH_HEAVY_TIER`    | `0`                                  | Gates the **Tier 2 / Heavy** triage path. `0` = off (the default): the heavy tier is unavailable and triage falls back to Tier 1. When on, a Tier-2 run adds the explorer fan-out + inline synthesis understand phase before the dev, and a 3-reviewer adversarial-panel verify phase (majority-of-3 to block) before the PR opens. |
 
 The config is plain bash; edit it in any editor. On the next
 `ralph start` Ralph notices the change (sha256 mismatch in

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -1483,6 +1483,338 @@ describe('buildPrompt', () => {
     })
   })
 
+  describe('Tier-2 reviewer panel verify gate', () => {
+    function verifySection(out) {
+      const start = out.search(/##+ .*Tier 2[^\n]*verify/i)
+      const end = out.search(/\n4d\.\s+\*\*Document via the tech writer/)
+      return out.slice(start, end === -1 ? undefined : end)
+    }
+
+    it('dispatches a panel of three reviewers on a Tier-2 run', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      expect(section).toMatch(/##+ .*Tier 2[^\n]*verify/i)
+      expect(section).toMatch(/(three|3)\s+reviewer/i)
+      expect(section).toMatch(/panel/i)
+    })
+
+    it('reuses the existing reviewer contract rather than duplicating the maintainability standard', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      // Reuses the existing reviewer role (the "Code reviewer specialist").
+      expect(section).toMatch(/reviewer (role|contract)|existing reviewer/i)
+      // The maintainability standard is NOT re-stated in the verify section: the
+      // "Ralph-authored maintainability standard" heading text appears only in
+      // the pre-existing step 4c prose + the reviewer role file (its 2 baseline
+      // sites), never re-printed inside the verify-phase section.
+      expect(section).not.toMatch(/Ralph-authored maintainability standard/)
+      expect((out.match(/Ralph-authored maintainability standard/g) || []).length).toBe(2)
+    })
+
+    it('assigns the three distinct lenses: correctness, security, maintainability', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      expect(section).toMatch(/correctness/i)
+      expect(section).toMatch(/security/i)
+      expect(section).toMatch(/maintainability/i)
+      // The existing maintainability standard becomes the maintainability lens.
+      expect(section).toMatch(/maintainability lens/i)
+    })
+
+    it('blocks on majority-of-3 (2 of 3); a single reviewer cannot trap the loop', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      // Majority-of-3 / 2 of 3 blocking rule.
+      expect(section).toMatch(/majority/i)
+      expect(section).toMatch(/2 of 3|two of (the )?three|2 of the 3/i)
+      // A single reviewer cannot block / trap the loop on its own.
+      expect(section).toMatch(/single reviewer[\s\S]{0,40}(cannot|can't|does not|no).{0,20}(block|trap)/i)
+    })
+
+    it('bounds the panel to a maximum of 2 rounds', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      expect(section).toMatch(/(maximum|max|up to|at most).{0,12}2 rounds/i)
+      // Blocking findings loop back to the dev.
+      expect(section).toMatch(/back to the dev|return.+dev|hand.+back/i)
+    })
+
+    it('opens the PR anyway on non-convergence with a [!WARNING] block, Tier-1-consistent', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      // Non-convergence opens the PR anyway.
+      expect(section).toMatch(/open.+PR anyway|PR is opened anyway/i)
+      expect(section).toMatch(/non-convergence|converge/i)
+      // With a [!WARNING] block.
+      expect(section).toMatch(/\[!WARNING\]/)
+      // Semantics identical / consistent with Tier 1 — no Tier-2 special case.
+      expect(section).toMatch(/(identical|consistent).{0,40}tier[\s-]*1|tier[\s-]*1.{0,40}(identical|consistent)/i)
+    })
+
+    it('runs only on a Tier-2 run and leaves Tier 0/1 single-reviewer step 4c unchanged', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      // Gated behind the heavy-tier flag and scoped to Tier-2 runs.
+      expect(section).toMatch(/RALPH_HEAVY_TIER/)
+      expect(section).toMatch(/Tier[\s-]*2 run/i)
+      // Tier 0 / 1 keeps the existing single reviewer (step 4c) unchanged.
+      expect(section).toMatch(/Tier 0[\s\S]{0,40}(1|Tier 1)/i)
+      expect(section).toMatch(/single[\s-]reviewer|step 4c/i)
+    })
+
+    it('places the verify phase after the reviewer step (4c) and before step 4d and the Open PR step', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const reviewerStepIdx = out.search(/\b4c\.\s+\*\*Review via the code reviewer/)
+      const verifyIdx = out.search(/##+ .*Tier 2[^\n]*verify/i)
+      const step4dIdx = out.search(/\n4d\.\s+\*\*Document via the tech writer/)
+      const openPrIdx = out.search(/\bOpen PR\b/)
+      expect(reviewerStepIdx).toBeGreaterThan(-1)
+      expect(verifyIdx).toBeGreaterThan(-1)
+      expect(step4dIdx).toBeGreaterThan(-1)
+      expect(openPrIdx).toBeGreaterThan(-1)
+      expect(verifyIdx).toBeGreaterThan(reviewerStepIdx)
+      expect(verifyIdx).toBeLessThan(step4dIdx)
+      expect(verifyIdx).toBeLessThan(openPrIdx)
+    })
+
+    it('strands no {{...}} placeholder in the verify section under a fully-populated custom env', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '## Stack\nRust + cargo' } })
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: {
+          INSTALL_CMD: 'pnpm install',
+          TEST_CMD: 'cargo test --all',
+          LINT_CMD: 'cargo clippy',
+          PR_TARGET: 'integration',
+          MERGE_STRATEGY: 'merge',
+          RALPH_HEAVY_TIER: '2',
+        },
+        fs: vol,
+      })
+      const section = verifySection(out)
+      expect(section).toMatch(/reviewer/i)
+      expect(section).not.toMatch(/\{\{[A-Za-z_]/)
+    })
+
+    it('does not warn on unknown placeholders once the verify phase is added', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol, stderr })
+      expect(stderr.calls).toHaveLength(0)
+    })
+  })
+
+  describe('Tier-2 reviewer panel verify gate — QA hardening', () => {
+    const FULL_ENV = {
+      INSTALL_CMD: 'pnpm install --frozen-lockfile',
+      TEST_CMD: 'cargo test --all',
+      LINT_CMD: 'cargo clippy --strict',
+      MAIN_BRANCH: 'release',
+      DEV_BRANCH: 'integration',
+      PR_TARGET: 'integration',
+      MERGE_STRATEGY: 'merge',
+      MERGE_POLL_INTERVAL: '7',
+      MERGE_POLL_MAX: '99',
+      RALPH_HEAVY_TIER: '2',
+    }
+
+    // The verify phase: from its heading up to the step-4d (tech writer) marker.
+    function verifySection(out) {
+      const start = out.search(/##+ .*Tier 2[^\n]*verify/i)
+      const end = out.search(/\n4d\.\s+\*\*Document via the tech writer/)
+      return out.slice(start, end === -1 ? undefined : end)
+    }
+
+    // Everything from step 4d onward (the writer step, validate, commit, Open PR,
+    // failure, restrictions). Verify-phase-unique tokens must not leak here.
+    function afterVerify(out) {
+      const start = out.search(/\n4d\.\s+\*\*Document via the tech writer/)
+      return out.slice(start)
+    }
+
+    // Everything strictly before the verify heading (intro header, triage,
+    // understand phase, steps 4 / 4b / 4c). The adversarial-panel prose is unique
+    // to the verify phase and must not appear upstream.
+    function beforeVerify(out) {
+      const end = out.search(/##+ .*Tier 2[^\n]*verify/i)
+      return out.slice(0, end)
+    }
+
+    // 1. Region confinement — verify-phase tokens must not leak downstream/upstream.
+    it('confines the adversarial-panel prose to the verify section — no leak before it or after step 4d', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const before = beforeVerify(out)
+      const after = afterVerify(out)
+      // Tokens unique to the verify phase must not appear in the writer/validate/
+      // PR region downstream...
+      expect(after).not.toMatch(/adversarial panel/i)
+      expect(after).not.toMatch(/majority/i)
+      expect(after).not.toMatch(/2 of 3/i)
+      // ...nor in the header/triage/understand/single-reviewer prose upstream.
+      expect(before).not.toMatch(/adversarial panel/i)
+      expect(before).not.toMatch(/majority/i)
+      expect(before).not.toMatch(/2 of 3/i)
+      // And the verify section really does carry them (so the negatives bite).
+      const section = verifySection(out)
+      expect(section).toMatch(/adversarial panel/i)
+      expect(section).toMatch(/majority/i)
+      expect(section).toMatch(/2 of 3/i)
+    })
+
+    // 2. No SECOND "Code reviewer specialist" heading — the panel reuses the one
+    //    composed at 4c; it does not redeclare the role.
+    it('introduces no second "Code reviewer specialist" heading — the count stays exactly 1', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // The verify phase reuses the reviewer composed at 4c; it must not compose a
+      // second copy of the role heading.
+      expect((out.match(/##+ .*Code reviewer specialist/gi) || []).length).toBe(1)
+      // The verify section itself must NOT carry a fresh role heading.
+      const section = verifySection(out)
+      expect(section).not.toMatch(/##+ .*Code reviewer specialist/i)
+      // It explicitly points back to the reuse instead.
+      expect(section).toMatch(/reuse|existing reviewer|composed above/i)
+    })
+
+    // 3. No-duplication adversarial — the maintainability-standard RULE BODIES are
+    //    not re-printed in the verify section (it only names the lens + points to 4c).
+    it('does not restate the maintainability rule bodies inside the verify section', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      // The verify section may NAME the lens / its rules, but must not re-print the
+      // rule prose bodies that live in step 4c + reviewer.md.
+      expect(section).not.toContain('flag files that have grown too large')
+      expect(section).not.toContain('reject tangled control flow')
+      expect(section).not.toContain('abstractions must earn their keep')
+      expect(section).not.toContain('remove it rather than adding another')
+      expect(section).not.toContain('Green tests are the floor')
+      // The "Ralph-authored maintainability standard" heading is one of its two
+      // baseline sites (step 4c prose + reviewer.md) and is NOT duplicated here.
+      expect(section).not.toMatch(/Ralph-authored maintainability standard/)
+      expect((out.match(/Ralph-authored maintainability standard/g) || []).length).toBe(2)
+      // It explicitly defers to step 4c rather than restating.
+      expect(section).toMatch(/step 4c/i)
+    })
+
+    // 4. Exactly three, not "at least" — no contradictory width, no hedging.
+    it('pins the panel width to exactly three with no contradictory width and no hedging', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      expect(section).toMatch(/(three|3)\s+reviewer/i)
+      // No alternative widths that would contradict the fixed 3.
+      expect(section).not.toMatch(/(two|four|five|6)\s+reviewer/i)
+      expect(section).not.toMatch(/reviewers?\s+\(.*\b(2|4|5)\b/i)
+      // No "at least"/"up to" hedging that would let the panel drift to a
+      // variable count.
+      expect(section).not.toMatch(/(at least|up to|as many as|one or more)\s+(three|3)?\s*reviewer/i)
+    })
+
+    // 5. Majority semantics adversarial — 2-of-3 is the threshold; unsafe
+    //    inversions (lone-reviewer block, unanimity-required) are absent.
+    it('fixes the block threshold at 2-of-3 and forbids the unsafe inversions', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      // 2-of-3 majority is the gate.
+      expect(section).toMatch(/majority/i)
+      expect(section).toMatch(/2 of 3|two of (the )?three|2 of the 3/i)
+      // A single / lone reviewer cannot block on its own.
+      expect(section).toMatch(/single reviewer[\s\S]{0,40}(cannot|can't|does not|no)/i)
+      // The unsafe inversions must NOT be stated. Use \b(can|may|must)\b so the
+      // SAFE phrase "single reviewer cannot block" (where "can" is a substring of
+      // "cannot") is not mistaken for an unsafe "single reviewer CAN block".
+      expect(section).not.toMatch(/single reviewer[\s\S]{0,30}\b(can|may|must)\b[\s\S]{0,20}block/i)
+      // Requiring all three / unanimity to block is also forbidden.
+      expect(section).not.toMatch(/(unanim|all three reviewers must|all 3 reviewers must)/i)
+    })
+
+    // 6. Custom-env survival + warning-free under a fully-populated env and a
+    //    NON-empty PROMPT.md.
+    it('strands no {{...}} in the verify section and emits no warning under a full custom env (RALPH_HEAVY_TIER=2) and a NON-empty PROMPT.md', () => {
+      const vol = setupFs({
+        projectFiles: { 'PROMPT.md': '## Stack\nRust + cargo\n\nProject notes.' },
+      })
+      const stderr = makeStderr()
+      const out = buildPrompt({ projectRoot: PROJECT, env: FULL_ENV, fs: vol, stderr })
+      const section = verifySection(out)
+      expect(section).toMatch(/reviewer/i)
+      // The panel re-runs the test+lint commands, which must interpolate cleanly.
+      expect(section).toContain('cargo test --all')
+      expect(section).toContain('cargo clippy --strict')
+      expect(section).not.toMatch(/\{\{[A-Za-z_]/)
+      // And the whole composition stays warning-free under the custom env.
+      expect(stderr.calls).toHaveLength(0)
+    })
+
+    // 7. Tier 0/1 unchanged invariant — single-reviewer 4c intact, verify skipped.
+    it('leaves the single-reviewer step 4c intact and explicitly skips the panel on Tier 0/1', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      // Step 4c (the single-reviewer gate) is still present and unchanged.
+      expect(out).toMatch(/\b4c\.\s+\*\*Review via the code reviewer/)
+      // The verify phase declares itself skipped on a Tier 0 / Tier 1 run, leaving
+      // 4c untouched.
+      const section = verifySection(out)
+      expect(section).toMatch(/Tier 0[\s\S]{0,40}(Tier )?1[\s\S]{0,80}skip/i)
+      expect(section).toMatch(/single-reviewer step 4c[\s\S]{0,40}(unchanged|left)/i)
+    })
+
+    // 8. Ordering robustness — verify strictly after 4c, strictly before 4d /
+    //    Open PR, with the understand phase also present upstream.
+    it('orders the verify phase strictly after step 4c and strictly before step 4d and Open PR, with the understand phase present upstream', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const understandIdx = out.search(/##+ .*Tier 2[^\n]*understand/i)
+      const step4cIdx = out.search(/\b4c\.\s+\*\*Review via the code reviewer/)
+      const verifyIdx = out.search(/##+ .*Tier 2[^\n]*verify/i)
+      const step4dIdx = out.search(/\n4d\.\s+\*\*Document via the tech writer/)
+      const openPrIdx = out.search(/\*\*Open PR\*\*/)
+      for (const idx of [understandIdx, step4cIdx, verifyIdx, step4dIdx, openPrIdx]) {
+        expect(idx).toBeGreaterThan(-1)
+      }
+      // understand phase comes before the single reviewer, which comes before the
+      // panel, which comes before the writer and the PR step.
+      expect(understandIdx).toBeLessThan(step4cIdx)
+      expect(step4cIdx).toBeLessThan(verifyIdx)
+      expect(verifyIdx).toBeLessThan(step4dIdx)
+      expect(verifyIdx).toBeLessThan(openPrIdx)
+    })
+
+    // 9. Non-convergence is Tier-1-consistent — reuses step 7's [!WARNING] block
+    //    so the outer bash needs no Tier-2 special case.
+    it('routes non-convergence through the SAME step-7 [!WARNING] block, needing no Tier-2 bash special case', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      const section = verifySection(out)
+      // Opens the PR anyway on non-convergence...
+      expect(section).toMatch(/open the PR \*\*anyway\*\*|open.+PR anyway|PR is opened anyway/i)
+      expect(section).toMatch(/converge/i)
+      // ...via the same [!WARNING] block step 7 already prepends (reuse, not a new
+      // mechanism)...
+      expect(section).toMatch(/\[!WARNING\]/)
+      expect(section).toMatch(/step 7/)
+      // ...and the bash needs NO Tier-2 special case for success/failure accounting.
+      expect(section).toMatch(/no[\s\S]{0,20}Tier-?2 special case|Tier-?2 special case/i)
+      // The verify section must NOT define a fresh warning template of its own — it
+      // points at the one step 7 already prepends. The literal block body (the
+      // "> [!WARNING]" line plus its "Unresolved review concerns" heading) is
+      // authored exactly once, in step 7; the verify prose only references it.
+      expect((out.match(/> \[!WARNING\]/g) || []).length).toBe(1)
+      expect((out.match(/Unresolved review concerns/g) || []).length).toBe(1)
+    })
+  })
+
   describe('issue selection query', () => {
     function selectQuery(out) {
       const match = out.match(/gh issue list[^\n]*--search '([^']+)'/)

--- a/packages/ralph/templates/prompt-team.md
+++ b/packages/ralph/templates/prompt-team.md
@@ -162,6 +162,50 @@ to the three competing hypotheses it came from.
 
 {{ROLE_REVIEW}}
 
+## Tier 2 / Heavy — verify phase (3-reviewer adversarial panel, majority block)
+
+This phase runs **only on a Tier-2 run** (selected in step 3b, gated behind the
+heavy-tier flag `RALPH_HEAVY_TIER`). It is the Tier-2 form of the verify/review
+gate: it sits **after** the single-reviewer step 4c and **before** step 4d and
+the PR step (7), gating the diff **before** the PR opens. On a Tier 0 / Tier 1
+run it is **skipped entirely** and the single-reviewer step 4c above is left
+unchanged.
+
+When Tier 2 is active, gate the diff with an **adversarial panel of three
+reviewers** instead of a single pass:
+
+1. **Panel of three (reuse the existing reviewer contract)**: dispatch the
+   existing reviewer role (the "Code reviewer specialist" composed above) as
+   **three** context-isolated subagents. The panel does **not** redefine or
+   duplicate the maintainability rules — it **reuses** that one reviewer contract
+   three times, handing each reviewer a **distinct lens**:
+   - **Correctness lens** — does the change do the right thing: logic, edge cases,
+     and behavior against the issue and the full test set.
+   - **Security lens** — input handling, injection, secrets, auth, and unsafe
+     operations introduced or exposed by the diff.
+   - **Maintainability lens** — the existing maintainability standard from step
+     4c (oversized-file guard, anti-spaghetti, abstraction quality,
+     prefer-deleting-indirection, do-not-approve-on-behavior-alone), applied
+     as-is. The step-4c maintainability standard simply **becomes the
+     maintainability lens** here; it is not restated.
+
+2. **Majority-of-3 to block (2 of 3)**: the panel blocks the diff only when a
+   **majority — 2 of 3 — of the reviewers** agree it must change.
+   A single reviewer cannot block or trap the loop on its own: one lone objection
+   is recorded but does not gate the PR. When 2 of 3 block, the agreed findings
+   loop back to the dev to fix, then control returns to the panel to re-check the
+   diff and re-run `{{TEST_CMD}}` and `{{LINT_CMD}}`.
+
+3. **Max 2 rounds, then non-convergence opens the PR anyway**: this loop is
+   bounded to a **maximum of 2 rounds** (consistent with the single-reviewer
+   step 4c). If the majority still blocks after 2 rounds, the bots have failed to
+   converge — do **not** loop further. Open the PR **anyway** in step 7 with the
+   same prominent `[!WARNING]` block step 7 already prepends, listing the
+   unresolved panel findings so a human is pulled in. On **non-convergence** these
+   semantics are **identical to / consistent with Tier 1**: it is treated as a
+   normal PR-with-warning, so the outer bash success/failure accounting needs **no
+   Tier-2 special case**.
+
 4d. **Document via the tech writer specialist**: once the review gate has
    passed, dispatch a context-isolated subagent in the **tech writer** role
    (see "Tech writer specialist" below) with the issue and the dev's diff. The


### PR DESCRIPTION
Closes #482

Adds the Tier-2 **verify phase** — the review-end analog of the already-merged Tier-2 understand phase (#496). A 3-reviewer adversarial panel gates the diff before the PR opens, reusing the existing reviewer contract ×3 with diverse lenses, majority-of-3 to block.

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/build-prompt.test.js` (new `describe('Tier-2 reviewer panel verify gate', ...)` — 10 deterministic composition tests)
- Implementation: `packages/ralph/templates/prompt-team.md` (new `## Tier 2 / Heavy — verify phase` section between the `{{ROLE_REVIEW}}` composition / step 4c and step 4d)
- Before implementation (red): the 10 new tests failed for the right reason — `verifySection(out)` returned empty because the `## Tier 2 … verify` heading genuinely did not exist yet (e.g. "expected '' to match /reviewer/i"; "expected -1 to be greater than -1"). The 474 baseline tests stayed green, confirming the failures were the missing prose, not a harness/import error.
- After implementation (green): all tests pass.

The panel dispatches the existing "Code reviewer specialist" contract three times (no second role heading, no duplicated maintainability standard — the step-4c standard *becomes* the maintainability lens), under correctness / security / maintainability lenses, blocks on majority-of-3 (2 of 3 — a lone reviewer cannot trap the loop), bounds to max 2 rounds, and on non-convergence opens the PR anyway with the same step-7 `[!WARNING]` block (Tier-1-consistent, so the bash success/failure accounting needs no Tier-2 special case). Gated behind `RALPH_HEAVY_TIER`; Tier 0/1 single-reviewer step 4c is left unchanged.

## QA scenarios added
QA augmented with a `describe('Tier-2 reviewer panel verify gate — QA hardening', ...)` block (9 tests) in `packages/ralph/lib/build-prompt.test.js`:
- Region confinement — panel prose (`adversarial panel`/`majority`/`2 of 3`) does not leak before the verify heading or past step 4d.
- No second "Code reviewer specialist" heading (reuses the one composed at 4c; count stays exactly 1).
- No restatement of the maintainability rule bodies inside the verify section (standard heading count stays 2 — its baseline sites).
- Panel width pinned to exactly three (no "two/four/five", no "at least/up to N" hedging).
- 2-of-3 block threshold with unsafe inversions (lone-reviewer-blocks / unanimity-required) explicitly absent.
- Custom-env survival (RALPH_HEAVY_TIER=2 + non-empty PROMPT.md): no stranded `{{...}}`, no stderr warning, `{{TEST_CMD}}`/`{{LINT_CMD}}` interpolate.
- Tier 0/1 invariant — step 4c intact, panel skipped.
- Ordering robustness — verify after 4c, before 4d / Open PR, with understand phase upstream.
- Non-convergence routes through the single step-7 `> [!WARNING]` block (body + "Unresolved review concerns" each appear once).

All QA tests pass — **no defects found**; the dev's implementation held against every adversarial probe.

## Review verdict
**APPROVE** — no blocking findings. The change faithfully mirrors the understand-phase house style (same heading pattern, gating preamble, numbered-list body), reuses the reviewer contract as a single source of truth (anti-spaghetti / no duplication), and satisfies every acceptance criterion. Two optional non-blocking nits noted (bare `RALPH_HEAVY_TIER` vs `{{RALPH_HEAVY_TIER}}` flag style; a per-describe `verifySection` helper — both consistent with existing `triageSection`/`understandSection` conventions). Tests green (493), lint 0 errors.

## Docs updated
- `packages/ralph/README.md` — documented the verify phase alongside the already-documented understand phase: the Tier-2 triage bullet, the reviewer specialist contract (roster item 3), and the `RALPH_HEAVY_TIER` config-reference row. No other docs implied a change (root README is a high-level overview; `docs/` has no Ralph-tier reference page; CHANGELOG is release-please-managed).

## Notes
- Full team run (Tier 1 / substantive): dev → QA → review → writer.
- Validation: `npm test` (packages/ralph) 493 pass; `npm run lint` 0 errors (26 pre-existing unrelated `src/` warnings); `npm run build` succeeds.
- Sibling of #496 (understand phase) under parent #477; blocker #480 is already merged to `dev` (`pending-merge`).