### PR TITLE
fix: prevent ralph loop infinite spin on non-JSON claude output (#505)

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -346,7 +346,28 @@ release. The reminder is deduped via `last_seen_release` in
 **No issues are picked up.** — Check the queue filter Ralph uses:
 `state:open -label:claude-working -label:claude-failed -label:do-not-ralph`.
 Issues already labelled `claude-working` or `claude-failed` are
-skipped; clear those labels to retry.
+skipped; clear those labels to retry. Ralph applies `claude-failed`
+itself when Claude exits non-zero on an issue (auth/credit/rate-limit
+errors, crashes) without otherwise resolving it, so the queue keeps
+advancing instead of stalling on the same issue — see the per-issue log
+to find out why.
+
+**An iteration prints `claude falhou na issue #N (exit não-zero)`.** —
+Claude exited non-zero on that issue without opening a PR, closing it,
+or applying an exclusion label. Ralph adds the `claude-failed` label so
+the next iteration moves on. The cause (auth, credit balance,
+rate-limit, or a crash) is captured in `logs/ralph-issue-N.log`:
+Claude's stderr is now written there (and echoed to the terminal)
+rather than being merged into the JSON stream. Fix the underlying
+problem, clear the `claude-failed` label, and re-run.
+
+**The loop aborts with `sem progresso na issue #N`.** — A zero-progress
+guard fired: the same issue was re-selected on consecutive iterations
+with no change to its exclusion state (no PR, not closed, no label),
+which means the loop could never drain the queue. Rather than burn API
+calls spinning forever, Ralph records the issue as a failure and stops.
+Inspect `logs/ralph-issue-N.log` for the root cause, resolve or label
+the issue (`claude-failed`, `do-not-ralph`), then start Ralph again.
 
 ## Links
 

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -49,6 +49,52 @@ fi
 
 mkdir -p logs
 
+# --- Claude streaming helper -------------------------------------------------
+# Pretty-prints claude's stream-json stdout via jq into a log file, while
+# keeping claude's stderr OUT of the JSON pipe. Non-JSON stderr lines (auth,
+# credit, rate-limit errors, warnings) are tee'd to the terminal + log instead
+# of being fed to jq (which would fail with "Invalid numeric literal"). jq uses
+# `fromjson?` so any stray non-JSON line on stdout is skipped, not fatal.
+#
+# Args: $1 = prompt-builder script path, $2 = log file path.
+# Sets the global `claude_failed` to "1" when claude exits non-zero, else "0".
+JQ_STREAM_FILTER='fromjson? // empty
+  | if .type == "assistant" then
+      (.message.content[]? | select(.type=="text").text // empty)
+    elif .type == "user" then
+      (.message.content[]? | select(.type=="tool_result") | "  ↳ tool_result")
+    elif .type == "result" then
+      "==> result: " + (.subtype // "ok")
+    else empty end'
+
+run_claude_stream() {
+  prompt_script="$1"
+  log_file="$2"
+  # Truncate the unique per-issue log ONCE up front, then have BOTH the stderr
+  # tee and the stdout tee APPEND. This removes a truncate-vs-append race: if
+  # the stdout `tee` opened with O_TRUNC while the stderr `tee -a` was already
+  # writing, the leading bytes of a stderr line (e.g. a failure signal) could
+  # be clobbered, producing the empty/lost failure log this guards against.
+  : > "$log_file"
+  node "$prompt_script" \
+    | claude -p --dangerously-skip-permissions \
+        --output-format stream-json --verbose --include-partial-messages \
+        2> >(tee -a "$log_file" >&2) \
+    | jq -rR --unbuffered "$JQ_STREAM_FILTER" \
+    | tee -a "$log_file"
+  # PIPESTATUS[1] is claude's exit code (node|claude|jq|tee).
+  if [ "${PIPESTATUS[1]}" -ne 0 ]; then
+    claude_failed=1
+  else
+    claude_failed=0
+  fi
+}
+
+run_claude_for_issue() {
+  run_claude_stream "$RALPH_PKG_DIR/lib/build-prompt.js" "logs/ralph-issue-$1.log"
+}
+# ---------------------------------------------------------------------------
+
 # --- Lazy config validation -------------------------------------------------
 # Run a one-shot Claude validation before the main loop when:
 #   • .ralph/state.json is absent, OR
@@ -81,17 +127,8 @@ if [ -f ralph.config.sh ]; then
 
   if [ "$needs_validate" = "yes" ]; then
     echo "==> Validando ralph.config.sh contra os manifestos do projeto..."
-    node "$RALPH_PKG_DIR/lib/build-validate-prompt.js" | claude -p --dangerously-skip-permissions \
-      --output-format stream-json --verbose --include-partial-messages 2>&1 \
-      | jq -r --unbuffered '
-          if .type == "assistant" then
-            (.message.content[]? | select(.type=="text").text // empty)
-          elif .type == "user" then
-            (.message.content[]? | select(.type=="tool_result") | "  ↳ tool_result")
-          elif .type == "result" then
-            "==> result: " + (.subtype // "ok")
-          else empty end' \
-      | tee "logs/ralph-validate.log"
+    claude_failed=0
+    run_claude_stream "$RALPH_PKG_DIR/lib/build-validate-prompt.js" "logs/ralph-validate.log"
 
     if [ ! -f .ralph/state.json ]; then
       echo "❌ Validação não produziu .ralph/state.json. Abortando." >&2
@@ -115,8 +152,15 @@ fi
 START=$(date +%s)
 successes=()
 failures=()
+claude_failed=0
 
 SEARCH_QUERY='state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge'
+
+# Track the previously-selected issue so we can detect a zero-progress spin:
+# if the same issue is re-selected without any exclusion-state changing
+# (claude crashed, no label applied, not closed), the queue can never drain
+# and the loop would burn API calls forever. We break out instead.
+prev_num=""
 
 while :; do
   count=$(gh issue list --search "$SEARCH_QUERY" --limit 100 --json number -q '. | length')
@@ -128,17 +172,12 @@ while :; do
   num=$(gh issue list --search "$SEARCH_QUERY sort:created-asc" --limit 1 --json number -q '.[0].number')
   echo "==> Iteração para issue #$num ($count restantes)"
 
-  node "$RALPH_PKG_DIR/lib/build-prompt.js" | claude -p --dangerously-skip-permissions \
-    --output-format stream-json --verbose --include-partial-messages 2>&1 \
-    | jq -r --unbuffered '
-        if .type == "assistant" then
-          (.message.content[]? | select(.type=="text").text // empty)
-        elif .type == "user" then
-          (.message.content[]? | select(.type=="tool_result") | "  ↳ tool_result")
-        elif .type == "result" then
-          "==> result: " + (.subtype // "ok")
-        else empty end' \
-    | tee "logs/ralph-issue-$num.log"
+  # Stream claude's JSON to jq, but keep stderr OUT of the JSON pipe: any
+  # non-JSON line claude prints to stderr (auth/credit/rate-limit errors,
+  # warnings) used to be merged via `2>&1` and broke jq with "Invalid numeric
+  # literal". Route stderr to the per-issue log + terminal instead. jq is also
+  # made tolerant of stray non-JSON input as defense-in-depth.
+  run_claude_for_issue "$num"
 
   labels=$(gh issue view "$num" --json labels -q '[.labels[].name] | join(",")')
   state=$(gh issue view "$num" --json state -q '.state')
@@ -147,8 +186,25 @@ while :; do
   elif [ "$state" = "CLOSED" ] || echo ",$labels," | grep -q ",pending-merge,"; then
     successes+=("$num")
   else
+    # No exclusion label and still open. If claude failed (non-zero exit) mark
+    # the issue claude-failed so the queue advances on the next iteration.
+    if [ "$claude_failed" = "1" ]; then
+      echo "⚠️  claude falhou na issue #$num (exit não-zero). Marcando claude-failed." >&2
+      gh issue edit "$num" --add-label claude-failed >/dev/null 2>&1 || true
+    fi
+
+    # Zero-progress guard: if we just re-selected the SAME issue we worked on
+    # last iteration and it still has no exclusion state, no progress was made.
+    # Record it as a failure and abort rather than spinning forever.
+    if [ "$num" = "$prev_num" ]; then
+      echo "❌ ralph.sh: sem progresso na issue #$num (re-selecionada sem mudar de estado). Abortando o loop." >&2
+      failures+=("$num")
+      break
+    fi
     failures+=("$num")
   fi
+
+  prev_num="$num"
 done
 
 echo "==> Cleanup"

--- a/packages/ralph/test/loop.adversarial.test.js
+++ b/packages/ralph/test/loop.adversarial.test.js
@@ -1,0 +1,485 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  chmodSync,
+  existsSync,
+  readFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { templatePath } from '../lib/paths.js'
+
+const RALPH_TEMPLATE = templatePath('ralph.sh')
+
+// Adversarial / edge-case companions to test/loop.test.js. These reuse the same
+// stub-on-PATH harness but exercise the corners of the issue #505 fix that the
+// dev's happy-path tests don't reach:
+//   - jq `fromjson? // empty` tolerance for stray non-JSON on STDOUT
+//   - queue draining through a transient claude failure (claude-failed advances)
+//   - the zero-progress guard only firing on CONSECUTIVE identical re-selection
+//   - claude's stderr landing in the per-issue log (no empty-log signal loss)
+//   - PIPESTATUS[1] reflecting claude's exit, not the tail of the pipe
+//   - --once mode exiting 0
+//   - empty queue / count="0" immediate exit
+
+let workdir
+let bindir
+
+function writeStub(name, body) {
+  const p = join(bindir, name)
+  writeFileSync(p, body, { mode: 0o755 })
+  chmodSync(p, 0o755)
+}
+
+// A FAITHFUL jq stub (PURE BASH — must not depend on the stubbed \`node\`) that
+// emulates the real \`jq -rR 'fromjson? // empty | ...'\` contract: each input
+// line is parsed; non-JSON lines are silently dropped (fromjson? // empty),
+// valid JSON lines are summarized. It NEVER errors on non-JSON input — that is
+// precisely the tolerance the fix relies on. This lets us prove the FILTER
+// design swallows stray stdout noise instead of dying. Recognition is by simple
+// substring matching (sufficient for the fixed stream-json the tests emit).
+// Non-streaming jq uses (@uri, .labels, .state) are handled elsewhere/no-op'd.
+const FAITHFUL_JQ = `#!/bin/bash
+is_stream=0
+for a in "$@"; do
+  case "$a" in
+    *".type =="*) is_stream=1 ;;
+  esac
+done
+if [ "$is_stream" -ne 1 ]; then
+  cat > /dev/null 2>/dev/null || true
+  exit 0
+fi
+while IFS= read -r line; do
+  case "$line" in
+    *'"type":"result"'*)
+      sub="ok"
+      case "$line" in
+        *'"subtype":"'*'"'*)
+          sub="\${line#*\\"subtype\\":\\"}"
+          sub="\${sub%%\\"*}"
+          ;;
+      esac
+      echo "==> result: $sub"
+      ;;
+    *'"type":"assistant"'*'"text":"'*)
+      txt="\${line#*\\"text\\":\\"}"
+      txt="\${txt%%\\"*}"
+      echo "$txt"
+      ;;
+    *) : ;;  # fromjson? // empty -> drop stray non-JSON, never fatal
+  esac
+done
+exit 0
+`
+
+function runLoop({ timeout = 15000, extraEnv = {}, args = [] } = {}) {
+  const env = {
+    ...process.env,
+    PATH: `${bindir}:${process.env.PATH}`,
+    RALPH_TMUX_SESSION: 'ralph-test',
+    CALLMEBOT_KEY: '',
+    WHATSAPP_PHONE: '',
+    ...extraEnv,
+  }
+  return spawnSync('bash', [RALPH_TEMPLATE, ...args], {
+    cwd: workdir,
+    env,
+    timeout,
+    encoding: 'utf8',
+  })
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'ralph-adv-'))
+  bindir = join(workdir, 'bin')
+  mkdirSync(bindir, { recursive: true })
+  mkdirSync(join(workdir, 'logs'), { recursive: true })
+  mkdirSync(join(workdir, '.ralph'), { recursive: true })
+  writeFileSync(join(workdir, '.ralph', 'state.json'), '{}')
+
+  writeStub(
+    'git',
+    `#!/bin/bash
+if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then
+  echo "${workdir}"
+  exit 0
+fi
+exit 0
+`
+  )
+
+  writeStub(
+    'node',
+    `#!/bin/bash
+echo "PROMPT"
+exit 0
+`
+  )
+
+  // tmux/curl no-ops.
+  writeStub('tmux', `#!/bin/bash\nexit 0\n`)
+  writeStub('curl', `#!/bin/bash\nexit 0\n`)
+
+  // Default to the faithful jq; individual tests can override.
+  writeStub('jq', FAITHFUL_JQ)
+})
+
+afterEach(() => {
+  if (workdir && existsSync(workdir)) {
+    rmSync(workdir, { recursive: true, force: true })
+  }
+})
+
+describe('ralph.sh main loop — adversarial / edge cases (#505 fix)', () => {
+  it('tolerates stray NON-JSON on claude STDOUT (fromjson? // empty) and still drains', () => {
+    // claude prints a stray non-JSON banner line on STDOUT, interleaved with
+    // real stream-json. Real jq -rR with `fromjson?` must skip the bad line,
+    // not abort with a parse error. We use the FAITHFUL jq stub so this test
+    // validates the FILTER design, not a permissive stub.
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+echo "Warning: deprecated flag --foo (this is NOT json)"   # stray stdout noise
+echo '{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}'
+echo 'not json either {{{'
+echo '{"type":"result","subtype":"success"}'
+exit 0
+`
+    )
+    writeFileSync(join(workdir, 'count.txt'), '2')
+    writeStub(
+      'gh',
+      `#!/bin/bash
+CNT_FILE="${join(workdir, 'count.txt')}"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  cnt=$(cat "$CNT_FILE")
+  case "$*" in
+    *sort:created-asc*)
+      echo "$cnt"
+      echo "$((cnt - 1))" > "$CNT_FILE"
+      ;;
+    *) echo "$cnt" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *labels*) echo "" ;;
+    *state*)  echo "CLOSED" ;;
+    *)        echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+    )
+
+    const res = runLoop()
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+    // No jq parse error must surface anywhere.
+    expect(`${res.stdout}\n${res.stderr}`).not.toMatch(/parse error|Invalid numeric literal/i)
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
+    // The valid JSON was still summarized through the tolerant filter.
+    expect(res.stdout).toContain('==> result: success')
+  })
+
+  it('drains the queue THROUGH a transient claude failure (claude-failed advances the queue)', () => {
+    // First selected issue (#50) fails: claude exits non-zero, no label yet.
+    // The loop must apply claude-failed; the gh stub then DROPS #50 from the
+    // search so the next iteration selects a DIFFERENT issue (#51), which
+    // succeeds. The queue drains; the guard must NOT break on the transient.
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+NUM=$(cat "${join(workdir, 'current.txt')}" 2>/dev/null || echo "")
+if [ "$NUM" = "50" ]; then
+  echo "Credit balance too low" >&2
+  exit 1
+fi
+echo '{"type":"result","subtype":"success"}'
+exit 0
+`
+    )
+    // gh: returns #50 first; once #50 is labeled claude-failed, search returns
+    // #51, then empties. View reports the labels we recorded via edit.
+    writeFileSync(join(workdir, 'failed50.txt'), '')
+    writeStub(
+      'gh',
+      `#!/bin/bash
+FAILED="${join(workdir, 'failed50.txt')}"
+CUR="${join(workdir, 'current.txt')}"
+SEL="${join(workdir, 'selected.log')}"
+if [ "$1" = "issue" ] && [ "$2" = "edit" ]; then
+  # record claude-failed on the issue number ($3)
+  echo "$3" >> "$FAILED"
+  exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  if grep -q "50" "$FAILED" 2>/dev/null; then
+    if [ -f "${join(workdir, 'done51.txt')}" ]; then
+      n=0
+    else
+      n=51
+    fi
+  else
+    n=50
+  fi
+  case "$*" in
+    *sort:created-asc*)
+      echo "$n" >> "$SEL"
+      echo "$n" > "$CUR"
+      echo "$n"
+      [ "$n" = "51" ] && touch "${join(workdir, 'done51.txt')}"
+      ;;
+    *)
+      [ "$n" = "0" ] && echo "0" || echo "1"
+      ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  num=$(cat "$CUR")
+  case "$*" in
+    *labels*)
+      if [ "$num" = "50" ] && grep -q "50" "$FAILED" 2>/dev/null; then
+        echo "claude-failed"
+      else
+        echo ""
+      fi
+      ;;
+    *state*)
+      if [ "$num" = "51" ]; then echo "CLOSED"; else echo "OPEN"; fi
+      ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+    )
+
+    const res = runLoop()
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+    // Queue must have advanced to a DIFFERENT issue, not broken on the guard.
+    const selected = readFileSync(join(workdir, 'selected.log'), 'utf8').trim().split('\n')
+    expect(selected).toContain('50')
+    expect(selected).toContain('51')
+    // No zero-progress abort message — the queue drained normally.
+    expect(res.stderr).not.toMatch(/sem progresso/)
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
+    // #50 ends a failure, #51 a success.
+    expect(res.stdout).toMatch(/1 ok, 1 falharam|1 ok/)
+  })
+
+  it('guard fires ONLY on consecutive identical re-selection (A, B, A does not trigger)', () => {
+    // Selection sequence: 70, 71, 70, then empty. None of these are
+    // *consecutive* duplicates, so prev_num never equals num and the
+    // zero-progress guard must never fire. claude succeeds each time but the
+    // issues stay OPEN+unlabeled (so they're counted failures, not successes) —
+    // the point is purely that the loop drains by sequence, not by guard-break.
+    writeFileSync(join(workdir, 'seq.idx'), '0')
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+echo '{"type":"result","subtype":"success"}'
+exit 0
+`
+    )
+    writeStub(
+      'gh',
+      `#!/bin/bash
+IDX="${join(workdir, 'seq.idx')}"
+SEL="${join(workdir, 'selected.log')}"
+SEQ=(70 71 70)
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  i=$(cat "$IDX")
+  case "$*" in
+    *sort:created-asc*)
+      n="\${SEQ[$i]}"
+      echo "$n" >> "$SEL"
+      echo "$n"
+      echo "$((i + 1))" > "$IDX"
+      ;;
+    *)
+      if [ "$i" -ge "\${#SEQ[@]}" ]; then echo "0"; else echo "1"; fi
+      ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *labels*) echo "" ;;
+    *state*)  echo "OPEN" ;;
+    *)        echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+    )
+
+    const res = runLoop()
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+    const selected = readFileSync(join(workdir, 'selected.log'), 'utf8').trim().split('\n')
+    expect(selected).toEqual(['70', '71', '70'])
+    // Guard must NOT have fired — no abort message.
+    expect(res.stderr).not.toMatch(/sem progresso/)
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
+  })
+
+  it("writes claude's stderr line to the per-issue log (no empty-log signal loss)", () => {
+    // The issue called out empty logs. claude writes an auth error to STDERR.
+    // The fix routes stderr to `tee -a "$log_file" >&2`, so the error must land
+    // in logs/ralph-issue-<N>.log. Use the FAILING-on-non-json behavior plus
+    // the zero-progress single-issue setup so the loop terminates via the guard.
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+echo "Credit balance too low (auth error)" >&2
+exit 1
+`
+    )
+    writeStub(
+      'gh',
+      `#!/bin/bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  case "$*" in
+    *sort:created-asc*) echo "98"; exit 0 ;;
+    *) echo "1"; exit 0 ;;
+  esac
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *labels*) echo "" ;;
+    *state*)  echo "OPEN" ;;
+    *)        echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+    )
+
+    const res = runLoop()
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    const logPath = join(workdir, 'logs', 'ralph-issue-98.log')
+    expect(existsSync(logPath), `expected per-issue log at ${logPath}`).toBe(true)
+    const logContents = readFileSync(logPath, 'utf8')
+    // The stderr error line must reach the per-issue log IN FULL (the issue's
+    // core complaint was an EMPTY/lost log on failure). The truncate-vs-append
+    // race is now fixed: the log is truncated ONCE up front and both tees only
+    // append, so no writer can clobber another's leading bytes. Assert the
+    // COMPLETE stderr line to guard that no-clobber property.
+    expect(logContents).toMatch(/Credit balance too low \(auth error\)/)
+  })
+
+  it('sets claude_failed from claude exit (PIPESTATUS[1]) even when jq+tee succeed', () => {
+    // claude exits non-zero but emits VALID json that jq/tee process fine
+    // (so the tail of the pipe is success). The fix reads PIPESTATUS[1]
+    // (claude), so claude_failed must be 1 -> the loop applies claude-failed.
+    // Observable consequence: `gh issue edit --add-label claude-failed` is
+    // called for the issue.
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+echo '{"type":"result","subtype":"error_during_execution"}'
+exit 1
+`
+    )
+    writeStub(
+      'gh',
+      `#!/bin/bash
+EDIT="${join(workdir, 'edits.log')}"
+if [ "$1" = "issue" ] && [ "$2" = "edit" ]; then
+  echo "$*" >> "$EDIT"
+  exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  case "$*" in
+    *sort:created-asc*) echo "98"; exit 0 ;;
+    *) echo "1"; exit 0 ;;
+  esac
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *labels*) echo "" ;;
+    *state*)  echo "OPEN" ;;
+    *)        echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+    )
+
+    const res = runLoop()
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    const edits = existsSync(join(workdir, 'edits.log'))
+      ? readFileSync(join(workdir, 'edits.log'), 'utf8')
+      : ''
+    expect(edits, 'claude_failed must have triggered an --add-label claude-failed edit').toMatch(
+      /--add-label claude-failed/
+    )
+  })
+
+  it('empty queue: exits cleanly with 0 ok / 0 failed when count is "0" immediately', () => {
+    writeStub(
+      'gh',
+      `#!/bin/bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  echo "0"   # length 0 on the count query; loop breaks before selecting
+  exit 0
+fi
+exit 0
+`
+    )
+    const res = runLoop()
+    expect(res.signal).toBeNull()
+    expect(res.status).toBe(0)
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
+    expect(res.stdout).toMatch(/0 ok, 0 falharam|0 ok/)
+  })
+
+  it('--once mode exits 0 and skips end-of-run notify/tmux teardown', () => {
+    writeStub(
+      'gh',
+      `#!/bin/bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  echo "0"
+  exit 0
+fi
+exit 0
+`
+    )
+    // tmux stub records any kill-session call so we can assert it's skipped.
+    writeStub(
+      'tmux',
+      `#!/bin/bash
+echo "$*" >> "${join(workdir, 'tmux.log')}"
+exit 0
+`
+    )
+    const res = runLoop({ args: ['--once'] })
+    expect(res.signal).toBeNull()
+    expect(res.status).toBe(0)
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
+    // --once must exit before the tmux kill-session teardown.
+    const tmuxLog = existsSync(join(workdir, 'tmux.log'))
+      ? readFileSync(join(workdir, 'tmux.log'), 'utf8')
+      : ''
+    expect(tmuxLog).not.toMatch(/kill-session/)
+  })
+})

--- a/packages/ralph/test/loop.test.js
+++ b/packages/ralph/test/loop.test.js
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { templatePath } from '../lib/paths.js'
+
+const RALPH_TEMPLATE = templatePath('ralph.sh')
+
+// These integration tests execute templates/ralph.sh's main loop against
+// stubbed external commands (git, gh, claude, jq, node) placed on a PATH we
+// prepend. They reproduce issue #505: the loop spinning forever on a single
+// issue when `claude -p` emits non-JSON and the issue never gets an exclusion
+// label. The fix must guarantee forward progress (a zero-progress guard).
+
+let workdir
+let bindir
+
+function writeStub(name, body) {
+  const p = join(bindir, name)
+  writeFileSync(p, body, { mode: 0o755 })
+  chmodSync(p, 0o755)
+}
+
+function runLoop({ timeout = 15000 } = {}) {
+  // Prepend our stub bin to PATH; keep the real bash + coreutils available.
+  const env = {
+    ...process.env,
+    PATH: `${bindir}:${process.env.PATH}`,
+    RALPH_TMUX_SESSION: 'ralph-test',
+    // Ensure no real notifications fire.
+    CALLMEBOT_KEY: '',
+    WHATSAPP_PHONE: '',
+  }
+  return spawnSync('bash', [RALPH_TEMPLATE], {
+    cwd: workdir,
+    env,
+    timeout,
+    encoding: 'utf8',
+  })
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'ralph-loop-'))
+  bindir = join(workdir, 'bin')
+  mkdirSync(bindir, { recursive: true })
+  mkdirSync(join(workdir, 'logs'), { recursive: true })
+  // Pre-seed .ralph/state.json so the lazy-validation block is bypassed.
+  // (Validation only runs when ralph.config.sh exists; we don't create it,
+  // so the whole block is skipped and the test isolates the main loop.)
+  mkdirSync(join(workdir, '.ralph'), { recursive: true })
+  writeFileSync(join(workdir, '.ralph', 'state.json'), '{}')
+
+  // --- git stub: answer rev-parse --show-toplevel with our workdir, and
+  // no-op everything else (checkout/pull/branch in cleanup). -----------------
+  writeStub(
+    'git',
+    `#!/bin/bash
+if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then
+  echo "${workdir}"
+  exit 0
+fi
+exit 0
+`
+  )
+
+  // --- node stub: the script calls \`node -p require(...).version\` only when
+  // ralph.config.sh exists (it doesn't here), and \`node .../build-prompt.js\`
+  // inside the loop. The build-prompt invocation just needs to emit *some*
+  // prompt text on stdout that the claude stub will read. ---------------------
+  writeStub(
+    'node',
+    `#!/bin/bash
+# build-prompt.js / build-validate-prompt.js -> emit a dummy prompt.
+echo "PROMPT"
+exit 0
+`
+  )
+
+  // --- claude stub: simulate the failure mode — print a NON-JSON line to
+  // stderr (an auth/credit error) and exit non-zero, emitting nothing to
+  // stdout. This is exactly what triggers the jq parse error when stderr is
+  // merged via 2>&1. ----------------------------------------------------------
+  writeStub(
+    'claude',
+    `#!/bin/bash
+cat > /dev/null   # drain the piped prompt
+echo "Credit balance too low (auth error)" >&2
+exit 1
+`
+  )
+
+  // --- jq stub: behave like a minimal real jq for the queries the loop uses,
+  // but FAIL loudly on the streaming filter if it ever receives the non-JSON
+  // claude stderr (mirrors real jq's "Invalid numeric literal"). We don't
+  // implement full jq; we recognize the specific invocations. ----------------
+  writeStub(
+    'jq',
+    `#!/bin/bash
+# Detect the streaming pretty-print filter used on claude output.
+for a in "$@"; do
+  case "$a" in
+    *".type == \\"assistant\\""*)
+      # Read stdin; if any line isn't JSON, emulate jq's parse error + nonzero.
+      while IFS= read -r line; do
+        case "$line" in
+          '{'*) : ;;        # looks like JSON, ignore
+          '') : ;;
+          *)
+            echo "jq: parse error: Invalid numeric literal at line 1, column 6" >&2
+            exit 5
+            ;;
+        esac
+      done
+      exit 0
+      ;;
+  esac
+done
+# Fallback for other jq uses (e.g. @uri encoding in notifications): no-op.
+cat > /dev/null 2>/dev/null || true
+exit 0
+`
+  )
+
+  // --- gh stub: always report 8 open issues, and always select #98 (the
+  // sort:created-asc query). \`gh issue view\` reports the issue as OPEN with no
+  // labels — i.e. claude never managed to label it claude-failed / close it.
+  // This is precisely the zero-progress condition that makes the loop respin.
+  // Append to a marker file so the test can prove the SAME issue was selected
+  // repeatedly before any guard fires. ---------------------------------------
+  writeStub(
+    'gh',
+    `#!/bin/bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  case "$*" in
+    *sort:created-asc*)
+      echo "98" >> "${join(workdir, 'selected.log')}"
+      echo "98"
+      exit 0
+      ;;
+    *)
+      echo "8"   # count of open issues — never drops
+      exit 0
+      ;;
+  esac
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *labels*) echo "" ;;        # no labels
+    *state*)  echo "OPEN" ;;    # still open
+    *)        echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+  )
+
+  // tmux/curl stubs so cleanup/notify paths never touch the real system.
+  writeStub('tmux', `#!/bin/bash\nexit 0\n`)
+  writeStub('curl', `#!/bin/bash\nexit 0\n`)
+})
+
+afterEach(() => {
+  if (workdir && existsSync(workdir)) {
+    rmSync(workdir, { recursive: true, force: true })
+  }
+})
+
+describe('ralph.sh main loop — issue #505 (no infinite spin)', () => {
+  it('does not spin forever when claude fails and the issue is never excluded', () => {
+    const res = runLoop({ timeout: 15000 })
+
+    // The decisive assertion: the process must EXIT ON ITS OWN, not be killed
+    // by the timeout. spawnSync sets res.signal === 'SIGTERM' (and error.code
+    // 'ETIMEDOUT') when it hard-kills a process that overran the timeout.
+    expect(res.signal, `loop was killed by timeout — it spun forever. stdout:\n${res.stdout}`).toBeNull()
+
+    // Prove the SAME issue was selected more than once before the guard fired
+    // (i.e. the loop genuinely iterated on #98), but a bounded number of times
+    // — not thousands — so we know the guard broke the spin.
+    const selected = existsSync(join(workdir, 'selected.log'))
+      ? readFileSync(join(workdir, 'selected.log'), 'utf8').trim().split('\n')
+      : []
+    // The guard fires only on re-selection (num === prev_num), so #98 must be
+    // selected at least twice before the loop breaks.
+    expect(selected.length).toBeGreaterThanOrEqual(2)
+    // Bounded: the guard must stop re-selecting after a few iterations.
+    expect(selected.length).toBeLessThanOrEqual(5)
+    expect(selected.every((n) => n === '98')).toBe(true)
+  })
+
+  it('happy path: drains the queue and exits cleanly when issues get resolved', () => {
+    // gh stub: count counts down from a counter file; each iteration the
+    // selected issue is "closed" (count decremented) so the queue empties and
+    // the loop terminates normally. claude exits 0 with valid JSON.
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+echo '{"type":"result","subtype":"success"}'
+exit 0
+`
+    )
+    // 3 issues; each list call returns the current count, sort:created-asc
+    // returns a unique number, and viewing reports CLOSED (success).
+    writeFileSync(join(workdir, 'count.txt'), '3')
+    writeStub(
+      'gh',
+      `#!/bin/bash
+CNT_FILE="${join(workdir, 'count.txt')}"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  cnt=$(cat "$CNT_FILE")
+  case "$*" in
+    *sort:created-asc*)
+      echo "$cnt"      # use the count as the issue number (unique each time)
+      echo "$((cnt - 1))" > "$CNT_FILE"   # simulate it getting resolved
+      ;;
+    *)
+      echo "$cnt"
+      ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *labels*) echo "" ;;
+    *state*)  echo "CLOSED" ;;
+    *)        echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+    )
+
+    const res = runLoop({ timeout: 15000 })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
+    // All resolved -> reported as successes, none failed.
+    expect(res.stdout).toMatch(/3 ok, 0 falharam|Ralph finalizado: 3 ok/)
+  })
+})


### PR DESCRIPTION
Closes #505

## Dev/TDD
- Tests added/modified: `packages/ralph/test/loop.test.js` (new), `packages/ralph/test/loop.adversarial.test.js` (new)
- Before implementation (red): `ralph.sh main loop — issue #505 (no infinite spin) > does not spin forever when claude fails and the issue is never excluded` — the loop spun forever (`==> Iteração para issue #98` repeated, count never dropped, process never exited), proven via a `selected.log` marker showing #98 re-selected every iteration. `spawnSync` had to hard-kill it at the timeout (`expected 'SIGTERM' to be null`).
- After implementation (green): all 536 tests pass (25 files).

Root cause & fix in `packages/ralph/templates/ralph.sh`:
1. **`2>&1` merged stderr into the jq pipe** → any non-JSON line claude prints (auth/credit/rate-limit) broke jq with `Invalid numeric literal`. New `run_claude_stream()` helper routes claude's stderr to the per-issue log + terminal (`2> >(tee -a ...)`) instead of into jq, and makes jq tolerant (`jq -rR 'fromjson? // empty'`). Applied to both the validation block and the main loop (dedup'd the antipattern).
2. **No progress guarantee** → a crashed claude left the issue unlabeled, so the next `sort:created-asc` query re-selected it forever. Added: capture claude's exit via `PIPESTATUS[1]` and apply `claude-failed` so the queue advances; plus a zero-progress guard tracking `prev_num` that breaks the loop with a clear error if the same issue is re-selected with no state change.
3. Log-write race fix: truncate the unique per-issue log once up front, then both writers append (no truncate-vs-append clobber).

## QA scenarios added
Added `packages/ralph/test/loop.adversarial.test.js` (+7 tests):
- Stray non-JSON on claude **stdout** is swallowed by `fromjson? // empty` (faithful jq stub) — queue still drains, no parse error.
- Queue drains **through** a transient claude failure — failed issue gets `claude-failed`, next iteration selects a different issue.
- Zero-progress guard fires **only on consecutive** identical re-selection (A, B, A does not false-trigger).
- claude's stderr error line lands in `logs/ralph-issue-N.log` (no more empty failure log).
- `claude_failed` is set from claude's exit (`PIPESTATUS[1]`) even when jq+tee succeed.
- Empty queue exits cleanly; `--once` mode exits 0 and skips tmux teardown.

## Review verdict
Approved (round 2). Reviewer initially BLOCKED on one real correctness finding — a concurrent same-file `tee` race (stderr append vs stdout truncate) in the exact failure-log path #505 protects. Fixed by truncating the unique per-issue log once (`: > "$log_file"`) and making both tees append; the QA assertion was tightened from an interior substring to the full stderr line to guard the no-clobber property. Re-review confirmed resolved.

## Docs updated
- `packages/ralph/README.md` — Troubleshooting section: documented that Ralph now self-applies `claude-failed` on a non-zero claude exit, that claude's stderr is written to the per-issue log, and the new `sem progresso na issue #N` zero-progress abort. (CHANGELOG left untouched — release-please auto-generated.)

## Notes
- Change is confined to the separately-versioned `@lucasfe/ralph` package; this issue is explicitly about that package. Root `npm run lint` does not cover `packages/**` (and doesn't lint bash); ralph suite is green at 536 tests.
- Non-blocking FYI: `bash -n` syntax-checked; `2> >(...)` and `PIPESTATUS` are bash-isms — template is `#!/bin/bash`, bash-only.