### PR TITLE
fix(ralph): emit run event so ralph start runs reach the 24h rollup

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -285,6 +285,13 @@ directories, etc.), the message degrades to
 `❌ Ralph 24h summary failed: <reason>` so silence never reads as
 healthy.
 
+The cycle count covers **both** scheduled `ralph cycle` passes and
+interactive `ralph start` runs. Each finished run appends one run event
+to `logs/ralph-cycle.out.log`, which the rollup aggregates; an
+interactive `ralph start` therefore shows up in the 24h summary just
+like an automated cycle does. (`ralph cycle` itself stays the sole
+emitter for the scheduled path, so the two never double-count.)
+
 The schedule defaults to `09:00` in your local timezone. Override it
 with `RALPH_DAILY_SUMMARY_TIME` in `.env.local`:
 

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -167,6 +167,10 @@ fi
 # ---------------------------------------------------------------------------
 
 START=$(date +%s)
+# Single source of truth for the run_id (`<session>-<start-epoch>`). Both the
+# per-issue capture and the end-of-run RALPH_CYCLE_EVENT reference this, so the
+# two can never drift apart.
+RALPH_RUN_ID="${RALPH_TMUX_SESSION:-ralph}-${START}"
 successes=()
 failures=()
 claude_failed=0
@@ -203,7 +207,7 @@ while :; do
   # .ralph/metrics/issues.jsonl. Runs once per iteration regardless of outcome.
   # Telemetry failure MUST NEVER abort or alter the loop, hence `|| true`.
   RALPH_ISSUE_NUMBER="$num" \
-    RALPH_RUN_ID="${RALPH_TMUX_SESSION:-ralph}-${START}" \
+    RALPH_RUN_ID="$RALPH_RUN_ID" \
     RALPH_CLAUDE_EXIT="$claude_failed" \
     RALPH_ISSUE_LABELS="$labels" \
     RALPH_ISSUE_STATE="$state" \
@@ -268,6 +272,20 @@ echo "$msg"
 if [ -n "$RALPH_ONCE_MODE" ]; then
   exit 0
 fi
+
+# --- Run-event telemetry (issue #531) -------------------------------------
+# Normal (interactive `ralph start`) mode only. The automated path (`ralph
+# cycle`) is the sole emitter for itself and runs detached, so its stdout never
+# reaches logs/ralph-cycle.out.log — the file lib/heartbeat.js globs for the 24h
+# rollup. Append exactly one RALPH_CYCLE_EVENT line carrying the loop's REAL
+# bash-computed counts + the same run_id used by the per-issue capture, so
+# interactive runs are counted too. Purely additive; same tag/file/fields the
+# heartbeat already parses. Best-effort: `|| true` so it NEVER aborts the loop.
+run_event_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+printf 'RALPH_CYCLE_EVENT {"ts":"%s","status":"%s","ok":%d,"failed":%d,"durationMin":%d,"processed":%d,"run_id":"%s"}\n' \
+  "$run_event_ts" "$status" "$ok_count" "$fail_count" "$duration_min" "$((ok_count + fail_count))" "$RALPH_RUN_ID" \
+  >> logs/ralph-cycle.out.log || true
+# ---------------------------------------------------------------------------
 
 # Re-source .env.local so credentials added mid-run are picked up.
 if [ -f ./.env.local ]; then

--- a/packages/ralph/test/loop.test.js
+++ b/packages/ralph/test/loop.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, existsSync, r
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { templatePath } from '../lib/paths.js'
+import { summarizeLast24h } from '../lib/heartbeat.js'
 
 const RALPH_TEMPLATE = templatePath('ralph.sh')
 // Resolve the REAL node binary so the stub can delegate the capture-issue-event
@@ -28,7 +29,7 @@ function writeStub(name, body) {
   chmodSync(p, 0o755)
 }
 
-function runLoop({ timeout = 15000 } = {}) {
+function runLoop({ timeout = 15000, once = false } = {}) {
   // Prepend our stub bin to PATH; keep the real bash + coreutils available.
   const env = {
     ...process.env,
@@ -38,12 +39,22 @@ function runLoop({ timeout = 15000 } = {}) {
     CALLMEBOT_KEY: '',
     WHATSAPP_PHONE: '',
   }
-  return spawnSync('bash', [RALPH_TEMPLATE], {
+  const args = once ? [RALPH_TEMPLATE, '--once'] : [RALPH_TEMPLATE]
+  return spawnSync('bash', args, {
     cwd: workdir,
     env,
     timeout,
     encoding: 'utf8',
   })
+}
+
+// Collect the RALPH_CYCLE_EVENT lines the loop appended to logs/ralph-cycle.out.log.
+function readCycleEvents() {
+  const f = join(workdir, 'logs', 'ralph-cycle.out.log')
+  if (!existsSync(f)) return []
+  return readFileSync(f, 'utf8')
+    .split('\n')
+    .filter((l) => l.includes('RALPH_CYCLE_EVENT'))
 }
 
 beforeEach(() => {
@@ -173,6 +184,49 @@ exit 0
   writeStub('curl', `#!/bin/bash\nexit 0\n`)
 })
 
+// Reconfigure the gh/claude stubs so the queue drains cleanly: `count` issues,
+// each selected once and reported CLOSED (success). Shared by the happy-path,
+// cycle-event, and once-mode tests.
+function seedHappyPath(count = 3) {
+  writeStub(
+    'claude',
+    `#!/bin/bash
+cat > /dev/null
+echo '{"type":"result","subtype":"success"}'
+exit 0
+`
+  )
+  writeFileSync(join(workdir, 'count.txt'), String(count))
+  writeStub(
+    'gh',
+    `#!/bin/bash
+CNT_FILE="${join(workdir, 'count.txt')}"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  cnt=$(cat "$CNT_FILE")
+  case "$*" in
+    *sort:created-asc*)
+      echo "$cnt"      # use the count as the issue number (unique each time)
+      echo "$((cnt - 1))" > "$CNT_FILE"   # simulate it getting resolved
+      ;;
+    *)
+      echo "$cnt"
+      ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *labels*) echo "" ;;
+    *state*)  echo "CLOSED" ;;
+    *)        echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+  )
+}
+
 afterEach(() => {
   if (workdir && existsSync(workdir)) {
     rmSync(workdir, { recursive: true, force: true })
@@ -272,5 +326,228 @@ exit 0
       .map((l) => JSON.parse(l.slice('RALPH_ISSUE_EVENT '.length)).issue_number)
       .sort()
     expect(issueNums).toEqual([1, 2, 3])
+  })
+})
+
+describe('ralph.sh run-event telemetry — issue #531 (24h rollup reach)', () => {
+  it('normal mode: appends exactly one RALPH_CYCLE_EVENT with real counts + run_id', () => {
+    seedHappyPath(3)
+
+    const res = runLoop({ timeout: 15000 })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+
+    const cycleEvents = readCycleEvents()
+    // Exactly ONE run event, so the 24h rollup counts an interactive run once.
+    expect(
+      cycleEvents.length,
+      `expected exactly one RALPH_CYCLE_EVENT, got:\n${cycleEvents.join('\n')}`,
+    ).toBe(1)
+
+    const idx = cycleEvents[0].indexOf('RALPH_CYCLE_EVENT')
+    const json = cycleEvents[0].slice(idx + 'RALPH_CYCLE_EVENT'.length).trim()
+    const ev = JSON.parse(json)
+
+    // Real bash-computed counts: 3 issues resolved, none failed.
+    expect(ev.ok).toBe(3)
+    expect(ev.failed).toBe(0)
+    expect(ev.status).toBe('success')
+    expect(ev.processed).toBe(3)
+    expect(typeof ev.durationMin).toBe('number')
+    expect(Number.isFinite(Date.parse(ev.ts))).toBe(true)
+    expect(ev.run_id).toMatch(/^ralph-test-\d+$/)
+
+    // Consistency: the run_id must equal the run_id used by the per-issue
+    // capture events from the SAME run.
+    const metricsFile = join(workdir, '.ralph', 'metrics', 'issues.jsonl')
+    const issueRunIds = readFileSync(metricsFile, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l.slice('RALPH_ISSUE_EVENT '.length)).run_id)
+    for (const rid of issueRunIds) {
+      expect(rid).toBe(ev.run_id)
+    }
+  })
+
+  // Parse the single RALPH_CYCLE_EVENT JSON object out of the collected lines.
+  function parseSingleCycleEvent(lines) {
+    expect(lines.length, `expected exactly one RALPH_CYCLE_EVENT, got:\n${lines.join('\n')}`).toBe(1)
+    const idx = lines[0].indexOf('RALPH_CYCLE_EVENT')
+    return JSON.parse(lines[0].slice(idx + 'RALPH_CYCLE_EVENT'.length).trim())
+  }
+
+  it('failure path: STILL emits a RALPH_CYCLE_EVENT with status:"failed" when every issue fails', () => {
+    // Use the beforeEach default stubs: claude exits non-zero, #98 stays OPEN
+    // with no exclusion label, so the zero-progress guard fires and records the
+    // issue as a failure. Telemetry must fire regardless of run outcome.
+    const res = runLoop({ timeout: 15000 })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+
+    const ev = parseSingleCycleEvent(readCycleEvents())
+    // No issue ever resolved -> all failures, status must be "failed".
+    expect(ev.status).toBe('failed')
+    expect(ev.ok).toBe(0)
+    expect(ev.failed).toBeGreaterThanOrEqual(1)
+    // processed is the sum of ok + failed and must be internally consistent.
+    expect(ev.processed).toBe(ev.ok + ev.failed)
+    expect(ev.run_id).toMatch(/^ralph-test-\d+$/)
+    expect(Number.isFinite(Date.parse(ev.ts))).toBe(true)
+  })
+
+  it('partial path: emits status:"partial" with processed = ok + failed on a mixed run', () => {
+    // Drive a mixed run: the FIRST selected issue (#2) closes (success); the
+    // SECOND (#1) stays OPEN with no label and claude fails -> it gets re-
+    // selected once and the zero-progress guard records it as a failure and
+    // breaks. Net: 1 ok, >=1 failed -> status "partial".
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+# Succeed for the high-numbered issue, fail for the rest.
+exit 0
+`,
+    )
+    writeFileSync(join(workdir, 'count.txt'), '2')
+    writeStub(
+      'gh',
+      `#!/bin/bash
+CNT_FILE="${join(workdir, 'count.txt')}"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  cnt=$(cat "$CNT_FILE")
+  case "$*" in
+    *sort:created-asc*)
+      echo "$cnt"
+      # Only the first issue (#2) resolves; once we reach #1, it never closes,
+      # so the count stays at 1 (stuck) -> guard fires on re-selection.
+      if [ "$cnt" -gt 1 ]; then echo "$((cnt - 1))" > "$CNT_FILE"; fi
+      ;;
+    *)
+      echo "$cnt"
+      ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  # Determine which issue we're viewing from the args.
+  num=""
+  for a in "$@"; do case "$a" in [0-9]*) num="$a" ;; esac; done
+  case "$*" in
+    *labels*) echo "" ;;
+    *state*)
+      if [ "$num" = "2" ]; then echo "CLOSED"; else echo "OPEN"; fi
+      ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const res = runLoop({ timeout: 15000 })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+
+    const ev = parseSingleCycleEvent(readCycleEvents())
+    expect(ev.status).toBe('partial')
+    expect(ev.ok).toBeGreaterThanOrEqual(1)
+    expect(ev.failed).toBeGreaterThanOrEqual(1)
+    expect(ev.processed).toBe(ev.ok + ev.failed)
+  })
+
+  it('appends (does not overwrite) when a prior RALPH_CYCLE_EVENT already exists in the log', () => {
+    // The heartbeat SUMS multiple events across cycles, so a new run must append
+    // rather than truncate. Pre-seed a prior event line from an earlier cycle.
+    const priorEvent =
+      'RALPH_CYCLE_EVENT {"ts":"2020-01-01T00:00:00Z","status":"success","ok":7,"failed":0,"durationMin":1,"processed":7,"run_id":"prior-1"}'
+    writeFileSync(join(workdir, 'logs', 'ralph-cycle.out.log'), priorEvent + '\n')
+
+    seedHappyPath(3)
+    const res = runLoop({ timeout: 15000 })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+
+    const lines = readCycleEvents()
+    // Two events now: the prior one intact + the freshly appended one.
+    expect(lines.length, `expected 2 events (prior + new), got:\n${lines.join('\n')}`).toBe(2)
+    // Prior line must be byte-for-byte intact (not clobbered/truncated).
+    expect(lines[0]).toBe(priorEvent)
+    // New line is the current run's success event.
+    const idx = lines[1].indexOf('RALPH_CYCLE_EVENT')
+    const fresh = JSON.parse(lines[1].slice(idx + 'RALPH_CYCLE_EVENT'.length).trim())
+    expect(fresh.status).toBe('success')
+    expect(fresh.ok).toBe(3)
+    expect(fresh.run_id).not.toBe('prior-1')
+  })
+
+  it('heartbeat round-trip: the emitted line is parsed identically by summarizeLast24h', () => {
+    // The real integration risk: the consumer (lib/heartbeat.js) must parse the
+    // exact line ralph.sh emits. Run a real cycle, then feed logs/ through the
+    // real parser with a clock pinned just after emission so it's within 24h.
+    seedHappyPath(3)
+    const res = runLoop({ timeout: 15000 })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+
+    const ev = parseSingleCycleEvent(readCycleEvents())
+    // Pin clock to the event's own timestamp so it's deterministically within 24h.
+    const clock = () => Date.parse(ev.ts) + 1000
+
+    const summary = summarizeLast24h({
+      logDir: join(workdir, 'logs'),
+      clock,
+    })
+
+    // The consumer must count exactly this one cycle with matching tallies.
+    expect(summary.cycles).toBe(1)
+    expect(summary.ok).toBe(3)
+    expect(summary.failed).toBe(0)
+    expect(summary.totalIssues).toBe(3)
+    expect(summary.abortedCycles).toBe(0)
+    // durationMin from the event must round-trip into durations[].
+    expect(summary.durations).toEqual([ev.durationMin])
+    // lastCycle echoes the emitted event fields (run_id round-trips too).
+    expect(summary.lastCycle.run_id).toBe(ev.run_id)
+    expect(summary.lastCycle.status).toBe('success')
+  })
+
+  it('heartbeat round-trip: failure cycle counts as a failed cycle (ok=0, failed>=1)', () => {
+    // A failed run's emitted event must also be consumed correctly: it is NOT
+    // an aborted-status event (those are preflight/lock/tmux), so it counts as a
+    // real cycle with failed issues. Uses the beforeEach default failure stubs.
+    const res = runLoop({ timeout: 15000 })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+
+    const ev = parseSingleCycleEvent(readCycleEvents())
+    const clock = () => Date.parse(ev.ts) + 1000
+
+    const summary = summarizeLast24h({ logDir: join(workdir, 'logs'), clock })
+    expect(summary.cycles).toBe(1)
+    expect(summary.ok).toBe(0)
+    expect(summary.failed).toBe(ev.failed)
+    expect(summary.failed).toBeGreaterThanOrEqual(1)
+    // "failed" is not in ABORTED_STATUSES, so it is a counted cycle, not aborted.
+    expect(summary.abortedCycles).toBe(0)
+  })
+
+  it('--once mode: emits NO RALPH_CYCLE_EVENT (ralph cycle is the sole emitter)', () => {
+    seedHappyPath(3)
+
+    const res = runLoop({ timeout: 15000, once: true })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+    // Queue still drains in once mode.
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
+
+    // No run event — the automated path (ralph cycle) is the sole emitter, so
+    // ralph.sh must not double-count.
+    const cycleEvents = readCycleEvents()
+    expect(
+      cycleEvents.length,
+      `expected NO RALPH_CYCLE_EVENT in once mode, got:\n${cycleEvents.join('\n')}`,
+    ).toBe(0)
   })
 })


### PR DESCRIPTION
Closes #531

## Dev/TDD
- Tests added/modified: `packages/ralph/test/loop.test.js`
- Before implementation (red): `normal mode: appends exactly one RALPH_CYCLE_EVENT with real counts + run_id` failed with `expected +0 to be 1` — the loop ran to completion (`res.status === 0`) but wrote zero run events, confirming the feature was genuinely absent (not a path/import error).
- After implementation (green): all 650 tests pass (30 files) in `packages/ralph`.

In normal (interactive `ralph start`) mode only — **not** `--once` mode — `templates/ralph.sh` now appends exactly one line to `logs/ralph-cycle.out.log` (the file `lib/heartbeat.js` globs for the 24h rollup):

```
RALPH_CYCLE_EVENT {"ts":"<ISO-8601 UTC>","status":"...","ok":N,"failed":N,"durationMin":N,"processed":N,"run_id":"<session>-<start-epoch>"}
```

It carries the loop's real bash-computed counts and reuses the same `run_id` as the per-issue capture (hoisted to a single `RALPH_RUN_ID` variable so the two can't drift). The block sits after the `--once` early `exit 0`, so the automated `ralph cycle` path remains the sole emitter for itself (no double-counting). Emission is best-effort (`|| true`) so telemetry can never abort the loop. Purely additive — same tag, file, and fields the heartbeat already parses.

## QA scenarios added
All in `packages/ralph/test/loop.test.js` (+5 tests):
- **failure path** — every issue fails (zero-progress guard fires): event still emitted with `status:"failed"`, `ok:0`, `failed>=1`, `processed == ok+failed`.
- **partial path** — mixed run: `status:"partial"`, processed = ok+failed.
- **append, not overwrite** — a prior `RALPH_CYCLE_EVENT` in the log is preserved byte-for-byte; the file ends with 2 events.
- **heartbeat round-trip** — the emitted line is fed through the real `summarizeLast24h`: `cycles:1, ok:3, failed:0, totalIssues:3, abortedCycles:0`, durations round-trip. Proves the consumer parses it identically.
- **heartbeat round-trip (failure)** — a `status:"failed"` event counts as a real failed cycle, not an aborted one.

## Review verdict
- **APPROVE.** Field/tag/format parity with `lib/heartbeat.js` and `lib/commands/cycle.js` verified; run_id consistency asserted in-test; best-effort safety and once-mode no-emit confirmed. Reviewer's non-blocking nit (run_id literal duplicated across lines 206/281) was applied — hoisted to a single `RALPH_RUN_ID` assignment. No blocking findings.

## Docs updated
- `packages/ralph/README.md` — heartbeat "Daily heartbeat (24h summary)" section now states the cycle count covers both scheduled `ralph cycle` passes and interactive `ralph start` runs, and that `ralph cycle` stays the sole emitter for the scheduled path (no double-count).

## Notes
- All checks green: `npm run lint` (0 errors, 26 pre-existing warnings in unrelated `src/`), `packages/ralph` tests (650 pass), frontend `npm test` (553 pass), `npm run build` OK.
- Blocked-by #529 in the issue: its infrastructure (`RALPH_RUN_ID`, `issues.jsonl`, `RALPH_ISSUE_EVENT`) already landed in-code via #535/#538, so the dependency is satisfied in practice.
- `npm ci` is broken in this repo due to pre-existing lockfile drift (`@emnapi` transitive deps), unrelated to this change; tests were run against the installed `node_modules`. Lockfile left untouched.