### PR TITLE
feat: ralph stop stops the current project's tmux session

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -36,7 +36,7 @@ In a git repo on the branch you want Ralph to work from:
 ralph init     # one-time: detect stack, write config, slash command, gitignore
 ralph doctor   # verify required deps are on PATH
 ralph start    # launch the loop in a detached tmux session
-ralph stop     # kill the tmux session when you want Ralph to halt
+ralph stop     # kill this project's tmux session when you want Ralph to halt
 ```
 
 `ralph init` is non-interactive: it inspects the manifests in your repo

--- a/packages/ralph/lib/commands/stop.js
+++ b/packages/ralph/lib/commands/stop.js
@@ -1,6 +1,5 @@
 import { execa } from 'execa'
-
-const TMUX_SESSION = 'ralph'
+import { sessionNameFor } from '../lock.js'
 
 class StopAbort extends Error {
   constructor(message, exitCode = 1) {
@@ -10,6 +9,7 @@ class StopAbort extends Error {
 }
 
 export async function stopCommand({
+  cwd = process.cwd(),
   stdout = process.stdout,
   stderr = process.stderr,
   exec = execa,
@@ -17,18 +17,22 @@ export async function stopCommand({
   const out = (msg) => stdout.write(msg + '\n')
   const err = (msg) => stderr.write(msg + '\n')
 
-  const has = await exec('tmux', ['has-session', '-t', TMUX_SESSION], { reject: false })
+  // Per-project tmux session name so `stop` only touches THIS repo's loop,
+  // leaving other projects' running loops untouched.
+  const session = sessionNameFor(cwd)
+
+  const has = await exec('tmux', ['has-session', '-t', session], { reject: false })
   if (has.exitCode !== 0) {
-    out(`ℹ️  Nenhuma sessão tmux '${TMUX_SESSION}' em execução.`)
+    out(`ℹ️  Nenhuma sessão tmux '${session}' em execução.`)
     return { exitCode: 0, killed: false }
   }
 
-  const result = await exec('tmux', ['kill-session', '-t', TMUX_SESSION], { reject: false })
+  const result = await exec('tmux', ['kill-session', '-t', session], { reject: false })
   if (result.exitCode !== 0) {
     err(`❌ Falha ao matar sessão tmux: ${(result.stderr || '').trim()}`)
     throw new StopAbort('tmux kill-session failed', 1)
   }
-  out(`✅ Sessão tmux '${TMUX_SESSION}' encerrada.`)
+  out(`✅ Sessão tmux '${session}' encerrada.`)
   return { exitCode: 0, killed: true }
 }
 

--- a/packages/ralph/test/commands/stop.test.js
+++ b/packages/ralph/test/commands/stop.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { stopCommand, StopAbort } from '../../lib/commands/stop.js'
+import { sessionNameFor } from '../../lib/lock.js'
+
+// Per-project session name used across the suite. stopCommand derives the
+// session name from cwd via sessionNameFor; tests default to cwd '/repo'.
+const SESSION = sessionNameFor('/repo')
 
 function makeStream() {
   const chunks = []
@@ -13,11 +18,15 @@ function makeStream() {
 }
 
 function makeExec(handlers) {
-  return async (cmd, args) => {
+  const calls = []
+  const exec = async (cmd, args) => {
     const key = `${cmd} ${args.join(' ')}`
+    calls.push(key)
     if (handlers[key]) return handlers[key]
     throw new Error(`unexpected exec: ${key}`)
   }
+  exec.calls = calls
+  return exec
 }
 
 describe('stopCommand', () => {
@@ -25,33 +34,205 @@ describe('stopCommand', () => {
     const stdout = makeStream()
     const stderr = makeStream()
     const exec = makeExec({
-      'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 1, stdout: '', stderr: '' },
     })
-    const result = await stopCommand({ stdout, stderr, exec })
+    const result = await stopCommand({ cwd: '/repo', stdout, stderr, exec })
     expect(result).toEqual({ exitCode: 0, killed: false })
-    expect(stdout.output()).toContain("Nenhuma sessão tmux 'ralph'")
+    expect(stdout.output()).toContain(`Nenhuma sessão tmux '${SESSION}'`)
   })
 
   it('kills the session when present', async () => {
     const stdout = makeStream()
     const stderr = makeStream()
     const exec = makeExec({
-      'tmux has-session -t ralph': { exitCode: 0, stdout: '', stderr: '' },
-      'tmux kill-session -t ralph': { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux kill-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
     })
-    const result = await stopCommand({ stdout, stderr, exec })
+    const result = await stopCommand({ cwd: '/repo', stdout, stderr, exec })
     expect(result).toEqual({ exitCode: 0, killed: true })
-    expect(stdout.output()).toContain("Sessão tmux 'ralph' encerrada")
+    expect(stdout.output()).toContain(`Sessão tmux '${SESSION}' encerrada`)
   })
 
   it('throws StopAbort when kill-session fails', async () => {
     const stdout = makeStream()
     const stderr = makeStream()
     const exec = makeExec({
-      'tmux has-session -t ralph': { exitCode: 0, stdout: '', stderr: '' },
-      'tmux kill-session -t ralph': { exitCode: 1, stdout: '', stderr: 'boom' },
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux kill-session -t ${SESSION}`]: { exitCode: 1, stdout: '', stderr: 'boom' },
     })
-    await expect(stopCommand({ stdout, stderr, exec })).rejects.toBeInstanceOf(StopAbort)
+    await expect(
+      stopCommand({ cwd: '/repo', stdout, stderr, exec }),
+    ).rejects.toBeInstanceOf(StopAbort)
+    expect(stderr.output()).toContain('Falha ao matar sessão tmux')
+  })
+
+  it('targets the cwd-derived session name, not the literal "ralph"', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const exec = makeExec({
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux kill-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
+    })
+    await stopCommand({ cwd: '/repo', stdout, stderr, exec })
+    expect(exec.calls).toContain(`tmux has-session -t ${SESSION}`)
+    expect(exec.calls).toContain(`tmux kill-session -t ${SESSION}`)
+    expect(exec.calls.some((c) => c === 'tmux has-session -t ralph')).toBe(false)
+    expect(exec.calls.some((c) => c === 'tmux kill-session -t ralph')).toBe(false)
+  })
+
+  it('stops only the current project, leaving other projects untouched', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const otherSession = sessionNameFor('/other-project')
+    const workSession = sessionNameFor('/work')
+    const exec = makeExec({
+      [`tmux has-session -t ${workSession}`]: { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux kill-session -t ${workSession}`]: { exitCode: 0, stdout: '', stderr: '' },
+    })
+    const result = await stopCommand({ cwd: '/work', stdout, stderr, exec })
+    expect(result).toEqual({ exitCode: 0, killed: true })
+    expect(stdout.output()).toContain(`Sessão tmux '${workSession}' encerrada`)
+    // Never touches another project's session.
+    expect(exec.calls.some((c) => c.includes(otherSession))).toBe(false)
+  })
+
+  // --- QA: edge cases & adversarial scenarios -------------------------------
+
+  it('uses a valid, consistent session name for a cwd with spaces/parens', async () => {
+    const cwd = '/Users/x/my repo (1)'
+    const session = sessionNameFor(cwd)
+    // sessionNameFor must sanitize away spaces/parens so the name is a safe
+    // tmux target (no characters tmux would misinterpret).
+    expect(session).toMatch(/^[A-Za-z0-9_-]+$/)
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const exec = makeExec({
+      [`tmux has-session -t ${session}`]: { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux kill-session -t ${session}`]: { exitCode: 0, stdout: '', stderr: '' },
+    })
+    const result = await stopCommand({ cwd, stdout, stderr, exec })
+    expect(result).toEqual({ exitCode: 0, killed: true })
+    // Both calls target the identical derived name (no has/kill mismatch).
+    expect(exec.calls).toEqual([
+      `tmux has-session -t ${session}`,
+      `tmux kill-session -t ${session}`,
+    ])
+  })
+
+  it('uses the same derived name for has-session and kill-session within one call', async () => {
+    // Adversarial: a mismatch between the two would mean checking one session
+    // and killing another. Assert internal consistency by capturing the raw
+    // session targets passed to exec rather than precomputing them.
+    const cwd = '/some/deep/nested/project'
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const targets = []
+    const exec = async (cmd, args) => {
+      // args = ['has-session'|'kill-session', '-t', <session>]
+      targets.push({ sub: args[0], session: args[2] })
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    const result = await stopCommand({ cwd, stdout, stderr, exec })
+    expect(result).toEqual({ exitCode: 0, killed: true })
+    expect(targets).toHaveLength(2)
+    expect(targets[0].sub).toBe('has-session')
+    expect(targets[1].sub).toBe('kill-session')
+    expect(targets[0].session).toBe(targets[1].session)
+    expect(targets[0].session).toBe(sessionNameFor(cwd))
+  })
+
+  it('trailing-slash and clean cwd are internally consistent (each call self-consistent)', async () => {
+    // NOTE: in the current impl sessionNameFor('/repo') !== sessionNameFor('/repo/')
+    // because the hash is over the full (unnormalized) path. This test does not
+    // assert they are equal; it asserts each call uses ONE name consistently.
+    for (const cwd of ['/repo', '/repo/']) {
+      const session = sessionNameFor(cwd)
+      const stdout = makeStream()
+      const stderr = makeStream()
+      const exec = makeExec({
+        [`tmux has-session -t ${session}`]: { exitCode: 0, stdout: '', stderr: '' },
+        [`tmux kill-session -t ${session}`]: { exitCode: 0, stdout: '', stderr: '' },
+      })
+      const result = await stopCommand({ cwd, stdout, stderr, exec })
+      expect(result).toEqual({ exitCode: 0, killed: true })
+      expect(exec.calls).toEqual([
+        `tmux has-session -t ${session}`,
+        `tmux kill-session -t ${session}`,
+      ])
+    }
+  })
+
+  it('defaults cwd to process.cwd() when omitted', async () => {
+    const session = sessionNameFor(process.cwd())
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const exec = makeExec({
+      [`tmux has-session -t ${session}`]: { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux kill-session -t ${session}`]: { exitCode: 0, stdout: '', stderr: '' },
+    })
+    // cwd intentionally omitted -> should resolve via process.cwd().
+    const result = await stopCommand({ stdout, stderr, exec })
+    expect(result).toEqual({ exitCode: 0, killed: true })
+    expect(exec.calls).toContain(`tmux has-session -t ${session}`)
+    expect(exec.calls).toContain(`tmux kill-session -t ${session}`)
+  })
+
+  it('treats a non-zero, non-1 has-session exit (e.g. 127 / tmux missing) as no session', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const exec = makeExec({
+      [`tmux has-session -t ${SESSION}`]: {
+        exitCode: 127,
+        stdout: '',
+        stderr: 'tmux: command not found',
+      },
+      // Deliberately NO kill-session handler: makeExec throws on unexpected
+      // calls, so if stopCommand attempted a kill this test would error out.
+    })
+    const result = await stopCommand({ cwd: '/repo', stdout, stderr, exec })
+    expect(result).toEqual({ exitCode: 0, killed: false })
+    expect(exec.calls).toEqual([`tmux has-session -t ${SESSION}`])
+    expect(exec.calls.some((c) => c.startsWith('tmux kill-session'))).toBe(false)
+    expect(stdout.output()).toContain(`Nenhuma sessão tmux '${SESSION}'`)
+  })
+
+  it('StopAbort on kill failure carries exitCode 1 and reports the stderr', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const exec = makeExec({
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux kill-session -t ${SESSION}`]: {
+        exitCode: 1,
+        stdout: '',
+        stderr: '  permission denied  ',
+      },
+    })
+    let caught
+    try {
+      await stopCommand({ cwd: '/repo', stdout, stderr, exec })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(StopAbort)
+    expect(caught.exitCode).toBe(1)
+    // stderr surfaced to the user (trimmed).
+    expect(stderr.output()).toContain('permission denied')
+    expect(stderr.output()).toContain('Falha ao matar sessão tmux')
+    // No success message emitted.
+    expect(stdout.output()).not.toContain('encerrada')
+  })
+
+  it('does not emit a kill message when kill-session fails', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const exec = makeExec({
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux kill-session -t ${SESSION}`]: { exitCode: 2, stdout: '', stderr: '' },
+    })
+    await expect(
+      stopCommand({ cwd: '/repo', stdout, stderr, exec }),
+    ).rejects.toBeInstanceOf(StopAbort)
+    // Even with empty stderr, the failure message is still printed.
     expect(stderr.output()).toContain('Falha ao matar sessão tmux')
   })
 })


### PR DESCRIPTION
Closes #488

## Dev/TDD
- Tests added/modified: `packages/ralph/test/commands/stop.test.js`
- Before implementation (red): the 3 existing stop tests plus the new exec-spy/isolation tests failed with `unexpected exec: tmux has-session -t ralph` — `stopCommand` still targeted the literal `'ralph'` session instead of the cwd-derived per-project name.
- After implementation (green): all 520 tests pass (23 files). `stopCommand` now accepts `cwd = process.cwd()` and derives the session via `sessionNameFor(cwd)`; both `has-session` and `kill-session` target that name, and all output messages report the real derived name.

## QA scenarios added
Added 7 edge/adversarial tests in `packages/ralph/test/commands/stop.test.js`:
- Valid, consistent session name for a cwd with spaces/parens (sanitized, tmux-safe `^[A-Za-z0-9_-]+$`).
- Same derived name used for `has-session` and `kill-session` within one call (guards a check-one/kill-another mismatch).
- Trailing-slash vs clean cwd internal consistency.
- Defaults `cwd` to `process.cwd()` when omitted.
- Non-zero, non-1 `has-session` exit (127 / tmux missing) treated as "no session", never attempts kill.
- `StopAbort` on kill failure carries `exitCode 1` and surfaces stderr; no success message emitted.

## Review verdict
- APPROVE, no blocking findings. The change deletes the hardcoded `'ralph'` literal in favor of the shared `sessionNameFor(cwd)` helper (net complexity down), mirrors the established `start.js` per-project pattern exactly, keeps CLI wiring argless, and preserves the Portuguese user-facing strings.

## Docs updated
- `packages/ralph/README.md` — updated the `ralph stop` quick-reference line to "kill **this project's** tmux session", resolving an inconsistency where `start` was documented as per-project but `stop` read as a single hardcoded session.

## Notes
- Triage: Tier 1 / Standard (substantive behavioral change to the Ralph package). Heavy tier flag is off.
- `npm test` (ralph package): 520 passing. Root `npm run lint`: 0 errors (pre-existing warnings in `src/` only; `packages/**` is outside root lint scope by design).