### PR TITLE
feat: scope ralph cycle tmux guard to the current project

### DIFF
--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -7,6 +7,7 @@ import { sendWhatsappMessage } from '../utils/whatsapp.js'
 import {
   acquireLock as defaultAcquireLock,
   releaseLock as defaultReleaseLock,
+  sessionNameFor,
 } from '../lock.js'
 import {
   findOrphans as defaultFindOrphans,
@@ -18,7 +19,6 @@ import {
 } from '../healthcheck.js'
 import { templatePath } from '../paths.js'
 
-const TMUX_SESSION = 'ralph'
 const SEARCH_QUERY =
   'state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge'
 const CYCLE_EVENT_TAG = 'RALPH_CYCLE_EVENT'
@@ -59,7 +59,7 @@ export async function cycleCommand({
     out(`${CYCLE_EVENT_TAG} ${JSON.stringify(payload)}`)
   }
 
-  const tmux = await exec('tmux', ['has-session', '-t', TMUX_SESSION], { reject: false })
+  const tmux = await exec('tmux', ['has-session', '-t', sessionNameFor(root)], { reject: false })
   if (tmux.exitCode === 0) {
     emitEvent({ status: 'tmux-active', ok: 0, failed: 0, durationMin: 0, processed: 0 })
     return { exitCode: 0, status: 'tmux-active', processed: 0, skipped: true }

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { cycleCommand } from './cycle.js'
+import { sessionNameFor } from '../lock.js'
 
 const REPO = '/repo'
 const REPO_SLUG = 'lucasfe/agenthub'
+const SESSION = sessionNameFor(REPO)
 
 function makeStream() {
   const chunks = []
@@ -52,7 +54,7 @@ function makePing() {
 
 const baseHandlers = () => ({
   'git rev-parse --show-toplevel': { exitCode: 0, stdout: `${REPO}\n`, stderr: '' },
-  'tmux has-session -t ralph': { exitCode: 1, stdout: '', stderr: '' },
+  [`tmux has-session -t ${SESSION}`]: { exitCode: 1, stdout: '', stderr: '' },
   'gh auth status': { exitCode: 0, stdout: '', stderr: '' },
   'gh repo view --json nameWithOwner -q .nameWithOwner': {
     exitCode: 0,
@@ -92,11 +94,11 @@ const baseDeps = (overrides = {}) => {
 }
 
 describe('cycleCommand — tmux active', () => {
-  it('exits 0 silently when ralph tmux session is already running', async () => {
+  it('exits 0 silently when this project\'s tmux session is already running', async () => {
     const deps = baseDeps()
     deps.exec = makeExec({
       ...baseHandlers(),
-      'tmux has-session -t ralph': { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
     })
     const result = await cycleCommand(deps)
     expect(result).toEqual({
@@ -107,6 +109,132 @@ describe('cycleCommand — tmux active', () => {
     })
     expect(deps.sendWa.messages).toEqual([])
     expect(deps.exec.calls.some((c) => c.key.startsWith('gh auth status'))).toBe(false)
+  })
+
+  it('checks the per-project derived session name, not the literal "ralph"', async () => {
+    const deps = baseDeps()
+    await cycleCommand(deps)
+    expect(deps.exec.calls.some((c) => c.key === `tmux has-session -t ${SESSION}`)).toBe(true)
+    expect(deps.exec.calls.some((c) => c.key === 'tmux has-session -t ralph')).toBe(false)
+  })
+
+  it('does not skip when another project\'s session is active but this project\'s is not', async () => {
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      // Another project's interactive session is live...
+      'tmux has-session -t ralph-other-deadbeef': { exitCode: 0, stdout: '', stderr: '' },
+      // ...but this project's derived session is NOT.
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 1, stdout: '', stderr: '' },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.status).not.toBe('tmux-active')
+    expect(result.status).toBe('queue-empty')
+  })
+})
+
+describe('cycleCommand — tmux guard is keyed to the repo ROOT, not cwd', () => {
+  it('checks sessionNameFor(root) when cwd is a subdirectory and git resolves a different root', async () => {
+    // cwd is deep inside the repo; git rev-parse resolves the true repo root.
+    const SUBDIR = '/repo/packages/x'
+    const deps = baseDeps({ cwd: SUBDIR })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      // git rev-parse returns the repo root, NOT the cwd subdir.
+      'git rev-parse --show-toplevel': { exitCode: 0, stdout: `${REPO}\n`, stderr: '' },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    // The guard must check the root-derived name, not a cwd-derived one.
+    expect(deps.exec.calls.some((c) => c.key === `tmux has-session -t ${sessionNameFor(REPO)}`)).toBe(true)
+    expect(deps.exec.calls.some((c) => c.key === `tmux has-session -t ${sessionNameFor(SUBDIR)}`)).toBe(false)
+    // Sanity: the two derived names genuinely differ, so this is a real distinction.
+    expect(sessionNameFor(REPO)).not.toBe(sessionNameFor(SUBDIR))
+  })
+
+  it('skips only when the ROOT-derived session is active — a session keyed to the cwd subdir must NOT cause a skip', async () => {
+    const SUBDIR = '/repo/packages/x'
+    const deps = baseDeps({ cwd: SUBDIR })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'git rev-parse --show-toplevel': { exitCode: 0, stdout: `${REPO}\n`, stderr: '' },
+      // A session derived from the cwd subdir is live...
+      [`tmux has-session -t ${sessionNameFor(SUBDIR)}`]: { exitCode: 0, stdout: '', stderr: '' },
+      // ...but the root-derived session is NOT.
+      [`tmux has-session -t ${sessionNameFor(REPO)}`]: { exitCode: 1, stdout: '', stderr: '' },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.status).not.toBe('tmux-active')
+    expect(result.status).toBe('queue-empty')
+  })
+
+  it('uses a DIFFERENT session key for a different repo root and skips only when THAT key is active', async () => {
+    const OTHER = '/other/project'
+    const deps = baseDeps({ cwd: OTHER })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'git rev-parse --show-toplevel': { exitCode: 0, stdout: `${OTHER}\n`, stderr: '' },
+      // The OTHER project's own derived session is live → must skip.
+      [`tmux has-session -t ${sessionNameFor(OTHER)}`]: { exitCode: 0, stdout: '', stderr: '' },
+    })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('tmux-active')
+    expect(result.skipped).toBe(true)
+    // It must have queried the OTHER-derived name, never the default /repo one.
+    expect(deps.exec.calls.some((c) => c.key === `tmux has-session -t ${sessionNameFor(OTHER)}`)).toBe(true)
+    expect(deps.exec.calls.some((c) => c.key === `tmux has-session -t ${sessionNameFor(REPO)}`)).toBe(false)
+    expect(sessionNameFor(OTHER)).not.toBe(sessionNameFor(REPO))
+  })
+
+  it('trims trailing whitespace/newline from git output before deriving the session name', async () => {
+    // git rev-parse output is trimmed by resolveRepoRoot; the derived name must
+    // match sessionNameFor('/repo'), not sessionNameFor('/repo\n') or with stray spaces.
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'git rev-parse --show-toplevel': { exitCode: 0, stdout: `  ${REPO}  \n`, stderr: '' },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    expect(deps.exec.calls.some((c) => c.key === `tmux has-session -t ${sessionNameFor(REPO)}`)).toBe(true)
+  })
+
+  it('derives a sanitized session name when the repo root basename has special chars', async () => {
+    // basename with characters outside [A-Za-z0-9_-] must be sanitized to '-'.
+    const WEIRD = '/work/my repo.v2'
+    const deps = baseDeps({ cwd: WEIRD })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'git rev-parse --show-toplevel': { exitCode: 0, stdout: `${WEIRD}\n`, stderr: '' },
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    const expected = sessionNameFor(WEIRD)
+    // The sanitized name is what we expect a real tmux target to look like.
+    expect(expected).toBe('ralph-my-repo-v2-' + expected.slice(-8))
+    expect(deps.exec.calls.some((c) => c.key === `tmux has-session -t ${expected}`)).toBe(true)
   })
 })
 
@@ -458,7 +586,7 @@ describe('cycleCommand — RALPH_CYCLE_EVENT log line', () => {
     const deps = baseDeps()
     deps.exec = makeExec({
       ...baseHandlers(),
-      'tmux has-session -t ralph': { exitCode: 0, stdout: '', stderr: '' },
+      [`tmux has-session -t ${SESSION}`]: { exitCode: 0, stdout: '', stderr: '' },
     })
     await cycleCommand(deps)
     const event = readEvent(deps.stdout)


### PR DESCRIPTION
Closes #489

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/commands/cycle.test.js`
- Implementation: `packages/ralph/lib/commands/cycle.js`
- Before implementation (red): with the guard still reading the literal `ralph` session, 22 tests failed — the `exec`-spy test `checks the per-project derived session name, not the literal "ralph"` found `tmux has-session -t ralph` instead of `tmux has-session -t ralph-repo-816fc349`, and the cross-project test asserted `expected 'tmux-active' to be 'queue-empty'`.
- After implementation (green): all 527 ralph-package tests pass (23 files). Frontend suite also green (553 tests).

The fix: `cycle.js` now imports `sessionNameFor` from `../lock.js`, drops the unused `const TMUX_SESSION = 'ralph'`, and checks `sessionNameFor(root)` — matching how `ralph start`/`ralph stop` already derive per-project session names. A scheduled cycle now skips (status `tmux-active`) only when *this* project's interactive session is live.

## QA scenarios added
QA added 5 adversarial tests in `cycle.test.js` (describe block `tmux guard is keyed to the repo ROOT, not cwd`):
- Guard keys off the git-resolved `root`, not `cwd`, when cwd is a subdirectory.
- A session keyed to the cwd subdir does NOT cause a skip when the root-derived session is absent.
- A different repo root yields a different session key and skips only when THAT key is active.
- `git rev-parse` output is trimmed before deriving the name (whitespace/newline).
- Basename with special chars is sanitized (`my repo.v2` → `ralph-my-repo-v2-<hash>`).
All 5 pass; no defect found.

## Review verdict
APPROVE — no blocking findings. Reviewer confirmed `sessionNameFor(root)` is the correct anchor (the scheduled cycle agent runs with `cwd === root`, and cycle already anchors lock/preflight/queue on `root`), tests are behavior-focused and non-brittle, and the `TMUX_SESSION` constant is fully removed with no dangling references.

## Docs updated
- none — diff implied no doc change. No documentation described the `cycle` tmux guard or claimed a global `ralph` session; the only tmux-session docs concern `start`/`stop`, which already document per-project naming.

## Notes
Tier 1 / Standard run (full team: dev → QA → review → writer). Lint: 0 errors (26 pre-existing warnings in unrelated `src/` files).