### PR TITLE
feat: add sessionNameFor helper for per-project tmux session names

### DIFF
--- a/packages/ralph/lib/lock.js
+++ b/packages/ralph/lib/lock.js
@@ -9,9 +9,18 @@ import {
 const DEFAULT_STALE_AFTER_MS = 6 * 60 * 60 * 1000
 const DEFAULT_TMP_DIR = '/tmp'
 
+function slugFor(repoPath) {
+  return createHash('sha256').update(repoPath).digest('hex').slice(0, 8)
+}
+
 export function lockPathFor(repoPath, tmpDir = DEFAULT_TMP_DIR) {
-  const slug = createHash('sha256').update(repoPath).digest('hex').slice(0, 8)
-  return `${tmpDir}/ralph-cycle-${slug}.lock`
+  return `${tmpDir}/ralph-cycle-${slugFor(repoPath)}.lock`
+}
+
+export function sessionNameFor(repoPath) {
+  const basename = repoPath.replace(/\/+$/, '').split('/').pop() || ''
+  const sanitized = basename.replace(/[^A-Za-z0-9_-]/g, '-')
+  return `ralph-${sanitized}-${slugFor(repoPath)}`
 }
 
 export function acquireLock(repoPath, options = {}) {

--- a/packages/ralph/lib/lock.test.js
+++ b/packages/ralph/lib/lock.test.js
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { Volume } from 'memfs'
 import { createHash } from 'node:crypto'
-import { acquireLock, lockPathFor, peekLock, releaseLock } from './lock.js'
+import {
+  acquireLock,
+  lockPathFor,
+  peekLock,
+  releaseLock,
+  sessionNameFor,
+} from './lock.js'
 
 const REPO = '/Users/me/repos/agenthub'
 
@@ -50,6 +56,125 @@ describe('lockPathFor', () => {
 
   it('honors a custom tmp directory', () => {
     expect(lockPathFor(REPO, '/var/tmp')).toBe(expectedLockPath(REPO, '/var/tmp'))
+  })
+})
+
+describe('sessionNameFor', () => {
+  it('returns ralph-<sanitized-basename>-<sha8> for the repo path', () => {
+    const slug = createHash('sha256').update(REPO).digest('hex').slice(0, 8)
+    expect(sessionNameFor(REPO)).toBe(`ralph-agenthub-${slug}`)
+  })
+
+  it('shares the 8-char slug with the lock file path', () => {
+    const slug = createHash('sha256').update(REPO).digest('hex').slice(0, 8)
+    expect(sessionNameFor(REPO)).toContain(slug)
+    expect(lockPathFor(REPO)).toContain(slug)
+  })
+
+  it('includes the repo basename', () => {
+    expect(sessionNameFor('/Users/me/repos/my-project')).toContain('my-project')
+  })
+
+  it('sanitizes characters outside [A-Za-z0-9_-] (including . and :)', () => {
+    const name = sessionNameFor('/Users/me/repos/my.cool:repo')
+    expect(name).toContain('my-cool-repo')
+    expect(name).toMatch(/^ralph-[A-Za-z0-9_-]+$/)
+  })
+
+  it('resolves the basename even with a trailing slash', () => {
+    const slug = createHash('sha256').update('/Users/me/repos/agenthub/').digest('hex').slice(0, 8)
+    expect(sessionNameFor('/Users/me/repos/agenthub/')).toBe(`ralph-agenthub-${slug}`)
+  })
+
+  it('is deterministic for the same repo path', () => {
+    expect(sessionNameFor(REPO)).toBe(sessionNameFor(REPO))
+  })
+
+  it('differs for different repo paths', () => {
+    expect(sessionNameFor('/a/foo')).not.toBe(sessionNameFor('/b/foo'))
+  })
+
+  // --- QA adversarial / edge-case augmentation ---
+
+  const TMUX_VALID = /^ralph-[A-Za-z0-9_-]+-[0-9a-f]{8}$/
+
+  it('collapses nothing but still resolves basename across consecutive mid-path slashes', () => {
+    const p = '/Users/me//repos///agenthub'
+    const slug = createHash('sha256').update(p).digest('hex').slice(0, 8)
+    // split('/') yields ['', 'Users', 'me', '', 'repos', '', '', 'agenthub']
+    // .pop() => 'agenthub'
+    expect(sessionNameFor(p)).toBe(`ralph-agenthub-${slug}`)
+    expect(sessionNameFor(p)).toMatch(TMUX_VALID)
+  })
+
+  it('handles a bare directory name with no slash', () => {
+    const slug = createHash('sha256').update('agenthub').digest('hex').slice(0, 8)
+    expect(sessionNameFor('agenthub')).toBe(`ralph-agenthub-${slug}`)
+    expect(sessionNameFor('agenthub')).toMatch(TMUX_VALID)
+  })
+
+  it('produces a tmux-valid name even when the basename is entirely illegal chars', () => {
+    const p = '/repos/@#$'
+    const slug = createHash('sha256').update(p).digest('hex').slice(0, 8)
+    const name = sessionNameFor(p)
+    // '@#$' (3 illegal chars) -> '---', so name is 'ralph-' + '---' + '-' + slug
+    expect(name).toBe(`ralph-----${slug}`)
+    expect(name).toMatch(TMUX_VALID)
+    // tmux forbids only '.' and ':' in session names; hyphens are fine.
+    expect(name).not.toContain('.')
+    expect(name).not.toContain(':')
+  })
+
+  it('replaces spaces, dots, colons and unicode with hyphens (full result tmux-safe)', () => {
+    const name = sessionNameFor('/Users/me/repos/my repo.v2:café')
+    // 'my repo.v2:café' -> 'my-repo-v2-caf-' (é replaced)
+    expect(name).toMatch(/^ralph-[A-Za-z0-9_-]+$/)
+    expect(name).toMatch(TMUX_VALID)
+    expect(name).not.toContain('.')
+    expect(name).not.toContain(':')
+    expect(name).not.toContain(' ')
+    expect(name).not.toContain('é')
+  })
+
+  it('preserves underscores and hyphens (already-legal tmux chars)', () => {
+    const slug = createHash('sha256').update('/x/my_cool-repo').digest('hex').slice(0, 8)
+    expect(sessionNameFor('/x/my_cool-repo')).toBe(`ralph-my_cool-repo-${slug}`)
+  })
+
+  it('embeds the exact same 8-hex slug as lockPathFor for several distinct paths', () => {
+    for (const p of ['/a/foo', '/very/deep/nested/proj', 'bare', '/with space/dir', REPO]) {
+      const sessSlug = sessionNameFor(p).match(/-([0-9a-f]{8})$/)
+      const lockSlug = lockPathFor(p).match(/ralph-cycle-([0-9a-f]{8})\.lock$/)
+      expect(sessSlug).not.toBeNull()
+      expect(lockSlug).not.toBeNull()
+      expect(sessSlug[1]).toBe(lockSlug[1])
+    }
+  })
+
+  it('produces DIFFERENT session names for two paths sharing the same basename', () => {
+    // The whole point of the slug: same basename, different full path => no collision.
+    const a = sessionNameFor('/a/agenthub')
+    const b = sessionNameFor('/b/agenthub')
+    expect(a).not.toBe(b)
+    // Sanitized basename portion is identical; only the slug differs.
+    expect(a).toContain('ralph-agenthub-')
+    expect(b).toContain('ralph-agenthub-')
+  })
+
+  it('handles a root-ish empty-basename path without throwing and stays tmux-valid', () => {
+    // '/' -> trailing slash stripped to '' -> basename '' -> 'ralph--<slug>'.
+    // The basename segment is EMPTY, so the strict TMUX_VALID regex (which
+    // requires +) does not match. That is fine: tmux only forbids '.' and ':'
+    // in session names; an empty segment yielding a double-hyphen is still a
+    // legal tmux session name. So we assert tmux-legality, not the strict shape.
+    const slug = createHash('sha256').update('/').digest('hex').slice(0, 8)
+    const name = sessionNameFor('/')
+    expect(name).toBe(`ralph--${slug}`)
+    expect(name).not.toContain('.')
+    expect(name).not.toContain(':')
+    expect(name).not.toContain(' ')
+    // Composed only of legal tmux session-name chars:
+    expect(name).toMatch(/^[A-Za-z0-9_-]+$/)
   })
 })
 


### PR DESCRIPTION
Closes #486

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/lock.test.js`
- Before implementation (red): added a `describe('sessionNameFor')` block (7 tests) — all failed with `TypeError: sessionNameFor is not a function` (correct reason: function not yet implemented). Suite was `7 failed | 493 passed`.
- After implementation (green): implemented `sessionNameFor(repoPath)` in `packages/ralph/lib/lock.js` returning `ralph-<sanitized-basename>-<sha8>`. Refactored a shared private `slugFor(repoPath)` so `lockPathFor` and `sessionNameFor` provably derive the same 8-hex slug. All 500 tests pass.

## QA scenarios added
QA augmented the green suite with 8 adversarial/edge-case tests in `packages/ralph/lib/lock.test.js` (total 508 pass):
- consecutive mid-path slashes (`/Users/me//repos///agenthub`)
- bare directory name with no slash (`agenthub`)
- basename of entirely-illegal chars (`/repos/@#$`) stays tmux-valid
- spaces, dots, colons, unicode all sanitized to `-` (full result matches `^ralph-[A-Za-z0-9_-]+$`)
- underscores/hyphens preserved
- structural shared-slug invariant vs `lockPathFor` across 5 paths
- **collision sanity**: two paths with the same basename (`/a/agenthub` vs `/b/agenthub`) yield different session names (slug differs)
- root-ish empty-basename path (`/`) doesn't throw and stays tmux-legal

No QA test exposed a defect; the empty-basename edge (`ralph--<slug>`) was judged tmux-valid (tmux forbids only `.` and `:`).

## Review verdict
- **APPROVE.** Reviewer found the `slugFor` extraction a genuine improvement (makes the shared-slug guarantee structural, not coincidental), naming/readability good, file not oversized, no spaghetti. Non-blocking nits only: `node:path.basename()` would be marginally more idiomatic than the hand-rolled POSIX split (but the hand-rolled split is more predictable for this tmux/POSIX tool), and minor test redundancy in the shared-slug assertions. No blocking findings.

## Docs updated
- none — diff implied no doc change. The helper is foundation-only plumbing (not yet wired into start/stop/cycle, which still use the hardcoded `ralph` session). README/CONTRIBUTING still correctly document current behavior; `lock.js` exports carry no JSDoc, so adding one only to the new function would break convention.

## Notes
- This is the foundation slice for parent #485; the start/stop/cycle slices depend on it and will wire `sessionNameFor` into the call sites.
- `packages/ralph` runs its own suite (`cd packages/ralph && npm test`); root `npm test`/`npm run lint` ignore `packages/**`, so there is no root-lint coverage for this package. Root `npm run lint` passes with 0 errors.