### PR TITLE
fix(ralph): ralph cycle records real ok/failed counts from issues.jsonl

### DIFF
--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -1,9 +1,11 @@
-import { existsSync as realExistsSync } from 'node:fs'
+import { existsSync as realExistsSync, readFileSync as realReadFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { execa } from 'execa'
 import { loadEnvFile } from '../utils/env.js'
 import { sendWhatsappMessage } from '../utils/whatsapp.js'
+import { aggregateCycleCounts, metricsPath } from '../issue-metrics.js'
+import { buildRunId } from '../run-id.js'
 import {
   acquireLock as defaultAcquireLock,
   releaseLock as defaultReleaseLock,
@@ -45,6 +47,7 @@ export async function cycleCommand({
   pingSuccess = defaultPingSuccess,
   pingFail = defaultPingFail,
   runQueueOnce = defaultRunQueueOnce,
+  readFile = realReadFileSync,
   now = Date.now,
   claudeCredentialsPath = resolve(homedir(), '.claude', '.credentials.json'),
   processEnv = process.env,
@@ -161,15 +164,24 @@ export async function cycleCommand({
     await notify(`🟢 cycle started — ${queueCount} issues, repo ${repoSlug}`)
 
     const start = now()
-    const result = await runQueueOnce({ exec, root, stdout, stderr })
-    const successes = Array.isArray(result?.successes) ? result.successes : []
-    const failures = Array.isArray(result?.failures) ? result.failures : []
+    const runId = buildRunId(sessionNameFor(root), Math.floor(start / 1000))
+    await runQueueOnce({ exec, root, stdout, stderr, runId })
+
+    // Read the REAL per-issue events that `--once` appended to issues.jsonl and
+    // aggregate them. The bash loop's stdio is inherited (not captured), so the
+    // metrics file — not runQueueOnce's return — is the source of truth (#532).
+    const metricsText = safeReadMetrics(readFile, metricsPath(root))
+    const counts = aggregateCycleCounts(metricsText, start)
+    const okCount = counts.ok
+    const failedCount = counts.failed
+    const processed = counts.processed
     const durationMin = Math.max(0, Math.round((now() - start) / 60000))
-    const status = failures.length === 0 ? 'success' : successes.length > 0 ? 'partial' : 'failed'
-    const okList = successes.length > 0 ? successes.map((n) => `#${n}`).join(' ') : '-'
-    const failList = failures.length > 0 ? failures.map((n) => `#${n}`).join(' ') : '-'
+    const status = failedCount === 0 ? 'success' : okCount > 0 ? 'partial' : 'failed'
+    const okList = counts.okIssues.length > 0 ? counts.okIssues.map((n) => `#${n}`).join(' ') : '-'
+    const failList =
+      counts.failedIssues.length > 0 ? counts.failedIssues.map((n) => `#${n}`).join(' ') : '-'
     const summary =
-      `Ralph finalizado: ${successes.length} ok, ${failures.length} falharam, ${durationMin}min. ` +
+      `Ralph finalizado: ${okCount} ok, ${failedCount} falharam, ${durationMin}min. ` +
       `OK: ${okList}| FAIL: ${failList}`
     out(summary)
     await notify(summary)
@@ -188,19 +200,20 @@ export async function cycleCommand({
 
     emitEvent({
       status,
-      ok: successes.length,
-      failed: failures.length,
+      ok: okCount,
+      failed: failedCount,
       durationMin,
-      processed: successes.length + failures.length,
+      processed,
+      run_id: runId,
     })
 
     return {
       exitCode: 0,
       status,
-      processed: successes.length + failures.length,
+      processed,
       skipped: false,
-      successes,
-      failures,
+      successes: counts.okIssues,
+      failures: counts.failedIssues,
       durationMin,
     }
   } finally {
@@ -302,11 +315,21 @@ function ageInMinutes(nowMs, isoStartedAt) {
   return Math.max(0, Math.round((nowMs - startMs) / 60000))
 }
 
-async function defaultRunQueueOnce({ exec, root, stdout, stderr }) {
+// Read the metrics file, degrading to '' on any error (missing file, etc.) so
+// a blind cycle never crashes — it just reports zeros.
+function safeReadMetrics(readFile, path) {
+  try {
+    return readFile(path, 'utf8') || ''
+  } catch {
+    return ''
+  }
+}
+
+async function defaultRunQueueOnce({ exec, root, stdout, stderr, runId }) {
   const ralphTemplate = templatePath('ralph.sh')
   const result = await exec('bash', [ralphTemplate, '--once'], {
     cwd: root,
-    env: { ...process.env, RALPH_ONCE: '1' },
+    env: { ...process.env, RALPH_ONCE: '1', RALPH_RUN_ID: runId },
     reject: false,
     stdio: 'inherit',
   })

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -88,10 +88,20 @@ const baseDeps = (overrides = {}) => {
     pingSuccess,
     pingFail,
     runQueueOnce: async () => ({ successes: [], failures: [] }),
+    readFile: () => '',
     now: () => Date.parse('2026-04-29T00:30:00.000Z'),
     ...overrides,
   }
 }
+
+// Build an issues.jsonl text body of synthetic per-issue events, exactly as the
+// writer (appendIssueEvent) emits them: one `RALPH_ISSUE_EVENT <json>` per line.
+function issuesJsonl(events) {
+  return events.map((e) => 'RALPH_ISSUE_EVENT ' + JSON.stringify(e)).join('\n') + '\n'
+}
+
+// The base `now` in this harness; synthetic events with ts >= this are in-window.
+const NOW_MS = Date.parse('2026-04-29T00:30:00.000Z')
 
 describe('cycleCommand — tmux active', () => {
   it('exits 0 silently when this project\'s tmux session is already running', async () => {
@@ -385,7 +395,10 @@ describe('cycleCommand — success path', () => {
     let released = false
     const deps = baseDeps({
       releaseLock: () => { released = true },
-      runQueueOnce: async () => ({ successes: [101, 102], failures: [] }),
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'pass', ts: NOW_MS },
+        { issue_number: 102, verdict: 'pass', ts: NOW_MS },
+      ]),
     })
     deps.exec = makeExec({
       ...baseHandlers(),
@@ -412,7 +425,10 @@ describe('cycleCommand — success path', () => {
 
   it('reports partial status when some issues failed', async () => {
     const deps = baseDeps({
-      runQueueOnce: async () => ({ successes: [101], failures: [102] }),
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'pass', ts: NOW_MS },
+        { issue_number: 102, verdict: 'fail', ts: NOW_MS },
+      ]),
     })
     deps.exec = makeExec({
       ...baseHandlers(),
@@ -430,7 +446,9 @@ describe('cycleCommand — success path', () => {
 
   it('reports failed status and pings fail when every issue failed', async () => {
     const deps = baseDeps({
-      runQueueOnce: async () => ({ successes: [], failures: [101] }),
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'fail', ts: NOW_MS },
+      ]),
     })
     deps.exec = makeExec({
       ...baseHandlers(),
@@ -561,7 +579,10 @@ describe('cycleCommand — RALPH_CYCLE_EVENT log line', () => {
 
   it('emits status=success with ts/ok/failed/durationMin/processed on the success path', async () => {
     const deps = baseDeps({
-      runQueueOnce: async () => ({ successes: [101, 102], failures: [] }),
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'pass', ts: NOW_MS },
+        { issue_number: 102, verdict: 'pass', ts: NOW_MS },
+      ]),
     })
     deps.exec = makeExec({
       ...baseHandlers(),
@@ -638,7 +659,9 @@ describe('cycleCommand — RALPH_CYCLE_EVENT log line', () => {
 
   it('emits status=failed when every issue failed', async () => {
     const deps = baseDeps({
-      runQueueOnce: async () => ({ successes: [], failures: [101] }),
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'fail', ts: NOW_MS },
+      ]),
     })
     deps.exec = makeExec({
       ...baseHandlers(),
@@ -654,5 +677,214 @@ describe('cycleCommand — RALPH_CYCLE_EVENT log line', () => {
     expect(event.status).toBe('failed')
     expect(event.ok).toBe(0)
     expect(event.failed).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #532: real per-issue counts read from .ralph/metrics/issues.jsonl, not the
+// (always-empty) runQueueOnce return; plus run_id threading into --once.
+// ---------------------------------------------------------------------------
+describe('cycleCommand — real counts from issues.jsonl (#532)', () => {
+  function readEvent(stdout) {
+    const text = stdout.output()
+    const idx = text.indexOf('RALPH_CYCLE_EVENT ')
+    if (idx === -1) return null
+    const lineEnd = text.indexOf('\n', idx)
+    const line = text.slice(idx, lineEnd === -1 ? text.length : lineEnd)
+    return JSON.parse(line.slice('RALPH_CYCLE_EVENT '.length).trim())
+  }
+
+  const queueHandler = (n) => ({
+    'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+      exitCode: 0,
+      stdout: String(n),
+      stderr: '',
+    },
+  })
+
+  const expectedRunId = sessionNameFor(REPO) + '-' + Math.floor(NOW_MS / 1000)
+
+  it('reports REAL ok/failed (not 0/0) from in-window metrics events', async () => {
+    const deps = baseDeps({
+      readFile: () => issuesJsonl([
+        // An earlier event from a prior run — BEFORE start; must be excluded.
+        { issue_number: 99, verdict: 'pass', ts: NOW_MS - 60000, run_id: 'stale-1' },
+        { issue_number: 101, verdict: 'pass', ts: NOW_MS, run_id: expectedRunId },
+        { issue_number: 102, verdict: 'fail', ts: NOW_MS, run_id: expectedRunId },
+        { issue_number: 103, verdict: 'unknown', ts: NOW_MS, run_id: expectedRunId },
+      ]),
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(3) })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    expect(event).not.toBeNull()
+    // 1 pass = ok; fail + unknown = 2 failed. NOT 0/0.
+    expect(event.ok).toBe(1)
+    expect(event.failed).toBe(2)
+    expect(event.processed).toBe(3)
+    expect(event.status).toBe('partial')
+    // The excluded stale event (#99) must not have inflated counts.
+    expect(event.ok + event.failed).toBe(3)
+  })
+
+  it('the emitted run_id matches <session>-<epoch-seconds> and the in-window events', async () => {
+    const deps = baseDeps({
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'pass', ts: NOW_MS, run_id: expectedRunId },
+      ]),
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(1) })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    expect(event.run_id).toBe(expectedRunId)
+    expect(event.run_id).toMatch(new RegExp('^' + sessionNameFor(REPO) + '-\\d+$'))
+  })
+
+  it('passes the computed runId down into runQueueOnce (→ --once)', async () => {
+    let seenRunId
+    const deps = baseDeps({
+      runQueueOnce: async ({ runId }) => {
+        seenRunId = runId
+        return { successes: [], failures: [] }
+      },
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'pass', ts: NOW_MS, run_id: expectedRunId },
+      ]),
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(1) })
+    await cycleCommand(deps)
+    expect(seenRunId).toBe(expectedRunId)
+  })
+
+  it('status=success when every in-window event passed', async () => {
+    const deps = baseDeps({
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'pass', ts: NOW_MS },
+        { issue_number: 102, verdict: 'pass', ts: NOW_MS },
+      ]),
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(2) })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('success')
+    expect(result.successes).toEqual([101, 102])
+    expect(result.failures).toEqual([])
+  })
+
+  it('status=failed when only failures/unknowns are in window (crash-only cycle)', async () => {
+    const deps = baseDeps({
+      readFile: () => issuesJsonl([
+        { issue_number: 101, verdict: 'unknown', ts: NOW_MS },
+        { issue_number: 102, verdict: 'fail', ts: NOW_MS },
+      ]),
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(2) })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('failed')
+    expect(result.failures).toEqual([101, 102])
+    expect(deps.pingFail.calls.length).toBe(1)
+    expect(deps.pingSuccess.calls.length).toBe(0)
+  })
+
+  it('reports 0/0 success when the metrics file is unreadable (degrades gracefully)', async () => {
+    const deps = baseDeps({
+      readFile: () => { throw new Error('ENOENT') },
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(1) })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('success')
+    expect(result.processed).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#532): the append-only file accumulates history across runs.
+// These probe that `since` strictly fences this run from prior ones — the most
+// important defect class (double-counting an append-only log).
+// ---------------------------------------------------------------------------
+describe('QA: cycleCommand — cross-run accumulation is fenced by `since`', () => {
+  function readEvent(stdout) {
+    const text = stdout.output()
+    const idx = text.indexOf('RALPH_CYCLE_EVENT ')
+    if (idx === -1) return null
+    const lineEnd = text.indexOf('\n', idx)
+    const line = text.slice(idx, lineEnd === -1 ? text.length : lineEnd)
+    return JSON.parse(line.slice('RALPH_CYCLE_EVENT '.length).trim())
+  }
+
+  const queueHandler = (n) => ({
+    'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+      exitCode: 0,
+      stdout: String(n),
+      stderr: '',
+    },
+  })
+
+  const expectedRunId = sessionNameFor(REPO) + '-' + Math.floor(NOW_MS / 1000)
+
+  it('counts ONLY this run, ignoring a fat history of multiple prior runs', async () => {
+    // A realistic append-only file: three prior runs (well before `start`)
+    // plus this run's two events. Only the latter two may be counted.
+    const deps = baseDeps({
+      readFile: () => issuesJsonl([
+        // --- prior run A (1 hour ago) ---
+        { issue_number: 1, verdict: 'pass', ts: NOW_MS - 3600000, run_id: 'run-A' },
+        { issue_number: 2, verdict: 'fail', ts: NOW_MS - 3600000, run_id: 'run-A' },
+        // --- prior run B (10 min ago) ---
+        { issue_number: 3, verdict: 'pass', ts: NOW_MS - 600000, run_id: 'run-B' },
+        { issue_number: 4, verdict: 'unknown', ts: NOW_MS - 600000, run_id: 'run-B' },
+        // --- prior run C: exactly 1ms before start → must be EXCLUDED ---
+        { issue_number: 5, verdict: 'pass', ts: NOW_MS - 1, run_id: 'run-C' },
+        // --- THIS run (ts === start) ---
+        { issue_number: 101, verdict: 'pass', ts: NOW_MS, run_id: expectedRunId },
+        { issue_number: 102, verdict: 'fail', ts: NOW_MS, run_id: expectedRunId },
+      ]),
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(2) })
+    const result = await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    // Only this run's two events: 1 pass + 1 fail. Prior 5 events ignored.
+    expect(event.ok).toBe(1)
+    expect(event.failed).toBe(1)
+    expect(event.processed).toBe(2)
+    expect(event.status).toBe('partial')
+    expect(result.successes).toEqual([101])
+    expect(result.failures).toEqual([102])
+    // The fenced-out #5 (ts = start - 1) must not leak in.
+    expect(result.successes).not.toContain(5)
+  })
+
+  it('releases the lock even when the metrics file read throws (ENOENT)', async () => {
+    let released = false
+    const deps = baseDeps({
+      releaseLock: () => { released = true },
+      readFile: () => { throw new Error('ENOENT') },
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(1) })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('success')
+    expect(result.processed).toBe(0)
+    expect(released).toBe(true)
+  })
+
+  it('run_id round-trips: emitted run_id === runId passed to runQueueOnce === in-window events run_id', async () => {
+    let seenRunId
+    const inWindow = [
+      { issue_number: 101, verdict: 'pass', ts: NOW_MS, run_id: expectedRunId },
+      { issue_number: 102, verdict: 'fail', ts: NOW_MS, run_id: expectedRunId },
+    ]
+    const deps = baseDeps({
+      runQueueOnce: async ({ runId }) => {
+        seenRunId = runId
+        return { successes: [], failures: [] }
+      },
+      readFile: () => issuesJsonl(inWindow),
+    })
+    deps.exec = makeExec({ ...baseHandlers(), ...queueHandler(2) })
+    await cycleCommand(deps)
+    const event = readEvent(deps.stdout)
+    // All three must be the same identifier.
+    expect(seenRunId).toBe(expectedRunId)
+    expect(event.run_id).toBe(seenRunId)
+    expect(inWindow.every((e) => e.run_id === event.run_id)).toBe(true)
   })
 })

--- a/packages/ralph/lib/issue-metrics.js
+++ b/packages/ralph/lib/issue-metrics.js
@@ -14,6 +14,52 @@ export function metricsPath(projectRoot) {
   return join(projectRoot, '.ralph', 'metrics', 'issues.jsonl')
 }
 
+const ISSUE_EVENT_TAG = 'RALPH_ISSUE_EVENT '
+
+// PURE aggregator over the newline-delimited issues.jsonl text (no I/O, no
+// Date.now). Parses each `RALPH_ISSUE_EVENT <json>` line, keeps only events
+// whose numeric `ts` epoch-ms is `>= since`, and tallies verdicts: `pass` is
+// ok, everything else (`fail`/`unknown`) is failed — matching the bash loop's
+// conservative accounting where an indeterminate issue counts as a failure.
+// Malformed lines (blank, untagged, bad JSON, missing/non-finite ts) are
+// skipped silently; never throws.
+export function aggregateCycleCounts(jsonlText, since) {
+  const okIssues = []
+  const failedIssues = []
+  let ok = 0
+  let failed = 0
+
+  if (!jsonlText) {
+    return { ok, failed, processed: 0, okIssues, failedIssues }
+  }
+
+  for (const line of jsonlText.split('\n')) {
+    const idx = line.indexOf(ISSUE_EVENT_TAG)
+    if (idx === -1) continue
+    let event
+    try {
+      event = JSON.parse(line.slice(idx + ISSUE_EVENT_TAG.length))
+    } catch {
+      continue
+    }
+    if (!event || typeof event !== 'object') continue
+    const ts = event.ts
+    if (typeof ts !== 'number' || !Number.isFinite(ts) || ts < since) continue
+
+    const issueNumber = event.issue_number
+    const isFinite = typeof issueNumber === 'number' && Number.isFinite(issueNumber)
+    if (event.verdict === 'pass') {
+      ok++
+      if (isFinite) okIssues.push(issueNumber)
+    } else {
+      failed++
+      if (isFinite) failedIssues.push(issueNumber)
+    }
+  }
+
+  return { ok, failed, processed: ok + failed, okIssues, failedIssues }
+}
+
 export function appendIssueEvent(projectRoot, event, fsImpl) {
   const fs = wrap(fsImpl)
   const path = metricsPath(projectRoot)

--- a/packages/ralph/lib/issue-metrics.test.js
+++ b/packages/ralph/lib/issue-metrics.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { join } from 'node:path'
-import { appendIssueEvent, metricsPath } from './issue-metrics.js'
+import { appendIssueEvent, metricsPath, aggregateCycleCounts } from './issue-metrics.js'
 
 // In-memory fs stub matching the injectable-fs pattern from state.js.
 function makeFsStub() {
@@ -101,5 +101,242 @@ describe('QA: appendIssueEvent — JSON escaping round-trip', () => {
     const parsed = JSON.parse(lines[0].slice('RALPH_ISSUE_EVENT '.length))
     expect(parsed).toEqual(event)
     expect(parsed.note).toContain('\n')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// aggregateCycleCounts — pure aggregator over issues.jsonl text (#532).
+// ---------------------------------------------------------------------------
+describe('aggregateCycleCounts', () => {
+  const line = (event) => 'RALPH_ISSUE_EVENT ' + JSON.stringify(event)
+
+  it('returns all zeros for empty / missing input', () => {
+    const empty = { ok: 0, failed: 0, processed: 0, okIssues: [], failedIssues: [] }
+    expect(aggregateCycleCounts('', 0)).toEqual(empty)
+    expect(aggregateCycleCounts(undefined, 0)).toEqual(empty)
+    expect(aggregateCycleCounts(null, 0)).toEqual(empty)
+  })
+
+  it('counts pass as ok and fail/unknown as failed', () => {
+    const text = [
+      line({ issue_number: 1, verdict: 'pass', ts: 100 }),
+      line({ issue_number: 2, verdict: 'fail', ts: 100 }),
+      line({ issue_number: 3, verdict: 'unknown', ts: 100 }),
+    ].join('\n')
+    const counts = aggregateCycleCounts(text, 0)
+    expect(counts.ok).toBe(1)
+    expect(counts.failed).toBe(2)
+    expect(counts.processed).toBe(3)
+    expect(counts.okIssues).toEqual([1])
+    expect(counts.failedIssues).toEqual([2, 3])
+  })
+
+  it('excludes events whose ts is before the since cutoff', () => {
+    const text = [
+      line({ issue_number: 1, verdict: 'pass', ts: 50 }), // before cutoff
+      line({ issue_number: 2, verdict: 'pass', ts: 200 }), // after cutoff
+      line({ issue_number: 3, verdict: 'fail', ts: 200 }), // after cutoff
+    ].join('\n')
+    const counts = aggregateCycleCounts(text, 100)
+    expect(counts.ok).toBe(1)
+    expect(counts.failed).toBe(1)
+    expect(counts.processed).toBe(2)
+    expect(counts.okIssues).toEqual([2])
+    expect(counts.failedIssues).toEqual([3])
+  })
+
+  it('keeps events whose ts equals the since cutoff (>=)', () => {
+    const text = line({ issue_number: 9, verdict: 'pass', ts: 100 })
+    expect(aggregateCycleCounts(text, 100).ok).toBe(1)
+  })
+
+  it('tolerates malformed lines: blank, non-tagged, bad JSON, missing ts', () => {
+    const text = [
+      '',
+      'garbage line without tag',
+      'RALPH_ISSUE_EVENT {not valid json',
+      line({ issue_number: 5, verdict: 'pass' }), // missing ts → skipped
+      line({ issue_number: 6, verdict: 'pass', ts: 'nope' }), // non-finite ts → skipped
+      '   ',
+      line({ issue_number: 7, verdict: 'pass', ts: 100 }), // the only valid in-window event
+    ].join('\n')
+    const counts = aggregateCycleCounts(text, 0)
+    expect(counts.ok).toBe(1)
+    expect(counts.failed).toBe(0)
+    expect(counts.processed).toBe(1)
+    expect(counts.okIssues).toEqual([7])
+  })
+
+  it('collects issue numbers, dropping non-finite ones', () => {
+    const text = [
+      line({ issue_number: 10, verdict: 'pass', ts: 100 }),
+      line({ issue_number: 'x', verdict: 'pass', ts: 100 }), // bad number kept out of okIssues
+      line({ issue_number: 20, verdict: 'fail', ts: 100 }),
+      line({ verdict: 'fail', ts: 100 }), // no issue_number
+    ].join('\n')
+    const counts = aggregateCycleCounts(text, 0)
+    // verdict-based counts still tally every in-window event
+    expect(counts.ok).toBe(2)
+    expect(counts.failed).toBe(2)
+    // ...but only finite issue numbers are collected into the arrays
+    expect(counts.okIssues).toEqual([10])
+    expect(counts.failedIssues).toEqual([20])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#532): adversarial edge cases the happy path missed.
+// ---------------------------------------------------------------------------
+describe('QA: aggregateCycleCounts — since boundary is inclusive of ts === since', () => {
+  const line = (event) => 'RALPH_ISSUE_EVENT ' + JSON.stringify(event)
+
+  it('ts === since is INCLUDED, ts === since - 1 is EXCLUDED', () => {
+    const text = [
+      line({ issue_number: 1, verdict: 'pass', ts: 999 }), // since - 1 → out
+      line({ issue_number: 2, verdict: 'pass', ts: 1000 }), // === since → in
+    ].join('\n')
+    const counts = aggregateCycleCounts(text, 1000)
+    expect(counts.ok).toBe(1)
+    expect(counts.processed).toBe(1)
+    expect(counts.okIssues).toEqual([2])
+  })
+})
+
+describe('QA: aggregateCycleCounts — ts type abuse is excluded', () => {
+  const line = (event) => 'RALPH_ISSUE_EVENT ' + JSON.stringify(event)
+
+  it('a numeric STRING ts ("1700000000000") is treated as malformed and excluded', () => {
+    const text = line({ issue_number: 1, verdict: 'pass', ts: '1700000000000' })
+    expect(aggregateCycleCounts(text, 0)).toEqual({
+      ok: 0,
+      failed: 0,
+      processed: 0,
+      okIssues: [],
+      failedIssues: [],
+    })
+  })
+
+  it('ts: null, missing ts, and ts: Infinity are all excluded', () => {
+    const text = [
+      line({ issue_number: 1, verdict: 'pass', ts: null }),
+      line({ issue_number: 2, verdict: 'pass' }), // missing
+      // Infinity is not representable in JSON; JSON.stringify emits null, but
+      // construct the raw line by hand to be explicit about the intent.
+      'RALPH_ISSUE_EVENT {"issue_number":3,"verdict":"pass","ts":1e999}', // → Infinity
+    ].join('\n')
+    const counts = aggregateCycleCounts(text, 0)
+    expect(counts.processed).toBe(0)
+    expect(counts.ok).toBe(0)
+    expect(counts.failed).toBe(0)
+  })
+
+  it('ts: NaN (raw JSON) is excluded — and does not throw', () => {
+    // NaN is invalid JSON; a hand-rolled "NaN" literal makes JSON.parse throw,
+    // which the aggregator swallows. Either way the event must not be counted.
+    const text = 'RALPH_ISSUE_EVENT {"issue_number":1,"verdict":"pass","ts":NaN}'
+    expect(() => aggregateCycleCounts(text, 0)).not.toThrow()
+    expect(aggregateCycleCounts(text, 0).processed).toBe(0)
+  })
+})
+
+describe('QA: aggregateCycleCounts — JSON valid but not an object', () => {
+  it('a tagged line whose JSON is a number / string / null is skipped, never throws', () => {
+    const text = [
+      'RALPH_ISSUE_EVENT 42',
+      'RALPH_ISSUE_EVENT "hi"',
+      'RALPH_ISSUE_EVENT null',
+      'RALPH_ISSUE_EVENT true',
+    ].join('\n')
+    let counts
+    expect(() => {
+      counts = aggregateCycleCounts(text, 0)
+    }).not.toThrow()
+    expect(counts).toEqual({
+      ok: 0,
+      failed: 0,
+      processed: 0,
+      okIssues: [],
+      failedIssues: [],
+    })
+  })
+})
+
+describe('QA: aggregateCycleCounts — issue_number abuse still tallies verdict', () => {
+  const line = (event) => 'RALPH_ISSUE_EVENT ' + JSON.stringify(event)
+
+  it('pass with missing/NaN/non-numeric issue_number counts in ok but not okIssues', () => {
+    const text = [
+      line({ verdict: 'pass', ts: 100 }), // missing issue_number
+      line({ issue_number: 'abc', verdict: 'pass', ts: 100 }), // non-numeric
+      'RALPH_ISSUE_EVENT {"issue_number":1e999,"verdict":"pass","ts":100}', // Infinity
+      line({ verdict: 'fail', ts: 100 }), // missing, failed branch
+      line({ issue_number: null, verdict: 'fail', ts: 100 }),
+    ].join('\n')
+    const counts = aggregateCycleCounts(text, 0)
+    expect(counts.ok).toBe(3)
+    expect(counts.failed).toBe(2)
+    expect(counts.processed).toBe(5)
+    expect(counts.okIssues).toEqual([])
+    expect(counts.failedIssues).toEqual([])
+  })
+})
+
+describe('QA: aggregateCycleCounts — realistic mixed blob', () => {
+  const line = (event) => 'RALPH_ISSUE_EVENT ' + JSON.stringify(event)
+
+  it('counts only in-window valid events amid noise; exact arrays', () => {
+    const text = [
+      'just some stdout', // non-tagged log line
+      line({ issue_number: 10, verdict: 'pass', ts: 5000 }), // in-window pass
+      '', // blank line
+      line({ issue_number: 11, verdict: 'unknown', ts: 5000 }), // in-window unknown → failed
+      line({ issue_number: 99, verdict: 'pass', ts: 100 }), // out-of-window pass
+      'RALPH_ISSUE_EVENT {bad json here', // bad-JSON tagged line
+      line({ issue_number: 12, verdict: 'fail', ts: 6000 }), // in-window fail
+    ].join('\n')
+    const counts = aggregateCycleCounts(text, 1000)
+    expect(counts.ok).toBe(1)
+    expect(counts.failed).toBe(2)
+    expect(counts.processed).toBe(3)
+    expect(counts.okIssues).toEqual([10])
+    expect(counts.failedIssues).toEqual([11, 12])
+  })
+})
+
+describe('QA: aggregateCycleCounts — tag position semantics', () => {
+  const line = (event) => 'RALPH_ISSUE_EVENT ' + JSON.stringify(event)
+
+  it('a tag embedded mid-line still parses (indexOf-based slicing is intentional)', () => {
+    const text =
+      '2026-01-01T00:00:00 ' + line({ issue_number: 7, verdict: 'pass', ts: 100 })
+    const counts = aggregateCycleCounts(text, 0)
+    expect(counts.ok).toBe(1)
+    expect(counts.okIssues).toEqual([7])
+  })
+
+  it('a line containing the tag but no following JSON is skipped without throwing', () => {
+    const text = 'noise RALPH_ISSUE_EVENT '
+    expect(() => aggregateCycleCounts(text, 0)).not.toThrow()
+    expect(aggregateCycleCounts(text, 0).processed).toBe(0)
+  })
+})
+
+describe('QA: aggregateCycleCounts — CRLF logs still count', () => {
+  const line = (event) => 'RALPH_ISSUE_EVENT ' + JSON.stringify(event)
+
+  it('a \\r\\n-terminated event leaves a trailing \\r that JSON.parse tolerates', () => {
+    // The impl splits on '\n' only, so each record retains a trailing '\r'.
+    // JSON.parse ignores trailing whitespace, so CRLF logs must still count.
+    const text =
+      line({ issue_number: 5, verdict: 'pass', ts: 100 }) +
+      '\r\n' +
+      line({ issue_number: 6, verdict: 'fail', ts: 100 }) +
+      '\r\n'
+    const counts = aggregateCycleCounts(text, 0)
+    expect(counts.ok).toBe(1)
+    expect(counts.failed).toBe(1)
+    expect(counts.processed).toBe(2)
+    expect(counts.okIssues).toEqual([5])
+    expect(counts.failedIssues).toEqual([6])
   })
 })

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -170,7 +170,7 @@ START=$(date +%s)
 # Single source of truth for the run_id (`<session>-<start-epoch>`). Both the
 # per-issue capture and the end-of-run RALPH_CYCLE_EVENT reference this, so the
 # two can never drift apart.
-RALPH_RUN_ID="${RALPH_TMUX_SESSION:-ralph}-${START}"
+RALPH_RUN_ID="${RALPH_RUN_ID:-${RALPH_TMUX_SESSION:-ralph}-${START}}"
 successes=()
 failures=()
 claude_failed=0


### PR DESCRIPTION
Closes #532

## Dev/TDD
- Tests added/modified:
  - `packages/ralph/lib/issue-metrics.test.js` (new `aggregateCycleCounts` describe block)
  - `packages/ralph/lib/commands/cycle.test.js` (new "real counts from issues.jsonl" block + `readFile` injection in `baseDeps`)
- Before implementation (red): the aggregator tests failed with `TypeError: aggregateCycleCounts is not a function` (function didn't exist); cycle tests asserting real counts failed because counts came from the always-empty `runQueueOnce` return rather than the metrics file.
- After implementation (green): all 675 tests pass (30 files).

Implementation:
- New pure `aggregateCycleCounts(jsonlText, since)` in `lib/issue-metrics.js` — parses `RALPH_ISSUE_EVENT <json>` lines, tolerates malformed lines, filters `ts >= since` (epoch-ms), counts `verdict === 'pass'` as ok and everything else (`fail`/`unknown`) as failed; returns `{ ok, failed, processed, okIssues, failedIssues }`.
- `lib/commands/cycle.js` — builds `run_id = buildRunId(sessionNameFor(root), Math.floor(start/1000))`, passes it down into `ralph.sh --once` (via `RALPH_RUN_ID` env), then reads `.ralph/metrics/issues.jsonl` and aggregates real counts. Adds `run_id` to the success-path `RALPH_CYCLE_EVENT` (abort-status events unchanged). Injectable `readFile` dep degrades to `''` on missing file.
- `templates/ralph.sh` — honors an inherited `RALPH_RUN_ID` (`${RALPH_RUN_ID:-...}`) so per-issue events carry the cycle's run_id; interactive `ralph start` behavior unchanged.

## QA scenarios added
- `aggregateCycleCounts`: inclusive `since` boundary (`ts === since` in, `since - 1` out); ts type abuse (numeric-string/null/NaN/Infinity excluded); valid-JSON-but-not-object skipped; issue_number abuse (verdict tallied but kept out of arrays); mixed realistic blob; mid-line tag position; CRLF tolerance.
- `cycleCommand`: cross-run accumulation (prior-run events fenced out by `since` — prevents double-counting the append-only file); missing metrics file (ENOENT → completes success 0/0, lock released); run_id round-trip (emitted == passed-down == in-window events' run_id).
- Test paths: `packages/ralph/lib/issue-metrics.test.js`, `packages/ralph/lib/commands/cycle.test.js`. No bugs found — all augmentation green.

## Review verdict
- APPROVE, no blocking findings. Reviewer confirmed: `verdict !== 'pass'` ⇒ failed mapping is consistent with the bash loop's own successes/failures accounting and `computeVerdict`; `start` and per-issue `ts` are both epoch-ms (same clock) so the `since` fence is valid; run_id shapes correlate (cycle injects the id, so the bash fallback is never reached on the cycle path); adding `run_id` to only the success-path event is correct (abort branches run before a run_id exists). Non-blocking notes: `defaultRunQueueOnce`'s return value is now vestigial; a local `isFinite` faintly shadows the global name.

## Docs updated
- none — diff implied no doc change. The existing `packages/ralph/README.md` already documented the intended behavior (real 24h counts, `run_id` format `<session>-<start-epoch>`); this fix makes the code match the docs rather than rendering any doc stale.

## Notes
- Tier 1 / Standard run (substantive runtime behavior change in the Ralph package; full team: dev → QA → review → writer).
- Validation: `npm test` (packages/ralph) 675 pass; `npm run lint` (repo root) 0 errors (26 pre-existing unrelated `src/` warnings); `npm run build` succeeds.