### PR TITLE
feat(ralph): per-issue event capture to issues.jsonl (minimal end-to-end)

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -53,7 +53,10 @@ a per-project tmux session named `ralph-<repo>-<hash>` (derived from the
 project path, so multiple repos can run Ralph concurrently without
 colliding). The exact attach / kill commands for your session are
 printed by `ralph start`; detach with `Ctrl+B` then `D`, or tail
-per-issue logs in `logs/ralph-issue-*.log`.
+per-issue logs in `logs/ralph-issue-*.log`. Each iteration also tees
+Claude's raw stream-json to `logs/ralph-issue-*.jsonl` and appends one
+telemetry event line to `.ralph/metrics/issues.jsonl` (see
+[Per-issue telemetry](#per-issue-telemetry)).
 
 ## How Ralph resolves issues
 
@@ -368,6 +371,34 @@ which means the loop could never drain the queue. Rather than burn API
 calls spinning forever, Ralph records the issue as a failure and stops.
 Inspect `logs/ralph-issue-N.log` for the root cause, resolve or label
 the issue (`claude-failed`, `do-not-ralph`), then start Ralph again.
+
+## Per-issue telemetry
+
+After each issue iteration — regardless of outcome — Ralph records two
+artifacts under the project root:
+
+| Path | Contents |
+| --- | --- |
+| `logs/ralph-issue-N.jsonl` | Claude's raw `stream-json` stdout for that issue, tee'd verbatim. Truncated fresh per issue. |
+| `.ralph/metrics/issues.jsonl` | One appended `RALPH_ISSUE_EVENT <json>` line per iteration. **Append-only** — events accumulate across runs and are never truncated. |
+
+Capture is **best-effort telemetry**: it runs after the loop has already
+decided the issue's outcome and can never abort or alter the loop — any
+failure is swallowed.
+
+Each event line is `RALPH_ISSUE_EVENT ` followed by a JSON object with
+these fields:
+
+| Field | Meaning |
+| --- | --- |
+| `issue_number` | The issue resolved this iteration. |
+| `run_id` | Ties all events from one loop invocation together: `<tmux-session>-<start-epoch-seconds>`. |
+| `ts` | Event timestamp. |
+| `subtype`, `total_cost_usd`, `num_turns`, `duration_ms`, `usage` | Pulled from the last `result` line of the raw stream-json (zeroed if absent). |
+| `claude_exit_code` | Claude's exit code for the iteration. |
+| `stderr_error_signals` | Count of stderr lines matching auth / credit / rate-limit signals. |
+| `verdict` | `pass` (CLOSED or `pending-merge`), `fail` (`claude-failed` label), or `unknown`. |
+| `files`, `insertions`, `deletions` | Diff stats — **placeholders (`0`) in this slice**, wired in a later change. |
 
 ## Links
 

--- a/packages/ralph/lib/capture-issue-event.js
+++ b/packages/ralph/lib/capture-issue-event.js
@@ -1,0 +1,79 @@
+// Best-effort per-issue event capture entrypoint (CLI), invoked by the bash loop
+// (templates/ralph.sh) AFTER it has computed the issue's label/state. It does
+// NOT re-fetch anything from gh — every input is handed in via env vars. This is
+// a TELEMETRY sidecar: any failure (parser crash, missing file, unwritable dir)
+// MUST exit 0 and never abort or alter the loop.
+//
+// Env-var contract (all read from `env`, default to process.env when invoked as
+// a script):
+//   PROJECT_ROOT          - repo root; where .ralph/metrics/issues.jsonl lives
+//   RALPH_ISSUE_NUMBER    - issue number (integer string)
+//   RALPH_RUN_ID          - run id (`<session>-<start-epoch>`)
+//   RALPH_CLAUDE_EXIT     - claude's exit code (integer string)
+//   RALPH_ISSUE_LABELS    - comma-joined issue labels (e.g. "bug,pending-merge")
+//   RALPH_ISSUE_STATE     - issue state ('OPEN' | 'CLOSED')
+//   RALPH_DEV_BRANCH      - dev branch name (recorded for future diff slices)
+//   RALPH_RAW_JSONL_PATH  - path to the tee'd raw claude stream-json (.jsonl)
+//   RALPH_STDERR_LOG_PATH - path to the per-issue stderr log
+//
+// On success appends one `RALPH_ISSUE_EVENT <json>` line via appendIssueEvent.
+
+import { readFileSync, existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+import { buildIssueEvent } from './issue-event.js'
+import { appendIssueEvent } from './issue-metrics.js'
+
+function readFileSafe(path) {
+  if (!path || !existsSync(path)) return ''
+  try {
+    return readFileSync(path, 'utf8').toString()
+  } catch {
+    return ''
+  }
+}
+
+function parseLabels(joined) {
+  if (!joined) return []
+  return joined
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+// Best-effort: wrap EVERYTHING; on any error write a short diagnostic and return
+// without throwing. The caller (script guard) exits 0 regardless.
+export function captureIssueEvent({ env = {}, now = Date.now, log = console.error } = {}) {
+  try {
+    const projectRoot = env.PROJECT_ROOT || process.cwd()
+    const rawStreamJson = readFileSafe(env.RALPH_RAW_JSONL_PATH)
+    const stderrLog = readFileSafe(env.RALPH_STDERR_LOG_PATH)
+
+    const issueNumber = Number.parseInt(env.RALPH_ISSUE_NUMBER, 10)
+    const claudeExitCode = Number.parseInt(env.RALPH_CLAUDE_EXIT, 10)
+
+    const event = buildIssueEvent({
+      rawStreamJson,
+      stderrLog,
+      issueNumber: Number.isNaN(issueNumber) ? null : issueNumber,
+      runId: env.RALPH_RUN_ID || '',
+      claudeExitCode: Number.isNaN(claudeExitCode) ? null : claudeExitCode,
+      labels: parseLabels(env.RALPH_ISSUE_LABELS),
+      state: env.RALPH_ISSUE_STATE || '',
+      ts: now(),
+    })
+
+    appendIssueEvent(projectRoot, event)
+  } catch (e) {
+    // Telemetry must never break the loop.
+    log(`capture-issue-event: skipped (${e && e.message ? e.message : e})`)
+  }
+}
+
+const invokedAsScript =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+if (invokedAsScript) {
+  captureIssueEvent({ env: process.env })
+  process.exit(0)
+}

--- a/packages/ralph/lib/capture-issue-event.test.js
+++ b/packages/ralph/lib/capture-issue-event.test.js
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { captureIssueEvent } from './capture-issue-event.js'
+import { metricsPath } from './issue-metrics.js'
+
+let workdir
+
+function envFor(overrides = {}) {
+  return {
+    PROJECT_ROOT: workdir,
+    RALPH_ISSUE_NUMBER: '98',
+    RALPH_RUN_ID: 'ralph-abc-1718000000',
+    RALPH_CLAUDE_EXIT: '0',
+    RALPH_ISSUE_LABELS: 'pending-merge',
+    RALPH_ISSUE_STATE: 'OPEN',
+    RALPH_DEV_BRANCH: 'dev',
+    RALPH_RAW_JSONL_PATH: join(workdir, 'logs', 'ralph-issue-98.jsonl'),
+    RALPH_STDERR_LOG_PATH: join(workdir, 'logs', 'ralph-issue-98.log'),
+    ...overrides,
+  }
+}
+
+function readEvents() {
+  const p = metricsPath(workdir)
+  if (!existsSync(p)) return []
+  return readFileSync(p, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l.slice('RALPH_ISSUE_EVENT '.length)))
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'ralph-capture-'))
+  mkdirSync(join(workdir, 'logs'), { recursive: true })
+})
+
+afterEach(() => {
+  if (workdir && existsSync(workdir)) {
+    rmSync(workdir, { recursive: true, force: true })
+  }
+})
+
+describe('captureIssueEvent', () => {
+  it('appends exactly one event line from a fixture .jsonl + stderr log', () => {
+    writeFileSync(
+      join(workdir, 'logs', 'ralph-issue-98.jsonl'),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        total_cost_usd: 0.5,
+        num_turns: 3,
+        duration_ms: 1000,
+        usage: { input_tokens: 10 },
+      }) + '\n',
+    )
+    writeFileSync(
+      join(workdir, 'logs', 'ralph-issue-98.log'),
+      'all good\n',
+    )
+
+    captureIssueEvent({ env: envFor() })
+
+    const events = readEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].issue_number).toBe(98)
+    expect(events[0].subtype).toBe('success')
+    expect(events[0].total_cost_usd).toBe(0.5)
+    expect(events[0].verdict).toBe('pass')
+    expect(events[0].run_id).toBe('ralph-abc-1718000000')
+    expect(typeof events[0].ts).toBe('number')
+    expect(events[0].stderr_error_signals).toBe(0)
+  })
+
+  it('still appends an event with default/zero fields when the .jsonl is missing', () => {
+    // No .jsonl, no stderr log written.
+    expect(() => captureIssueEvent({ env: envFor() })).not.toThrow()
+    const events = readEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].subtype).toBeNull()
+    expect(events[0].total_cost_usd).toBe(0)
+    expect(events[0].issue_number).toBe(98)
+  })
+
+  it('counts stderr error signals from the stderr log', () => {
+    writeFileSync(
+      join(workdir, 'logs', 'ralph-issue-98.jsonl'),
+      JSON.stringify({ type: 'result', subtype: 'error_during_execution' }) + '\n',
+    )
+    writeFileSync(
+      join(workdir, 'logs', 'ralph-issue-98.log'),
+      'Credit balance too low\nAuthentication error\n',
+    )
+    captureIssueEvent({
+      env: envFor({ RALPH_CLAUDE_EXIT: '1', RALPH_ISSUE_LABELS: 'claude-failed' }),
+    })
+    const events = readEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].stderr_error_signals).toBe(2)
+    expect(events[0].claude_exit_code).toBe(1)
+    expect(events[0].verdict).toBe('fail')
+  })
+
+  it('parses comma-joined labels into an array for the verdict', () => {
+    captureIssueEvent({
+      env: envFor({ RALPH_ISSUE_LABELS: 'bug,claude-failed,enhancement' }),
+    })
+    const events = readEvents()
+    expect(events[0].verdict).toBe('fail')
+  })
+
+  it('does not throw and writes nothing fatal when PROJECT_ROOT is unwritable-ish but best-effort', () => {
+    // Empty labels + missing files: still must not throw.
+    expect(() =>
+      captureIssueEvent({ env: envFor({ RALPH_ISSUE_LABELS: '' }) }),
+    ).not.toThrow()
+    expect(readEvents()).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation: best-effort contract + numeric coercion + determinism.
+// ---------------------------------------------------------------------------
+describe('QA: captureIssueEvent — best-effort + coercion', () => {
+  it('missing .jsonl AND missing stderr => one event with zero/default fields, no throw', () => {
+    // beforeEach makes the logs dir but writes no files.
+    expect(() =>
+      captureIssueEvent({ env: envFor({ RALPH_ISSUE_LABELS: 'pending-merge' }) }),
+    ).not.toThrow()
+    const events = readEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].subtype).toBeNull()
+    expect(events[0].total_cost_usd).toBe(0)
+    expect(events[0].stderr_error_signals).toBe(0)
+    expect(events[0].usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+  })
+
+  it('garbage/malformed .jsonl => event still written with safe defaults, no throw', () => {
+    writeFileSync(
+      join(workdir, 'logs', 'ralph-issue-98.jsonl'),
+      'not json\n{ broken\n\n',
+    )
+    expect(() => captureIssueEvent({ env: envFor() })).not.toThrow()
+    const events = readEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].subtype).toBeNull()
+    expect(events[0].total_cost_usd).toBe(0)
+  })
+
+  it('non-numeric RALPH_ISSUE_NUMBER => issue_number is null (not NaN)', () => {
+    captureIssueEvent({ env: envFor({ RALPH_ISSUE_NUMBER: 'not-a-number' }) })
+    const events = readEvents()
+    expect(events[0].issue_number).toBeNull()
+    // JSON.parse would have turned NaN into null on disk; assert the in-memory
+    // semantics by confirming it's exactly null after round-trip.
+    expect(events[0].issue_number).not.toBeNaN?.()
+  })
+
+  it('non-numeric RALPH_CLAUDE_EXIT => claude_exit_code is null (not NaN)', () => {
+    captureIssueEvent({ env: envFor({ RALPH_CLAUDE_EXIT: 'boom' }) })
+    const events = readEvents()
+    expect(events[0].claude_exit_code).toBeNull()
+  })
+
+  it('missing RALPH_ISSUE_NUMBER / RALPH_CLAUDE_EXIT entirely => null fields', () => {
+    const env = envFor()
+    delete env.RALPH_ISSUE_NUMBER
+    delete env.RALPH_CLAUDE_EXIT
+    captureIssueEvent({ env })
+    const events = readEvents()
+    expect(events[0].issue_number).toBeNull()
+    expect(events[0].claude_exit_code).toBeNull()
+  })
+
+  it('empty RALPH_ISSUE_LABELS + OPEN state => empty labels => unknown verdict', () => {
+    captureIssueEvent({
+      env: envFor({ RALPH_ISSUE_LABELS: '', RALPH_ISSUE_STATE: 'OPEN' }),
+    })
+    const events = readEvents()
+    expect(events[0].verdict).toBe('unknown')
+  })
+
+  it('empty RALPH_ISSUE_LABELS but CLOSED state => pass', () => {
+    captureIssueEvent({
+      env: envFor({ RALPH_ISSUE_LABELS: '', RALPH_ISSUE_STATE: 'CLOSED' }),
+    })
+    const events = readEvents()
+    expect(events[0].verdict).toBe('pass')
+  })
+
+  it('uses the injected now() for ts (deterministic)', () => {
+    captureIssueEvent({ env: envFor(), now: () => 1234567890 })
+    const events = readEvents()
+    expect(events[0].ts).toBe(1234567890)
+  })
+
+  it('whitespace-padded labels are trimmed and parsed', () => {
+    captureIssueEvent({
+      env: envFor({ RALPH_ISSUE_LABELS: '  bug , claude-failed , enhancement ' }),
+    })
+    const events = readEvents()
+    expect(events[0].verdict).toBe('fail')
+  })
+})

--- a/packages/ralph/lib/issue-event.js
+++ b/packages/ralph/lib/issue-event.js
@@ -1,0 +1,95 @@
+// PURE per-issue event builder. NO I/O, NO Date.now, NO process access — every
+// input (including the timestamp) is injected so this is trivially testable and
+// deterministic. Given the raw claude stream-json, the per-issue stderr log, and
+// the issue's label/state, it returns the normalized event object that the
+// metrics writer appends to .ralph/metrics/issues.jsonl.
+
+// Case-insensitive signal regex for auth / credit / rate-limit failures.
+const ERROR_SIGNAL = /auth|credit|rate.?limit/i
+
+const ZERO_USAGE = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+}
+
+// Find the LAST parseable `.type === 'result'` line in the newline-delimited
+// stream-json. Skips blank / garbage / non-JSON lines gracefully. Never throws.
+function lastResultLine(rawStreamJson) {
+  if (!rawStreamJson) return null
+  let found = null
+  for (const line of rawStreamJson.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let obj
+    try {
+      obj = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (obj && obj.type === 'result') found = obj
+  }
+  return found
+}
+
+function normalizeUsage(usage) {
+  const u = usage && typeof usage === 'object' ? usage : {}
+  return {
+    input_tokens: u.input_tokens ?? 0,
+    output_tokens: u.output_tokens ?? 0,
+    cache_read_input_tokens: u.cache_read_input_tokens ?? 0,
+    cache_creation_input_tokens: u.cache_creation_input_tokens ?? 0,
+  }
+}
+
+function countErrorSignals(stderrLog) {
+  if (!stderrLog) return 0
+  let n = 0
+  for (const line of stderrLog.split('\n')) {
+    if (ERROR_SIGNAL.test(line)) n++
+  }
+  return n
+}
+
+// Verdict precedence: claude-failed label => fail wins (even if CLOSED/OPEN);
+// else CLOSED state OR pending-merge label => pass; else unknown.
+function computeVerdict(labels, state) {
+  const ls = Array.isArray(labels) ? labels : []
+  if (ls.includes('claude-failed')) return 'fail'
+  if (state === 'CLOSED' || ls.includes('pending-merge')) return 'pass'
+  return 'unknown'
+}
+
+export function buildIssueEvent(input) {
+  const {
+    rawStreamJson = '',
+    stderrLog = '',
+    issueNumber,
+    runId,
+    claudeExitCode,
+    labels = [],
+    state,
+    ts,
+  } = input || {}
+
+  const result = lastResultLine(rawStreamJson)
+
+  return {
+    issue_number: issueNumber,
+    run_id: runId,
+    ts,
+    subtype: result ? (result.subtype ?? null) : null,
+    total_cost_usd: result ? (result.total_cost_usd ?? 0) : 0,
+    num_turns: result ? (result.num_turns ?? 0) : 0,
+    duration_ms: result ? (result.duration_ms ?? 0) : 0,
+    usage: result ? normalizeUsage(result.usage) : { ...ZERO_USAGE },
+    claude_exit_code: claudeExitCode,
+    stderr_error_signals: countErrorSignals(stderrLog),
+    verdict: computeVerdict(labels, state),
+    // diff fields — placeholders for this slice (#529).
+    files: 0,
+    insertions: 0,
+    deletions: 0,
+  }
+}

--- a/packages/ralph/lib/issue-event.test.js
+++ b/packages/ralph/lib/issue-event.test.js
@@ -1,0 +1,388 @@
+import { describe, it, expect } from 'vitest'
+import { buildIssueEvent } from './issue-event.js'
+
+// Helper: build a stream-json string from an array of JSON-able objects, one
+// per line (newline-delimited). Mirrors claude's --output-format stream-json.
+function streamLines(objs) {
+  return objs.map((o) => JSON.stringify(o)).join('\n') + '\n'
+}
+
+const resultLine = (overrides = {}) => ({
+  type: 'result',
+  subtype: 'success',
+  total_cost_usd: 0.1234,
+  num_turns: 7,
+  duration_ms: 4200,
+  usage: {
+    input_tokens: 1000,
+    output_tokens: 200,
+    cache_read_input_tokens: 50,
+    cache_creation_input_tokens: 25,
+  },
+  ...overrides,
+})
+
+const baseInput = (overrides = {}) => ({
+  rawStreamJson: streamLines([
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } },
+    resultLine(),
+  ]),
+  stderrLog: '',
+  issueNumber: 98,
+  runId: 'ralph-abc-1718000000',
+  claudeExitCode: 0,
+  labels: [],
+  state: 'OPEN',
+  ts: 1718000123456,
+  ...overrides,
+})
+
+describe('buildIssueEvent — result line parsing', () => {
+  it('reads cost/turns/duration/subtype from the result line (success)', () => {
+    const e = buildIssueEvent(baseInput())
+    expect(e.subtype).toBe('success')
+    expect(e.total_cost_usd).toBe(0.1234)
+    expect(e.num_turns).toBe(7)
+    expect(e.duration_ms).toBe(4200)
+  })
+
+  it('stores usage RAW as found on the result line', () => {
+    const e = buildIssueEvent(baseInput())
+    expect(e.usage).toEqual({
+      input_tokens: 1000,
+      output_tokens: 200,
+      cache_read_input_tokens: 50,
+      cache_creation_input_tokens: 25,
+    })
+  })
+
+  it('defaults missing usage fields to 0', () => {
+    const raw = streamLines([resultLine({ usage: { input_tokens: 5 } })])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.usage).toEqual({
+      input_tokens: 5,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+  })
+
+  it('captures error_max_turns subtype', () => {
+    const raw = streamLines([resultLine({ subtype: 'error_max_turns' })])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.subtype).toBe('error_max_turns')
+  })
+
+  it('captures error_during_execution subtype', () => {
+    const raw = streamLines([resultLine({ subtype: 'error_during_execution' })])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.subtype).toBe('error_during_execution')
+  })
+
+  it('uses the LAST result line when several are present', () => {
+    const raw = streamLines([
+      resultLine({ subtype: 'error_max_turns', total_cost_usd: 0.01 }),
+      resultLine({ subtype: 'success', total_cost_usd: 0.99 }),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.subtype).toBe('success')
+    expect(e.total_cost_usd).toBe(0.99)
+  })
+
+  it('never throws on truncated / garbage stream and falls back to safe defaults', () => {
+    const raw = 'not json at all\n{ broken json\n\n   \n'
+    let e
+    expect(() => {
+      e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    }).not.toThrow()
+    expect(e.total_cost_usd).toBe(0)
+    expect(e.num_turns).toBe(0)
+    expect(e.duration_ms).toBe(0)
+    expect(e.subtype).toBeNull()
+    expect(e.usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+  })
+
+  it('tolerates an empty stream string', () => {
+    const e = buildIssueEvent(baseInput({ rawStreamJson: '' }))
+    expect(e.subtype).toBeNull()
+    expect(e.total_cost_usd).toBe(0)
+  })
+})
+
+describe('buildIssueEvent — stderr error-signal counting', () => {
+  it('counts 0 when stderr has no error signals', () => {
+    const e = buildIssueEvent(
+      baseInput({ stderrLog: 'just a normal log line\nanother line\n' }),
+    )
+    expect(e.stderr_error_signals).toBe(0)
+  })
+
+  it('counts lines matching auth / credit / rate-limit (case-insensitive)', () => {
+    const stderr = [
+      'Authentication failed',
+      'Credit balance too low',
+      'You have been RATE LIMITED',
+      'rate-limit exceeded',
+      'all good here',
+    ].join('\n')
+    const e = buildIssueEvent(baseInput({ stderrLog: stderr }))
+    expect(e.stderr_error_signals).toBe(4)
+  })
+
+  it('counts 0 on empty stderr', () => {
+    const e = buildIssueEvent(baseInput({ stderrLog: '' }))
+    expect(e.stderr_error_signals).toBe(0)
+  })
+})
+
+describe('buildIssueEvent — verdict precedence', () => {
+  it("claude-failed label => 'fail' even when state is CLOSED", () => {
+    const e = buildIssueEvent(
+      baseInput({ labels: ['claude-failed'], state: 'CLOSED' }),
+    )
+    expect(e.verdict).toBe('fail')
+  })
+
+  it("claude-failed label => 'fail' even with pending-merge label", () => {
+    const e = buildIssueEvent(
+      baseInput({ labels: ['claude-failed', 'pending-merge'], state: 'OPEN' }),
+    )
+    expect(e.verdict).toBe('fail')
+  })
+
+  it("pending-merge label => 'pass'", () => {
+    const e = buildIssueEvent(
+      baseInput({ labels: ['pending-merge'], state: 'OPEN' }),
+    )
+    expect(e.verdict).toBe('pass')
+  })
+
+  it("state CLOSED => 'pass'", () => {
+    const e = buildIssueEvent(baseInput({ labels: [], state: 'CLOSED' }))
+    expect(e.verdict).toBe('pass')
+  })
+
+  it("plain OPEN with no labels => 'unknown'", () => {
+    const e = buildIssueEvent(baseInput({ labels: [], state: 'OPEN' }))
+    expect(e.verdict).toBe('unknown')
+  })
+
+  it("unrelated labels OPEN => 'unknown'", () => {
+    const e = buildIssueEvent(
+      baseInput({ labels: ['bug', 'enhancement'], state: 'OPEN' }),
+    )
+    expect(e.verdict).toBe('unknown')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation: adversarial / edge cases beyond the happy-path suite above.
+// ---------------------------------------------------------------------------
+
+describe('QA: buildIssueEvent — result line parsing (adversarial)', () => {
+  it('finds the result line even when interleaved with blank + garbage + partial-json lines', () => {
+    const raw = [
+      '',
+      'not json at all',
+      '{partial',
+      JSON.stringify({ type: 'assistant', message: {} }),
+      '   ',
+      JSON.stringify(resultLine({ subtype: 'success', total_cost_usd: 0.42 })),
+      '{ broken',
+      '',
+    ].join('\n')
+    let e
+    expect(() => {
+      e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    }).not.toThrow()
+    expect(e.subtype).toBe('success')
+    expect(e.total_cost_usd).toBe(0.42)
+  })
+
+  it('result line with type:result but usage entirely MISSING => all-zero usage', () => {
+    const line = resultLine()
+    delete line.usage
+    const raw = streamLines([line])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+    // present scalar fields still read raw
+    expect(e.num_turns).toBe(7)
+  })
+
+  it('result line with usage set to null => all-zero usage, no throw', () => {
+    const raw = streamLines([resultLine({ usage: null })])
+    let e
+    expect(() => {
+      e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    }).not.toThrow()
+    expect(e.usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+  })
+
+  it('stream that is ONLY garbage (no result line) => safe zero defaults, valid object', () => {
+    const raw = 'garbage one\nmore garbage\n{still not json\n'
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.subtype).toBeNull()
+    expect(e.total_cost_usd).toBe(0)
+    expect(e.num_turns).toBe(0)
+    expect(e.duration_ms).toBe(0)
+    expect(e.usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+  })
+
+  it('distinguishes a real 0 from absent: explicit zeros stay 0 with no NaN/undefined leak', () => {
+    const raw = streamLines([
+      resultLine({ total_cost_usd: 0, num_turns: 0, duration_ms: 0 }),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.total_cost_usd).toBe(0)
+    expect(e.num_turns).toBe(0)
+    expect(e.duration_ms).toBe(0)
+    for (const v of [e.total_cost_usd, e.num_turns, e.duration_ms]) {
+      expect(Number.isNaN(v)).toBe(false)
+      expect(v).not.toBeUndefined()
+    }
+  })
+
+  it('result line missing scalar fields => 0 (not undefined/NaN)', () => {
+    const raw = streamLines([{ type: 'result', subtype: 'success' }])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.total_cost_usd).toBe(0)
+    expect(e.num_turns).toBe(0)
+    expect(e.duration_ms).toBe(0)
+    for (const v of [e.total_cost_usd, e.num_turns, e.duration_ms]) {
+      expect(Number.isNaN(v)).toBe(false)
+      expect(v).not.toBeUndefined()
+    }
+  })
+
+  it('never throws when input itself is null/undefined', () => {
+    expect(() => buildIssueEvent(undefined)).not.toThrow()
+    expect(() => buildIssueEvent(null)).not.toThrow()
+    const e = buildIssueEvent(null)
+    expect(e.subtype).toBeNull()
+    expect(e.usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+  })
+})
+
+describe('QA: buildIssueEvent — stderr error-signal counting (adversarial)', () => {
+  it('a line matching MULTIPLE keywords counts ONCE (per-line, not per-keyword)', () => {
+    const stderr = 'auth failure and credit issue and rate limit too\n'
+    const e = buildIssueEvent(baseInput({ stderrLog: stderr }))
+    expect(e.stderr_error_signals).toBe(1)
+  })
+
+  it('matches rate-limit spelling variants (rate limit, rate-limit, ratelimit)', () => {
+    const stderr = ['rate limit', 'rate-limit', 'ratelimit'].join('\n')
+    const e = buildIssueEvent(baseInput({ stderrLog: stderr }))
+    expect(e.stderr_error_signals).toBe(3)
+  })
+
+  it('is case-insensitive (AUTH, Rate Limit)', () => {
+    const stderr = ['AUTH', 'Rate Limit'].join('\n')
+    const e = buildIssueEvent(baseInput({ stderrLog: stderr }))
+    expect(e.stderr_error_signals).toBe(2)
+  })
+
+  it('blank / whitespace lines do not count', () => {
+    const stderr = '\n   \n\t\nauth\n\n'
+    const e = buildIssueEvent(baseInput({ stderrLog: stderr }))
+    expect(e.stderr_error_signals).toBe(1)
+  })
+})
+
+describe('QA: buildIssueEvent — verdict (adversarial)', () => {
+  it('labels null => no throw, unknown', () => {
+    let e
+    expect(() => {
+      e = buildIssueEvent(baseInput({ labels: null, state: 'OPEN' }))
+    }).not.toThrow()
+    expect(e.verdict).toBe('unknown')
+  })
+
+  it('labels undefined => no throw, unknown', () => {
+    let e
+    expect(() => {
+      e = buildIssueEvent(baseInput({ labels: undefined, state: 'OPEN' }))
+    }).not.toThrow()
+    expect(e.verdict).toBe('unknown')
+  })
+
+  it('labels a non-array string => no throw, unknown', () => {
+    let e
+    expect(() => {
+      e = buildIssueEvent(baseInput({ labels: 'pending-merge', state: 'OPEN' }))
+    }).not.toThrow()
+    expect(e.verdict).toBe('unknown')
+  })
+
+  it('pending-merge present AND state OPEN => pass', () => {
+    const e = buildIssueEvent(
+      baseInput({ labels: ['pending-merge'], state: 'OPEN' }),
+    )
+    expect(e.verdict).toBe('pass')
+  })
+})
+
+describe('QA: buildIssueEvent — diff placeholders always zero', () => {
+  it('files/insertions/deletions stay exactly 0 even with garbage input', () => {
+    const e = buildIssueEvent(
+      baseInput({ rawStreamJson: 'garbage', stderrLog: 'auth\nauth', labels: null }),
+    )
+    expect(e.files).toBe(0)
+    expect(e.insertions).toBe(0)
+    expect(e.deletions).toBe(0)
+  })
+
+  it('files/insertions/deletions stay 0 even if the result line tries to set them', () => {
+    const raw = streamLines([
+      resultLine({ files: 99, insertions: 12, deletions: 34 }),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.files).toBe(0)
+    expect(e.insertions).toBe(0)
+    expect(e.deletions).toBe(0)
+  })
+})
+
+describe('buildIssueEvent — passthrough + placeholders', () => {
+  it('passes through issue_number, run_id, ts, claude_exit_code', () => {
+    const e = buildIssueEvent(
+      baseInput({ issueNumber: 42, runId: 'r-1', ts: 999, claudeExitCode: 3 }),
+    )
+    expect(e.issue_number).toBe(42)
+    expect(e.run_id).toBe('r-1')
+    expect(e.ts).toBe(999)
+    expect(e.claude_exit_code).toBe(3)
+  })
+
+  it('includes diff placeholder fields set to 0', () => {
+    const e = buildIssueEvent(baseInput())
+    expect(e.files).toBe(0)
+    expect(e.insertions).toBe(0)
+    expect(e.deletions).toBe(0)
+  })
+})

--- a/packages/ralph/lib/issue-metrics.js
+++ b/packages/ralph/lib/issue-metrics.js
@@ -1,0 +1,37 @@
+// Append-only writer for per-issue metrics. Each completed issue iteration
+// appends ONE line `RALPH_ISSUE_EVENT <json>\n` to .ralph/metrics/issues.jsonl.
+// Never truncates — events accumulate across runs. Follows the injectable-fs
+// pattern from state.js (wrap real fs, fall back when no fsImpl passed).
+
+import {
+  existsSync as realExistsSync,
+  mkdirSync as realMkdirSync,
+  appendFileSync as realAppendFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+
+export function metricsPath(projectRoot) {
+  return join(projectRoot, '.ralph', 'metrics', 'issues.jsonl')
+}
+
+export function appendIssueEvent(projectRoot, event, fsImpl) {
+  const fs = wrap(fsImpl)
+  const path = metricsPath(projectRoot)
+  fs.mkdirSync(dirname(path), { recursive: true })
+  fs.appendFileSync(path, 'RALPH_ISSUE_EVENT ' + JSON.stringify(event) + '\n')
+}
+
+function wrap(fsImpl) {
+  if (!fsImpl) {
+    return {
+      existsSync: realExistsSync,
+      mkdirSync: realMkdirSync,
+      appendFileSync: realAppendFileSync,
+    }
+  }
+  return {
+    existsSync: fsImpl.existsSync.bind(fsImpl),
+    mkdirSync: fsImpl.mkdirSync.bind(fsImpl),
+    appendFileSync: fsImpl.appendFileSync.bind(fsImpl),
+  }
+}

--- a/packages/ralph/lib/issue-metrics.test.js
+++ b/packages/ralph/lib/issue-metrics.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { join } from 'node:path'
+import { appendIssueEvent, metricsPath } from './issue-metrics.js'
+
+// In-memory fs stub matching the injectable-fs pattern from state.js.
+function makeFsStub() {
+  const files = new Map()
+  const dirs = new Set()
+  return {
+    files,
+    dirs,
+    existsSync(p) {
+      return files.has(p) || dirs.has(p)
+    },
+    mkdirSync(p) {
+      dirs.add(p)
+    },
+    appendFileSync(p, data) {
+      files.set(p, (files.get(p) || '') + data)
+    },
+  }
+}
+
+describe('metricsPath', () => {
+  it('points at .ralph/metrics/issues.jsonl under the project root', () => {
+    expect(metricsPath('/proj')).toBe(
+      join('/proj', '.ralph', 'metrics', 'issues.jsonl'),
+    )
+  })
+})
+
+describe('appendIssueEvent', () => {
+  it('appends exactly one RALPH_ISSUE_EVENT line with valid JSON', () => {
+    const fs = makeFsStub()
+    const event = { issue_number: 98, verdict: 'pass' }
+    appendIssueEvent('/proj', event, fs)
+
+    const contents = fs.files.get(metricsPath('/proj'))
+    const lines = contents.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(1)
+    expect(lines[0].startsWith('RALPH_ISSUE_EVENT ')).toBe(true)
+    const json = lines[0].slice('RALPH_ISSUE_EVENT '.length)
+    expect(JSON.parse(json)).toEqual(event)
+    expect(contents.endsWith('\n')).toBe(true)
+  })
+
+  it('appends (does not overwrite) on a second call', () => {
+    const fs = makeFsStub()
+    appendIssueEvent('/proj', { issue_number: 1 }, fs)
+    appendIssueEvent('/proj', { issue_number: 2 }, fs)
+
+    const contents = fs.files.get(metricsPath('/proj'))
+    const lines = contents.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0].slice('RALPH_ISSUE_EVENT '.length)).issue_number).toBe(1)
+    expect(JSON.parse(lines[1].slice('RALPH_ISSUE_EVENT '.length)).issue_number).toBe(2)
+  })
+
+  it('mkdirs the metrics dir recursively', () => {
+    const fs = makeFsStub()
+    appendIssueEvent('/proj', { issue_number: 1 }, fs)
+    expect(fs.dirs.has(join('/proj', '.ralph', 'metrics'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation: additivity + JSON-escaping round-trip.
+// ---------------------------------------------------------------------------
+describe('QA: appendIssueEvent — additive over many calls', () => {
+  it('3 sequential appends => 3 lines, all valid JSON, in order', () => {
+    const fs = makeFsStub()
+    appendIssueEvent('/proj', { issue_number: 1 }, fs)
+    appendIssueEvent('/proj', { issue_number: 2 }, fs)
+    appendIssueEvent('/proj', { issue_number: 3 }, fs)
+
+    const contents = fs.files.get(metricsPath('/proj'))
+    const lines = contents.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(3)
+    const nums = lines.map((l) => {
+      expect(l.startsWith('RALPH_ISSUE_EVENT ')).toBe(true)
+      return JSON.parse(l.slice('RALPH_ISSUE_EVENT '.length)).issue_number
+    })
+    expect(nums).toEqual([1, 2, 3])
+  })
+})
+
+describe('QA: appendIssueEvent — JSON escaping round-trip', () => {
+  it('event with newlines + quotes in a string field stays ONE line and round-trips', () => {
+    const fs = makeFsStub()
+    const event = {
+      issue_number: 7,
+      note: 'line one\nline two with "quotes" and a \\ backslash',
+      verdict: 'pass',
+    }
+    appendIssueEvent('/proj', event, fs)
+
+    const contents = fs.files.get(metricsPath('/proj'))
+    // exactly one trailing newline => exactly one record line
+    const lines = contents.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(1)
+    const parsed = JSON.parse(lines[0].slice('RALPH_ISSUE_EVENT '.length))
+    expect(parsed).toEqual(event)
+    expect(parsed.note).toContain('\n')
+  })
+})

--- a/packages/ralph/lib/run-id.js
+++ b/packages/ralph/lib/run-id.js
@@ -1,0 +1,6 @@
+// Pure run_id builder. A run_id ties all per-issue events from one Ralph loop
+// invocation together: `<tmux-session-name>-<start-epoch-seconds>`.
+
+export function buildRunId(sessionName, startEpochSeconds) {
+  return `${sessionName}-${startEpochSeconds}`
+}

--- a/packages/ralph/lib/run-id.test.js
+++ b/packages/ralph/lib/run-id.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { buildRunId } from './run-id.js'
+
+describe('buildRunId', () => {
+  it('joins session name and epoch seconds with a hyphen', () => {
+    expect(buildRunId('ralph-agenthub-1a2b3c4d', 1718000000)).toBe(
+      'ralph-agenthub-1a2b3c4d-1718000000',
+    )
+  })
+
+  it('pins the exact <session>-<epoch> format', () => {
+    expect(buildRunId('ralph', 0)).toBe('ralph-0')
+    expect(buildRunId('s', 42)).toBe('s-42')
+  })
+
+  // QA augmentation: edge cases.
+  it('coerces a numeric epoch and a string epoch to the same shape', () => {
+    expect(buildRunId('ralph', 1718000000)).toBe('ralph-1718000000')
+    expect(buildRunId('ralph', '1718000000')).toBe('ralph-1718000000')
+  })
+
+  it('preserves hyphens in the session name (last hyphen separates the epoch)', () => {
+    const id = buildRunId('ralph-agent-hub', 1718000000)
+    expect(id).toBe('ralph-agent-hub-1718000000')
+    // round-trip shape: epoch is the segment after the final hyphen
+    const idx = id.lastIndexOf('-')
+    expect(id.slice(0, idx)).toBe('ralph-agent-hub')
+    expect(id.slice(idx + 1)).toBe('1718000000')
+  })
+
+  it('handles an empty session name => leading hyphen', () => {
+    expect(buildRunId('', 1718000000)).toBe('-1718000000')
+  })
+})

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -70,19 +70,36 @@ JQ_STREAM_FILTER='fromjson? // empty
 run_claude_stream() {
   prompt_script="$1"
   log_file="$2"
+  raw_jsonl="${3:-}"
   # Truncate the unique per-issue log ONCE up front, then have BOTH the stderr
   # tee and the stdout tee APPEND. This removes a truncate-vs-append race: if
   # the stdout `tee` opened with O_TRUNC while the stderr `tee -a` was already
   # writing, the leading bytes of a stderr line (e.g. a failure signal) could
   # be clobbered, producing the empty/lost failure log this guards against.
   : > "$log_file"
-  node "$prompt_script" \
-    | claude -p --dangerously-skip-permissions \
-        --output-format stream-json --verbose --include-partial-messages \
-        2> >(tee -a "$log_file" >&2) \
-    | jq -rR --unbuffered "$JQ_STREAM_FILTER" \
-    | tee -a "$log_file"
-  # PIPESTATUS[1] is claude's exit code (node|claude|jq|tee).
+  if [ -n "$raw_jsonl" ]; then
+    # Tee claude's RAW stream-json stdout to "$raw_jsonl" (fresh per issue, so a
+    # plain `tee` truncate is fine) BETWEEN claude and jq. Claude stays pipe
+    # element index 1 so ${PIPESTATUS[1]} exit detection is unaffected
+    # (node|claude|tee|jq|tee → claude still index 1).
+    node "$prompt_script" \
+      | claude -p --dangerously-skip-permissions \
+          --output-format stream-json --verbose --include-partial-messages \
+          2> >(tee -a "$log_file" >&2) \
+      | tee "$raw_jsonl" \
+      | jq -rR --unbuffered "$JQ_STREAM_FILTER" \
+      | tee -a "$log_file"
+  else
+    # Original pipeline (node|claude|jq|tee) — byte-for-byte unchanged when no
+    # raw path is supplied (e.g. the config-validation call).
+    node "$prompt_script" \
+      | claude -p --dangerously-skip-permissions \
+          --output-format stream-json --verbose --include-partial-messages \
+          2> >(tee -a "$log_file" >&2) \
+      | jq -rR --unbuffered "$JQ_STREAM_FILTER" \
+      | tee -a "$log_file"
+  fi
+  # PIPESTATUS[1] is claude's exit code (claude is index 1 in BOTH variants).
   if [ "${PIPESTATUS[1]}" -ne 0 ]; then
     claude_failed=1
   else
@@ -91,7 +108,7 @@ run_claude_stream() {
 }
 
 run_claude_for_issue() {
-  run_claude_stream "$RALPH_PKG_DIR/lib/build-prompt.js" "logs/ralph-issue-$1.log"
+  run_claude_stream "$RALPH_PKG_DIR/lib/build-prompt.js" "logs/ralph-issue-$1.log" "logs/ralph-issue-$1.jsonl"
 }
 # ---------------------------------------------------------------------------
 
@@ -181,6 +198,20 @@ while :; do
 
   labels=$(gh issue view "$num" --json labels -q '[.labels[].name] | join(",")')
   state=$(gh issue view "$num" --json state -q '.state')
+
+  # Best-effort per-issue telemetry: capture one RALPH_ISSUE_EVENT line into
+  # .ralph/metrics/issues.jsonl. Runs once per iteration regardless of outcome.
+  # Telemetry failure MUST NEVER abort or alter the loop, hence `|| true`.
+  RALPH_ISSUE_NUMBER="$num" \
+    RALPH_RUN_ID="${RALPH_TMUX_SESSION:-ralph}-${START}" \
+    RALPH_CLAUDE_EXIT="$claude_failed" \
+    RALPH_ISSUE_LABELS="$labels" \
+    RALPH_ISSUE_STATE="$state" \
+    RALPH_DEV_BRANCH="${DEV_BRANCH:-}" \
+    RALPH_RAW_JSONL_PATH="logs/ralph-issue-$num.jsonl" \
+    RALPH_STDERR_LOG_PATH="logs/ralph-issue-$num.log" \
+    node "$RALPH_PKG_DIR/lib/capture-issue-event.js" || true
+
   if echo ",$labels," | grep -q ",claude-failed,"; then
     failures+=("$num")
   elif [ "$state" = "CLOSED" ] || echo ",$labels," | grep -q ",pending-merge,"; then

--- a/packages/ralph/test/loop.test.js
+++ b/packages/ralph/test/loop.test.js
@@ -1,11 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { spawnSync } from 'node:child_process'
+import { spawnSync, execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, existsSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { templatePath } from '../lib/paths.js'
 
 const RALPH_TEMPLATE = templatePath('ralph.sh')
+// Resolve the REAL node binary so the stub can delegate the capture-issue-event
+// invocation to it (the stub shadows `node` on PATH; build-prompt.js stays an
+// echo, but the telemetry sidecar must actually run).
+const REAL_NODE = execFileSync('node', ['-e', 'process.stdout.write(process.execPath)'], {
+  encoding: 'utf8',
+}).trim()
 
 // These integration tests execute templates/ralph.sh's main loop against
 // stubbed external commands (git, gh, claude, jq, node) placed on a PATH we
@@ -71,7 +77,13 @@ exit 0
   writeStub(
     'node',
     `#!/bin/bash
-# build-prompt.js / build-validate-prompt.js -> emit a dummy prompt.
+# The telemetry sidecar (capture-issue-event.js) must run for real so the
+# .ralph/metrics/issues.jsonl assertion is meaningful; delegate it to the real
+# node binary. Everything else (build-prompt.js / build-validate-prompt.js)
+# just needs to emit a dummy prompt.
+case "$*" in
+  *capture-issue-event.js*) exec "${REAL_NODE}" "$@" ;;
+esac
 echo "PROMPT"
 exit 0
 `
@@ -240,5 +252,25 @@ exit 0
     expect(res.stdout).toContain('Fila vazia, encerrando.')
     // All resolved -> reported as successes, none failed.
     expect(res.stdout).toMatch(/3 ok, 0 falharam|Ralph finalizado: 3 ok/)
+
+    // #529: per-issue telemetry — the capture sidecar must have appended a
+    // RALPH_ISSUE_EVENT line per resolved issue to .ralph/metrics/issues.jsonl.
+    const metricsFile = join(workdir, '.ralph', 'metrics', 'issues.jsonl')
+    expect(existsSync(metricsFile), `expected metrics at ${metricsFile}. stderr:\n${res.stderr}`).toBe(true)
+    const eventLines = readFileSync(metricsFile, 'utf8').trim().split('\n').filter(Boolean)
+    expect(eventLines.length).toBe(3)
+    for (const line of eventLines) {
+      expect(line.startsWith('RALPH_ISSUE_EVENT ')).toBe(true)
+      const ev = JSON.parse(line.slice('RALPH_ISSUE_EVENT '.length))
+      // Issues were reported CLOSED -> pass verdict; run_id is session-START.
+      expect(ev.verdict).toBe('pass')
+      expect(ev.run_id).toMatch(/^ralph-test-\d+$/)
+      expect(typeof ev.issue_number).toBe('number')
+    }
+    // One event for each selected issue number (3, 2, 1).
+    const issueNums = eventLines
+      .map((l) => JSON.parse(l.slice('RALPH_ISSUE_EVENT '.length)).issue_number)
+      .sort()
+    expect(issueNums).toEqual([1, 2, 3])
   })
 })


### PR DESCRIPTION
Closes #529

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/run-id.test.js`, `packages/ralph/lib/issue-event.test.js`, `packages/ralph/lib/issue-metrics.test.js`, `packages/ralph/lib/capture-issue-event.test.js`, `packages/ralph/test/loop.test.js`
- Before implementation (red): the four new `lib/*.test.js` files all failed to load (`Failed to load url ./<module>.js`) because the source modules didn't exist — correct red via import resolution.
- After implementation (green): full ralph package suite **597 tests pass** (29 files). Root frontend suite **553 pass**, build OK, lint 0 errors.

Implements the end-to-end tracer bullet: one issue iteration writes exactly one `RALPH_ISSUE_EVENT <json>` line to `.ralph/metrics/issues.jsonl`.
- `lib/run-id.js` — pure `buildRunId(session, epoch)` → `<session>-<epoch>` (format pinned by test).
- `lib/issue-event.js` — pure `buildIssueEvent(input)` (no I/O, injected `ts`); parses the last stream-json `result` line, stores `usage` raw, counts stderr auth/credit/rate-limit signals, computes verdict (claude-failed→fail wins; CLOSED/pending-merge→pass; else unknown). Diff fields `files/insertions/deletions` are `0` placeholders for this slice. Never throws on malformed/truncated/empty input.
- `lib/issue-metrics.js` — append-only `appendIssueEvent` + `metricsPath` (injectable fs, matches `state.js`).
- `lib/capture-issue-event.js` — best-effort CLI; reads inputs from env (never re-fetches from gh), tolerates missing files, swallows all errors and exits 0 so telemetry can never abort the loop.
- `templates/ralph.sh` — `run_claude_stream` gains an optional 3rd raw-jsonl arg (tees raw stream-json between claude and jq; claude stays `PIPESTATUS[1]`); the config-validation call stays 2-arg and byte-for-byte unchanged. After each iteration the loop invokes the capture entrypoint via env vars, suffixed `|| true`.

## QA scenarios added
- **issue-event**: multiple result lines → last wins; missing/partial/`null` usage → defaults to 0, present fields raw; interleaved blank/garbage/partial JSON → still finds result, no throw; only-garbage and empty stream → safe zero defaults; stderr signal counting per-line (multi-keyword line counts once), case-insensitive, variants `rate limit`/`rate-limit`/`ratelimit`; verdict adversarial combos (claude-failed + pending-merge/CLOSED → fail wins; non-array labels → no throw, unknown); diff fields always exactly 0 even when a result line tries to set them; `buildIssueEvent(null/undefined)` → no throw.
- **issue-metrics**: 3 sequential appends → 3 ordered valid JSON lines; event with newlines/quotes/backslash stays one line and round-trips.
- **capture-issue-event**: missing `.jsonl` + missing stderr → one event with defaults, no throw; garbage `.jsonl` → safe defaults; non-numeric `RALPH_ISSUE_NUMBER`/`RALPH_CLAUDE_EXIT` → `null` not `NaN`; empty labels + OPEN → unknown, + CLOSED → pass; injected `now` used for `ts`; padded comma labels trimmed.
- **run-id**: numeric vs string epoch; hyphenated session round-trip; empty session.
- Test paths: the four `lib/*.test.js` above (+31 tests over the dev baseline). Bugs found: **none** — all augmentation green.

## Review verdict
- **APPROVED** (Tier 1 single-reviewer maintainability gate). No blocking findings. Module split is right, pure/impure boundary correct, injectable-fs and `invokedAsScript` idioms match the existing codebase, best-effort telemetry contract is clean. Two non-blocking nits surfaced for human awareness (see Notes).

## Docs updated
- `packages/ralph/README.md` — extended the per-issue logs note (new raw `logs/ralph-issue-*.jsonl` tee) and added a **Per-issue telemetry** section documenting `.ralph/metrics/issues.jsonl`, the best-effort/never-aborts contract, and the `RALPH_ISSUE_EVENT` field table (diff fields noted as `0` placeholders this slice).
- CHANGELOG left untouched (release-please auto-generated); root `CLAUDE.md` unchanged (additive package internals, no steering-rule change).

## Notes
- Triage: **Tier 1 / Standard** (substantive package feature) — full team (dev → QA → review → writer). Heavy tier off.
- Non-blocking nits from review, for future slices (not expanded here to keep this slice minimal):
  1. `lib/run-id.js`'s `buildRunId` has no production caller yet — `ralph.sh` builds the run_id inline as `<session>-<START>`, duplicating the format. A later slice should make the capture entrypoint derive run_id via `buildRunId` (single source of truth) or drop the helper until used.
  2. `RALPH_CLAUDE_EXIT` carries the loop's `claude_failed` (0/1) flag, not the literal claude exit code, despite the field name/comment implying the raw code. Consider renaming or adjusting the doc comment in a follow-up.
