### PR TITLE
feat(ralph): real PR diff-stats in per-issue events

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -398,7 +398,7 @@ these fields:
 | `claude_exit_code` | Claude's exit code for the iteration. |
 | `stderr_error_signals` | Count of stderr lines matching auth / credit / rate-limit signals. |
 | `verdict` | `pass` (CLOSED or `pending-merge`), `fail` (`claude-failed` label), or `unknown`. |
-| `files`, `insertions`, `deletions` | Diff stats — **placeholders (`0`) in this slice**, wired in a later change. |
+| `files`, `insertions`, `deletions` | Real PR diff stats, fetched best-effort from the issue's PR (`gh pr list --head issue-<n>`). Degrade to `0` when no PR exists or the fetch fails — never aborts the loop. |
 
 ## Links
 

--- a/packages/ralph/lib/capture-issue-event.js
+++ b/packages/ralph/lib/capture-issue-event.js
@@ -1,8 +1,11 @@
 // Best-effort per-issue event capture entrypoint (CLI), invoked by the bash loop
-// (templates/ralph.sh) AFTER it has computed the issue's label/state. It does
-// NOT re-fetch anything from gh — every input is handed in via env vars. This is
-// a TELEMETRY sidecar: any failure (parser crash, missing file, unwritable dir)
-// MUST exit 0 and never abort or alter the loop.
+// (templates/ralph.sh) AFTER it has computed the issue's label/state. Most inputs
+// are handed in via env vars; the ONE exception is the PR diff stats, which this
+// entrypoint fetches with a single best-effort `gh` call (the issue branch is
+// merged+deleted before the iteration returns, so only the PR retains the diff —
+// see pr-diff-stats.js). That fetch degrades to zeros on any failure. This is a
+// TELEMETRY sidecar: any failure (parser crash, missing file, unwritable dir,
+// failed gh call) MUST exit 0 and never abort or alter the loop.
 //
 // Env-var contract (all read from `env`, default to process.env when invoked as
 // a script):
@@ -23,6 +26,7 @@ import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
 import { buildIssueEvent } from './issue-event.js'
 import { appendIssueEvent } from './issue-metrics.js'
+import { fetchPrDiffStats as realFetchPrDiffStats } from './pr-diff-stats.js'
 
 function readFileSafe(path) {
   if (!path || !existsSync(path)) return ''
@@ -43,7 +47,12 @@ function parseLabels(joined) {
 
 // Best-effort: wrap EVERYTHING; on any error write a short diagnostic and return
 // without throwing. The caller (script guard) exits 0 regardless.
-export function captureIssueEvent({ env = {}, now = Date.now, log = console.error } = {}) {
+export function captureIssueEvent({
+  env = {},
+  now = Date.now,
+  log = console.error,
+  fetchDiffStats = realFetchPrDiffStats,
+} = {}) {
   try {
     const projectRoot = env.PROJECT_ROOT || process.cwd()
     const rawStreamJson = readFileSafe(env.RALPH_RAW_JSONL_PATH)
@@ -51,16 +60,30 @@ export function captureIssueEvent({ env = {}, now = Date.now, log = console.erro
 
     const issueNumber = Number.parseInt(env.RALPH_ISSUE_NUMBER, 10)
     const claudeExitCode = Number.parseInt(env.RALPH_CLAUDE_EXIT, 10)
+    const resolvedIssueNumber = Number.isNaN(issueNumber) ? null : issueNumber
+
+    // Best-effort: never lets a slow/failed gh call abort the loop. The real
+    // fetcher already degrades to zeros internally; this guard also covers an
+    // injected fetcher that throws so the event is still written.
+    let diff = { additions: 0, deletions: 0, changedFiles: 0 }
+    try {
+      diff = fetchDiffStats(resolvedIssueNumber) || diff
+    } catch (e) {
+      log(`capture-issue-event: diff stats unavailable (${e && e.message ? e.message : e})`)
+    }
 
     const event = buildIssueEvent({
       rawStreamJson,
       stderrLog,
-      issueNumber: Number.isNaN(issueNumber) ? null : issueNumber,
+      issueNumber: resolvedIssueNumber,
       runId: env.RALPH_RUN_ID || '',
       claudeExitCode: Number.isNaN(claudeExitCode) ? null : claudeExitCode,
       labels: parseLabels(env.RALPH_ISSUE_LABELS),
       state: env.RALPH_ISSUE_STATE || '',
       ts: now(),
+      files: diff.changedFiles,
+      insertions: diff.additions,
+      deletions: diff.deletions,
     })
 
     appendIssueEvent(projectRoot, event)

--- a/packages/ralph/lib/capture-issue-event.test.js
+++ b/packages/ralph/lib/capture-issue-event.test.js
@@ -29,6 +29,15 @@ function envFor(overrides = {}) {
   }
 }
 
+// Hermetic default: never shell out to gh in tests that don't care about diff
+// stats. Tests that DO care inject their own fetchDiffStats.
+const noGhDiff = () => ({ additions: 0, deletions: 0, changedFiles: 0 })
+
+// captureIssueEvent with a hermetic fetcher injected unless the test overrides it.
+function capture(opts = {}) {
+  return captureIssueEvent({ fetchDiffStats: noGhDiff, ...opts })
+}
+
 function readEvents() {
   const p = metricsPath(workdir)
   if (!existsSync(p)) return []
@@ -67,7 +76,7 @@ describe('captureIssueEvent', () => {
       'all good\n',
     )
 
-    captureIssueEvent({ env: envFor() })
+    capture({ env: envFor() })
 
     const events = readEvents()
     expect(events).toHaveLength(1)
@@ -82,7 +91,7 @@ describe('captureIssueEvent', () => {
 
   it('still appends an event with default/zero fields when the .jsonl is missing', () => {
     // No .jsonl, no stderr log written.
-    expect(() => captureIssueEvent({ env: envFor() })).not.toThrow()
+    expect(() => capture({ env: envFor() })).not.toThrow()
     const events = readEvents()
     expect(events).toHaveLength(1)
     expect(events[0].subtype).toBeNull()
@@ -99,7 +108,7 @@ describe('captureIssueEvent', () => {
       join(workdir, 'logs', 'ralph-issue-98.log'),
       'Credit balance too low\nAuthentication error\n',
     )
-    captureIssueEvent({
+    capture({
       env: envFor({ RALPH_CLAUDE_EXIT: '1', RALPH_ISSUE_LABELS: 'claude-failed' }),
     })
     const events = readEvents()
@@ -110,7 +119,7 @@ describe('captureIssueEvent', () => {
   })
 
   it('parses comma-joined labels into an array for the verdict', () => {
-    captureIssueEvent({
+    capture({
       env: envFor({ RALPH_ISSUE_LABELS: 'bug,claude-failed,enhancement' }),
     })
     const events = readEvents()
@@ -120,9 +129,47 @@ describe('captureIssueEvent', () => {
   it('does not throw and writes nothing fatal when PROJECT_ROOT is unwritable-ish but best-effort', () => {
     // Empty labels + missing files: still must not throw.
     expect(() =>
-      captureIssueEvent({ env: envFor({ RALPH_ISSUE_LABELS: '' }) }),
+      capture({ env: envFor({ RALPH_ISSUE_LABELS: '' }) }),
     ).not.toThrow()
     expect(readEvents()).toHaveLength(1)
+  })
+})
+
+describe('captureIssueEvent — real PR diff stats (#530)', () => {
+  it('records real files/insertions/deletions from the injected fetcher', () => {
+    const fetchDiffStats = (issueNumber) => {
+      expect(issueNumber).toBe(98)
+      return { additions: 120, deletions: 30, changedFiles: 5 }
+    }
+    captureIssueEvent({ env: envFor(), fetchDiffStats })
+    const events = readEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].files).toBe(5)
+    expect(events[0].insertions).toBe(120)
+    expect(events[0].deletions).toBe(30)
+  })
+
+  it('records zeros when the fetcher returns zeros (no PR)', () => {
+    const fetchDiffStats = () => ({ additions: 0, deletions: 0, changedFiles: 0 })
+    captureIssueEvent({ env: envFor(), fetchDiffStats })
+    const events = readEvents()
+    expect(events[0].files).toBe(0)
+    expect(events[0].insertions).toBe(0)
+    expect(events[0].deletions).toBe(0)
+  })
+
+  it('degrades to zeros and never throws when the fetcher itself throws', () => {
+    const fetchDiffStats = () => {
+      throw new Error('gh blew up')
+    }
+    expect(() =>
+      captureIssueEvent({ env: envFor(), fetchDiffStats }),
+    ).not.toThrow()
+    const events = readEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].files).toBe(0)
+    expect(events[0].insertions).toBe(0)
+    expect(events[0].deletions).toBe(0)
   })
 })
 
@@ -133,7 +180,7 @@ describe('QA: captureIssueEvent — best-effort + coercion', () => {
   it('missing .jsonl AND missing stderr => one event with zero/default fields, no throw', () => {
     // beforeEach makes the logs dir but writes no files.
     expect(() =>
-      captureIssueEvent({ env: envFor({ RALPH_ISSUE_LABELS: 'pending-merge' }) }),
+      capture({ env: envFor({ RALPH_ISSUE_LABELS: 'pending-merge' }) }),
     ).not.toThrow()
     const events = readEvents()
     expect(events).toHaveLength(1)
@@ -153,7 +200,7 @@ describe('QA: captureIssueEvent — best-effort + coercion', () => {
       join(workdir, 'logs', 'ralph-issue-98.jsonl'),
       'not json\n{ broken\n\n',
     )
-    expect(() => captureIssueEvent({ env: envFor() })).not.toThrow()
+    expect(() => capture({ env: envFor() })).not.toThrow()
     const events = readEvents()
     expect(events).toHaveLength(1)
     expect(events[0].subtype).toBeNull()
@@ -161,7 +208,7 @@ describe('QA: captureIssueEvent — best-effort + coercion', () => {
   })
 
   it('non-numeric RALPH_ISSUE_NUMBER => issue_number is null (not NaN)', () => {
-    captureIssueEvent({ env: envFor({ RALPH_ISSUE_NUMBER: 'not-a-number' }) })
+    capture({ env: envFor({ RALPH_ISSUE_NUMBER: 'not-a-number' }) })
     const events = readEvents()
     expect(events[0].issue_number).toBeNull()
     // JSON.parse would have turned NaN into null on disk; assert the in-memory
@@ -170,7 +217,7 @@ describe('QA: captureIssueEvent — best-effort + coercion', () => {
   })
 
   it('non-numeric RALPH_CLAUDE_EXIT => claude_exit_code is null (not NaN)', () => {
-    captureIssueEvent({ env: envFor({ RALPH_CLAUDE_EXIT: 'boom' }) })
+    capture({ env: envFor({ RALPH_CLAUDE_EXIT: 'boom' }) })
     const events = readEvents()
     expect(events[0].claude_exit_code).toBeNull()
   })
@@ -179,14 +226,14 @@ describe('QA: captureIssueEvent — best-effort + coercion', () => {
     const env = envFor()
     delete env.RALPH_ISSUE_NUMBER
     delete env.RALPH_CLAUDE_EXIT
-    captureIssueEvent({ env })
+    capture({ env })
     const events = readEvents()
     expect(events[0].issue_number).toBeNull()
     expect(events[0].claude_exit_code).toBeNull()
   })
 
   it('empty RALPH_ISSUE_LABELS + OPEN state => empty labels => unknown verdict', () => {
-    captureIssueEvent({
+    capture({
       env: envFor({ RALPH_ISSUE_LABELS: '', RALPH_ISSUE_STATE: 'OPEN' }),
     })
     const events = readEvents()
@@ -194,7 +241,7 @@ describe('QA: captureIssueEvent — best-effort + coercion', () => {
   })
 
   it('empty RALPH_ISSUE_LABELS but CLOSED state => pass', () => {
-    captureIssueEvent({
+    capture({
       env: envFor({ RALPH_ISSUE_LABELS: '', RALPH_ISSUE_STATE: 'CLOSED' }),
     })
     const events = readEvents()
@@ -202,16 +249,132 @@ describe('QA: captureIssueEvent — best-effort + coercion', () => {
   })
 
   it('uses the injected now() for ts (deterministic)', () => {
-    captureIssueEvent({ env: envFor(), now: () => 1234567890 })
+    capture({ env: envFor(), now: () => 1234567890 })
     const events = readEvents()
     expect(events[0].ts).toBe(1234567890)
   })
 
   it('whitespace-padded labels are trimmed and parsed', () => {
-    captureIssueEvent({
+    capture({
       env: envFor({ RALPH_ISSUE_LABELS: '  bug , claude-failed , enhancement ' }),
     })
     const events = readEvents()
     expect(events[0].verdict).toBe('fail')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation: diff-stats fetcher wiring (#530) — resolved issue number,
+// throwing-fetcher diagnostics, realistic numbers, fetcher contract.
+// ---------------------------------------------------------------------------
+describe('QA: captureIssueEvent — diff-stats fetcher wiring (#530)', () => {
+  it('passes the RESOLVED numeric issue number to the fetcher', () => {
+    let received = 'unset'
+    const fetchDiffStats = (n) => {
+      received = n
+      return { additions: 0, deletions: 0, changedFiles: 0 }
+    }
+    captureIssueEvent({ env: envFor({ RALPH_ISSUE_NUMBER: '530' }), fetchDiffStats })
+    expect(received).toBe(530)
+  })
+
+  it('passes NULL (not NaN) to the fetcher when RALPH_ISSUE_NUMBER is non-numeric', () => {
+    let received = 'unset'
+    const fetchDiffStats = (n) => {
+      received = n
+      return { additions: 0, deletions: 0, changedFiles: 0 }
+    }
+    captureIssueEvent({
+      env: envFor({ RALPH_ISSUE_NUMBER: 'not-a-number' }),
+      fetchDiffStats,
+    })
+    expect(received).toBeNull()
+  })
+
+  it('passes NULL to the fetcher when RALPH_ISSUE_NUMBER is missing entirely', () => {
+    let received = 'unset'
+    const fetchDiffStats = (n) => {
+      received = n
+      return { additions: 0, deletions: 0, changedFiles: 0 }
+    }
+    const env = envFor()
+    delete env.RALPH_ISSUE_NUMBER
+    captureIssueEvent({ env, fetchDiffStats })
+    expect(received).toBeNull()
+  })
+
+  it('invokes the fetcher exactly once', () => {
+    let calls = 0
+    const fetchDiffStats = () => {
+      calls++
+      return { additions: 1, deletions: 1, changedFiles: 1 }
+    }
+    captureIssueEvent({ env: envFor(), fetchDiffStats })
+    expect(calls).toBe(1)
+  })
+
+  it('flows large/realistic diff numbers into files/insertions/deletions', () => {
+    const fetchDiffStats = () => ({
+      additions: 12_345,
+      deletions: 6_789,
+      changedFiles: 87,
+    })
+    captureIssueEvent({ env: envFor(), fetchDiffStats })
+    const events = readEvents()
+    expect(events[0].insertions).toBe(12_345)
+    expect(events[0].deletions).toBe(6_789)
+    expect(events[0].files).toBe(87)
+  })
+
+  it('correctly maps changedFiles->files (not additions->files)', () => {
+    // Regression guard against a field-mapping swap.
+    const fetchDiffStats = () => ({
+      additions: 100,
+      deletions: 10,
+      changedFiles: 3,
+    })
+    captureIssueEvent({ env: envFor(), fetchDiffStats })
+    const events = readEvents()
+    expect(events[0].files).toBe(3)
+    expect(events[0].insertions).toBe(100)
+    expect(events[0].deletions).toBe(10)
+  })
+
+  it('throwing fetcher => event written with zeros AND a diagnostic logged', () => {
+    const logged = []
+    const log = (msg) => logged.push(msg)
+    const fetchDiffStats = () => {
+      throw new Error('gh blew up')
+    }
+    expect(() =>
+      captureIssueEvent({ env: envFor(), fetchDiffStats, log }),
+    ).not.toThrow()
+    const events = readEvents()
+    expect(events).toHaveLength(1)
+    expect(events[0].files).toBe(0)
+    expect(events[0].insertions).toBe(0)
+    expect(events[0].deletions).toBe(0)
+    // diagnostic was emitted via the injected log spy
+    expect(logged.length).toBeGreaterThanOrEqual(1)
+    expect(logged.some((m) => /diff stats unavailable/.test(m))).toBe(true)
+    expect(logged.some((m) => /gh blew up/.test(m))).toBe(true)
+  })
+
+  it('fetcher returning null/undefined => event written with zero defaults, no throw', () => {
+    const events1 = (() => {
+      captureIssueEvent({ env: envFor(), fetchDiffStats: () => null })
+      return readEvents()
+    })()
+    expect(events1[0].files).toBe(0)
+    expect(events1[0].insertions).toBe(0)
+    expect(events1[0].deletions).toBe(0)
+  })
+
+  it('does NOT log a diagnostic on the happy path (no spurious noise)', () => {
+    const logged = []
+    const log = (msg) => logged.push(msg)
+    const fetchDiffStats = () => ({ additions: 1, deletions: 1, changedFiles: 1 })
+    captureIssueEvent({ env: envFor(), fetchDiffStats, log })
+    expect(logged).toHaveLength(0)
   })
 })

--- a/packages/ralph/lib/issue-event.js
+++ b/packages/ralph/lib/issue-event.js
@@ -71,6 +71,9 @@ export function buildIssueEvent(input) {
     labels = [],
     state,
     ts,
+    files = 0,
+    insertions = 0,
+    deletions = 0,
   } = input || {}
 
   const result = lastResultLine(rawStreamJson)
@@ -87,9 +90,9 @@ export function buildIssueEvent(input) {
     claude_exit_code: claudeExitCode,
     stderr_error_signals: countErrorSignals(stderrLog),
     verdict: computeVerdict(labels, state),
-    // diff fields — placeholders for this slice (#529).
-    files: 0,
-    insertions: 0,
-    deletions: 0,
+    // Real PR diff stats (#530), handed in by the entrypoint; default to 0.
+    files,
+    insertions,
+    deletions,
   }
 }

--- a/packages/ralph/lib/issue-event.test.js
+++ b/packages/ralph/lib/issue-event.test.js
@@ -386,3 +386,44 @@ describe('buildIssueEvent — passthrough + placeholders', () => {
     expect(e.deletions).toBe(0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#530): buildIssueEvent now READS files/insertions/deletions
+// from input — verify they flow through and edge values are preserved.
+// ---------------------------------------------------------------------------
+describe('QA: buildIssueEvent — diff stats passthrough (#530)', () => {
+  it('passes input files/insertions/deletions straight through to the event', () => {
+    const e = buildIssueEvent(
+      baseInput({ files: 5, insertions: 120, deletions: 30 }),
+    )
+    expect(e.files).toBe(5)
+    expect(e.insertions).toBe(120)
+    expect(e.deletions).toBe(30)
+  })
+
+  it('defaults each diff field independently to 0 when only some are provided', () => {
+    const e = buildIssueEvent(baseInput({ insertions: 9 }))
+    expect(e.files).toBe(0)
+    expect(e.insertions).toBe(9)
+    expect(e.deletions).toBe(0)
+  })
+
+  it('explicit 0 diff values stay 0 (real zero, not undefined/NaN)', () => {
+    const e = buildIssueEvent(
+      baseInput({ files: 0, insertions: 0, deletions: 0 }),
+    )
+    for (const v of [e.files, e.insertions, e.deletions]) {
+      expect(v).toBe(0)
+      expect(Number.isNaN(v)).toBe(false)
+    }
+  })
+
+  it('preserves large diff numbers without truncation', () => {
+    const e = buildIssueEvent(
+      baseInput({ files: 87, insertions: 12_345, deletions: 6_789 }),
+    )
+    expect(e.files).toBe(87)
+    expect(e.insertions).toBe(12_345)
+    expect(e.deletions).toBe(6_789)
+  })
+})

--- a/packages/ralph/lib/pr-diff-stats.js
+++ b/packages/ralph/lib/pr-diff-stats.js
@@ -1,0 +1,49 @@
+// Best-effort fetcher for real PR diff stats. The issue branch `issue-<n>` is
+// auto-merged and DELETED before the iteration returns, so a local `git diff`
+// reports zeros on exactly the successful issues. The PR retains its stats after
+// merge+delete and is addressable by the deterministic `issue-<n>` head ref, so
+// we query gh instead:
+//   gh pr list --head issue-<n> --state all --json additions,deletions,changedFiles
+//
+// This is TELEMETRY: any failure (exec throws / non-zero gh exit / unparseable
+// JSON / null issueNumber / no PR) degrades to zeros and NEVER throws.
+//
+// Follows the injectable-dependency pattern used across this package: callers
+// may pass an `exec(args) => stdoutString` impl; we fall back to a real
+// execFileSync against the `gh` binary when none is given.
+
+import { execFileSync } from 'node:child_process'
+
+const ZERO = { additions: 0, deletions: 0, changedFiles: 0 }
+
+// Real exec: runs `gh <args>` (argv array, NOT a shell string) and returns
+// stdout as a utf8 string.
+function realExec(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' })
+}
+
+export function fetchPrDiffStats(issueNumber, { exec = realExec } = {}) {
+  if (issueNumber == null) return { ...ZERO }
+  try {
+    const stdout = exec([
+      'pr',
+      'list',
+      '--head',
+      `issue-${issueNumber}`,
+      '--state',
+      'all',
+      '--json',
+      'additions,deletions,changedFiles',
+    ])
+    const parsed = JSON.parse(stdout)
+    if (!Array.isArray(parsed) || parsed.length === 0) return { ...ZERO }
+    const pr = parsed[0] || {}
+    return {
+      additions: pr.additions ?? 0,
+      deletions: pr.deletions ?? 0,
+      changedFiles: pr.changedFiles ?? 0,
+    }
+  } catch {
+    return { ...ZERO }
+  }
+}

--- a/packages/ralph/lib/pr-diff-stats.test.js
+++ b/packages/ralph/lib/pr-diff-stats.test.js
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest'
+import { fetchPrDiffStats } from './pr-diff-stats.js'
+
+const ZERO = { additions: 0, deletions: 0, changedFiles: 0 }
+
+describe('fetchPrDiffStats', () => {
+  it('parses additions/deletions/changedFiles from the first PR in the JSON array', () => {
+    const exec = () =>
+      JSON.stringify([
+        { additions: 42, deletions: 7, changedFiles: 3 },
+        { additions: 999, deletions: 999, changedFiles: 999 },
+      ])
+    const stats = fetchPrDiffStats(530, { exec })
+    expect(stats).toEqual({ additions: 42, deletions: 7, changedFiles: 3 })
+  })
+
+  it('passes the deterministic issue-<n> head ref and --state all to gh', () => {
+    let seenArgs
+    const exec = (args) => {
+      seenArgs = args
+      return JSON.stringify([{ additions: 1, deletions: 2, changedFiles: 3 }])
+    }
+    fetchPrDiffStats(530, { exec })
+    // exec receives the full gh argv (excluding the `gh` binary itself).
+    const joined = seenArgs.join(' ')
+    expect(joined).toContain('pr list')
+    expect(joined).toContain('--head issue-530')
+    expect(joined).toContain('--state all')
+    expect(joined).toContain('additions,deletions,changedFiles')
+  })
+
+  it('returns zeros when gh returns an empty array (no PR for the ref)', () => {
+    const exec = () => '[]'
+    expect(fetchPrDiffStats(530, { exec })).toEqual(ZERO)
+  })
+
+  it('returns zeros when exec throws (gh non-zero exit / not found)', () => {
+    const exec = () => {
+      throw new Error('gh: command failed')
+    }
+    expect(fetchPrDiffStats(530, { exec })).toEqual(ZERO)
+  })
+
+  it('returns zeros when gh emits unparseable JSON', () => {
+    const exec = () => 'not json at all'
+    expect(fetchPrDiffStats(530, { exec })).toEqual(ZERO)
+  })
+
+  it('returns zeros when issueNumber is null', () => {
+    let called = false
+    const exec = () => {
+      called = true
+      return '[]'
+    }
+    expect(fetchPrDiffStats(null, { exec })).toEqual(ZERO)
+    expect(called).toBe(false)
+  })
+
+  it('returns zeros when the parsed JSON is not an array', () => {
+    const exec = () => JSON.stringify({ additions: 5 })
+    expect(fetchPrDiffStats(530, { exec })).toEqual(ZERO)
+  })
+
+  it('defaults missing PR fields to 0', () => {
+    const exec = () => JSON.stringify([{ additions: 5 }])
+    expect(fetchPrDiffStats(530, { exec })).toEqual({
+      additions: 5,
+      deletions: 0,
+      changedFiles: 0,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation: adversarial fetcher inputs + exact argv regression guard +
+// issueNumber edge values. Hermetic — every exec is a spy, never real `gh`.
+// ---------------------------------------------------------------------------
+describe('QA: fetchPrDiffStats — exact gh argv regression guard', () => {
+  it('calls exec with EXACTLY the expected argv (command shape lock)', () => {
+    let seen
+    const exec = (args) => {
+      seen = args
+      return '[]'
+    }
+    fetchPrDiffStats(530, { exec })
+    expect(seen).toEqual([
+      'pr',
+      'list',
+      '--head',
+      'issue-530',
+      '--state',
+      'all',
+      '--json',
+      'additions,deletions,changedFiles',
+    ])
+  })
+
+  it('is invoked exactly once per call', () => {
+    let calls = 0
+    const exec = () => {
+      calls++
+      return '[]'
+    }
+    fetchPrDiffStats(530, { exec })
+    expect(calls).toBe(1)
+  })
+})
+
+describe('QA: fetchPrDiffStats — multiple PRs / determinism', () => {
+  it('deterministically takes the FIRST PR when several are returned', () => {
+    const exec = () =>
+      JSON.stringify([
+        { additions: 1, deletions: 1, changedFiles: 1 },
+        { additions: 2, deletions: 2, changedFiles: 2 },
+        { additions: 3, deletions: 3, changedFiles: 3 },
+      ])
+    expect(fetchPrDiffStats(530, { exec })).toEqual({
+      additions: 1,
+      deletions: 1,
+      changedFiles: 1,
+    })
+  })
+
+  it('first element being null falls back to all zeros (pr || {})', () => {
+    const exec = () => JSON.stringify([null, { additions: 9 }])
+    expect(fetchPrDiffStats(530, { exec })).toEqual(ZERO)
+  })
+})
+
+describe('QA: fetchPrDiffStats — partial / wrong-typed fields', () => {
+  it('only deletions present => deletions read, additions/changedFiles default 0', () => {
+    const exec = () => JSON.stringify([{ deletions: 8 }])
+    expect(fetchPrDiffStats(530, { exec })).toEqual({
+      additions: 0,
+      deletions: 8,
+      changedFiles: 0,
+    })
+  })
+
+  it('only changedFiles present => changedFiles read, others default 0', () => {
+    const exec = () => JSON.stringify([{ changedFiles: 4 }])
+    expect(fetchPrDiffStats(530, { exec })).toEqual({
+      additions: 0,
+      deletions: 0,
+      changedFiles: 4,
+    })
+  })
+
+  it('explicit null fields coalesce to 0 (?? guards null)', () => {
+    const exec = () =>
+      JSON.stringify([{ additions: null, deletions: null, changedFiles: null }])
+    expect(fetchPrDiffStats(530, { exec })).toEqual(ZERO)
+  })
+
+  it('explicit 0 fields stay 0 (real zero distinguished from absent)', () => {
+    const exec = () =>
+      JSON.stringify([{ additions: 0, deletions: 0, changedFiles: 0 }])
+    expect(fetchPrDiffStats(530, { exec })).toEqual(ZERO)
+  })
+
+  it('string-typed numbers ("5") pass through as-is (no coercion guarantee)', () => {
+    // Documents CURRENT behavior: ?? only guards null/undefined, NOT type.
+    // gh emits real numbers, so this is a contract note rather than a defect.
+    const exec = () =>
+      JSON.stringify([{ additions: '5', deletions: '2', changedFiles: '1' }])
+    expect(fetchPrDiffStats(530, { exec })).toEqual({
+      additions: '5',
+      deletions: '2',
+      changedFiles: '1',
+    })
+  })
+
+  it('float additions pass through unchanged (no rounding)', () => {
+    const exec = () =>
+      JSON.stringify([{ additions: 5.5, deletions: 2, changedFiles: 1 }])
+    expect(fetchPrDiffStats(530, { exec })).toEqual({
+      additions: 5.5,
+      deletions: 2,
+      changedFiles: 1,
+    })
+  })
+})
+
+describe('QA: fetchPrDiffStats — malformed exec output', () => {
+  it('returns zeros on empty string', () => {
+    expect(fetchPrDiffStats(530, { exec: () => '' })).toEqual(ZERO)
+  })
+
+  it('returns zeros on whitespace-only output', () => {
+    expect(fetchPrDiffStats(530, { exec: () => '   \n\t ' })).toEqual(ZERO)
+  })
+
+  it('returns zeros when JSON is a bare number', () => {
+    expect(fetchPrDiffStats(530, { exec: () => '42' })).toEqual(ZERO)
+  })
+
+  it('returns zeros when JSON is the literal null', () => {
+    expect(fetchPrDiffStats(530, { exec: () => 'null' })).toEqual(ZERO)
+  })
+
+  it('returns zeros when JSON is a string literal', () => {
+    expect(fetchPrDiffStats(530, { exec: () => '"hello"' })).toEqual(ZERO)
+  })
+
+  it('returns zeros when exec returns a non-string (undefined) — JSON.parse throws', () => {
+    expect(fetchPrDiffStats(530, { exec: () => undefined })).toEqual(ZERO)
+  })
+
+  it('never throws regardless of exec output', () => {
+    const garbageOutputs = ['', '   ', 'null', '{}', '[', '[}', '"x"', '42', undefined]
+    for (const out of garbageOutputs) {
+      expect(() => fetchPrDiffStats(530, { exec: () => out })).not.toThrow()
+    }
+  })
+})
+
+describe('QA: fetchPrDiffStats — issueNumber edge values', () => {
+  it('issueNumber 0 DOES attempt the fetch (0 is not null)', () => {
+    let seen
+    const exec = (args) => {
+      seen = args
+      return JSON.stringify([{ additions: 7, deletions: 1, changedFiles: 2 }])
+    }
+    const stats = fetchPrDiffStats(0, { exec })
+    expect(seen).toContain('issue-0')
+    expect(stats).toEqual({ additions: 7, deletions: 1, changedFiles: 2 })
+  })
+
+  it('issueNumber undefined => zeros, exec NOT called (== null catches undefined)', () => {
+    let called = false
+    const exec = () => {
+      called = true
+      return '[]'
+    }
+    expect(fetchPrDiffStats(undefined, { exec })).toEqual(ZERO)
+    expect(called).toBe(false)
+  })
+
+  it('issueNumber NaN DOES attempt the fetch and builds an issue-NaN ref', () => {
+    // NaN is not == null, so the guard does not short-circuit. Documents that
+    // the caller (capture-issue-event) is responsible for passing null, not NaN.
+    let seen
+    const exec = (args) => {
+      seen = args
+      return '[]'
+    }
+    fetchPrDiffStats(NaN, { exec })
+    expect(seen).toContain('issue-NaN')
+  })
+
+  it('negative issueNumber builds an issue--<n> ref and fetches', () => {
+    let seen
+    const exec = (args) => {
+      seen = args
+      return '[]'
+    }
+    fetchPrDiffStats(-5, { exec })
+    expect(seen).toContain('issue--5')
+  })
+
+  it('numeric-string issueNumber interpolates into the head ref', () => {
+    let seen
+    const exec = (args) => {
+      seen = args
+      return '[]'
+    }
+    fetchPrDiffStats('77', { exec })
+    expect(seen).toContain('issue-77')
+  })
+})


### PR DESCRIPTION
Closes #530

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/pr-diff-stats.test.js` (new), `packages/ralph/lib/capture-issue-event.test.js`, `packages/ralph/lib/issue-event.test.js`
- Before implementation (red): `pr-diff-stats.test.js` failed to load ("Does the file exist?" — module not yet created); `capture-issue-event.test.js > records real files/insertions/deletions from the injected fetcher` failed with `expected +0 to be 5` (stats not wired into the event)
- After implementation (green): all 643 tests pass (30 files)

A thin fetcher `packages/ralph/lib/pr-diff-stats.js` wraps `gh pr list --head issue-<n> --state all --json additions,deletions,changedFiles` with an injectable `exec`, returning `{additions, deletions, changedFiles}` or zeros when there is no PR / any failure. `capture-issue-event.js` calls it (injectable as `fetchDiffStats`) and maps `changedFiles→files`, `additions→insertions`, `deletions→deletions` into the `RALPH_ISSUE_EVENT` line. `issue-event.js` now emits the real diff fields (default 0) instead of the #529 placeholders. The PR is queried rather than a local `git diff` because the `issue-<n>` branch is merged+deleted before the iteration returns. No template change needed — the entrypoint already receives `RALPH_ISSUE_NUMBER` via env.

## QA scenarios added
- 35 hermetic adversarial tests (injected spies, no real `gh`): exact gh argv regression lock; multiple PRs → deterministic first; partial PR objects → per-field 0 default; wrong types (string/float/null) pass-through contract; malformed exec output (empty/whitespace/bare-number/`null`/garbage) → zeros; issueNumber edges (`0` fetches, `undefined` skips via `== null`, `NaN`/negative/numeric-string interpolate); integration: large numbers flow through, throwing fetcher → event still written with zeros + diagnostic logged, fetcher receives resolved null on non-numeric issue number
- Bugs exposed: none — implementation held

## Review verdict
- APPROVE. New module is a genuine boundary (hides the merged-branch-zeros rationale), follows the package's injectable-dependency convention, and the inner/outer try/catch double-guard is justified defense-in-depth across the injection seam (each covers a distinct failure class). Field mapping is correct and regression-tested. No blocking findings.

## Docs updated
- `packages/ralph/README.md` — per-issue telemetry schema table: the `files`/`insertions`/`deletions` row no longer says "placeholders (`0`) in this slice"; now documents real best-effort PR diff stats that degrade to 0 when no PR exists or the fetch fails

## Notes
Tier 1 / Standard run (full team: dev → QA → review → writer). Best-effort telemetry contract preserved end-to-end: a slow/failed `gh` call degrades to zeros and never aborts the loop.