### PR TITLE
feat(ralph): capture end-of-job context-window occupancy per issue

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -227,6 +227,7 @@ be committed. Re-running `ralph init` never overwrites it.
 | `MERGE_POLL_INTERVAL` | `30`                                 | Seconds between `gh pr view` polls while waiting for auto-merge.       |
 | `MERGE_POLL_MAX`      | `40`                                 | Max polls (default = 20 minutes) before giving up on a PR.             |
 | `RALPH_HEAVY_TIER`    | `0`                                  | Gates the **Tier 2 / Heavy** triage path. `0` = off (the default): the heavy tier is unavailable and triage falls back to Tier 1. When on, a Tier-2 run adds the explorer fan-out + inline synthesis understand phase before the dev, and a 3-reviewer adversarial-panel verify phase (majority-of-3 to block) before the PR opens. |
+| `RALPH_CONTEXT_WINDOW` | unset (auto-resolved)               | Optional numeric override (tokens) for the context window used by the [`context_end_pct`](#per-issue-stream--ralphmetricsissuesjsonl) metric. Unset = auto-resolve from the run's model id (`opus`/`sonnet`/`fable` = 1,000,000; `haiku` = 200,000; default 1,000,000 for the opus family). A non-numeric or `<= 0` value is ignored. |
 
 The config is plain bash; edit it in any editor. On the next
 `ralph start` Ralph notices the change (sha256 mismatch in
@@ -420,11 +421,17 @@ with these fields:
 | `stderr_error_signals` | Count of stderr lines matching auth / credit / rate-limit signals. |
 | `verdict` | `pass` (CLOSED or `pending-merge`), `fail` (`claude-failed` label), or `unknown`. |
 | `files`, `insertions`, `deletions` | Real PR diff stats, fetched best-effort from the issue's PR (`gh pr list --head issue-<n>`). Degrade to `0` when no PR exists or the fetch fails — never aborts the loop. |
+| `context_end_tokens` | End-of-job context-window occupancy — the statusline number. The sum of `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` from the **last** `message_start` event (not the cumulative `result` usage). `0` when no `message_start` or usage is present. |
+| `context_end_pct` | `context_end_tokens / window`, rounded to 6 decimal places. `null` when the model's window is unknown or tokens are `0`. The window resolves from the model id (`opus`/`sonnet`/`fable` = 1,000,000; `haiku` = 200,000; default 1,000,000 for the opus family) or from the [`RALPH_CONTEXT_WINDOW`](#configuration-reference) override. |
+| `model` | The model id from the last `message_start`, or `null` if absent. |
 
 `subtype`, `total_cost_usd`, `num_turns`, `duration_ms`, and `usage` are
 all pulled from the **last** parseable `result` line of the raw
 stream-json; blank, garbage, and non-JSON lines are skipped, and the
 fields default to zero/`null` when no `result` line is present.
+`context_end_tokens`, `context_end_pct`, and `model` are pulled from the
+**last** `message_start` event (bare or wrapped in a `stream_event`
+envelope) and degrade to `0`/`null` when none is present.
 
 ### Per-run stream — `RALPH_CYCLE_EVENT` in the heartbeat log
 

--- a/packages/ralph/lib/capture-issue-event.js
+++ b/packages/ralph/lib/capture-issue-event.js
@@ -18,6 +18,10 @@
 //   RALPH_DEV_BRANCH      - dev branch name (recorded for future diff slices)
 //   RALPH_RAW_JSONL_PATH  - path to the tee'd raw claude stream-json (.jsonl)
 //   RALPH_STDERR_LOG_PATH - path to the per-issue stderr log
+//   RALPH_CONTEXT_WINDOW  - optional numeric override for the model's context
+//                           window (tokens); ignored if non-numeric/<=0. When
+//                           absent, the window is resolved from the model id
+//                           (opus/sonnet/fable=1M, haiku=200k) — see issue-event.js.
 //
 // On success appends one `RALPH_ISSUE_EVENT <json>` line via appendIssueEvent.
 
@@ -62,6 +66,10 @@ export function captureIssueEvent({
     const claudeExitCode = Number.parseInt(env.RALPH_CLAUDE_EXIT, 10)
     const resolvedIssueNumber = Number.isNaN(issueNumber) ? null : issueNumber
 
+    // Optional context-window override; null unless a finite positive number.
+    const cw = Number(env.RALPH_CONTEXT_WINDOW)
+    const contextWindowOverride = Number.isFinite(cw) && cw > 0 ? cw : null
+
     // Best-effort: never lets a slow/failed gh call abort the loop. The real
     // fetcher already degrades to zeros internally; this guard also covers an
     // injected fetcher that throws so the event is still written.
@@ -84,6 +92,7 @@ export function captureIssueEvent({
       files: diff.changedFiles,
       insertions: diff.additions,
       deletions: diff.deletions,
+      contextWindowOverride,
     })
 
     appendIssueEvent(projectRoot, event)

--- a/packages/ralph/lib/capture-issue-event.test.js
+++ b/packages/ralph/lib/capture-issue-event.test.js
@@ -378,3 +378,74 @@ describe('QA: captureIssueEvent — diff-stats fetcher wiring (#530)', () => {
     expect(logged).toHaveLength(0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#534): RALPH_CONTEXT_WINDOW env -> contextWindowOverride.
+// A valid finite positive number is honored; 0 / negative / non-numeric / empty
+// are ignored so the window falls back to the model-id map.
+// ---------------------------------------------------------------------------
+describe('QA: captureIssueEvent — RALPH_CONTEXT_WINDOW wiring (#534)', () => {
+  // Write a stream whose LAST message_start uses an UNKNOWN model so the only way
+  // pct can be non-null is via the env override flowing into contextWindowOverride.
+  function writeUnknownModelStream(inputTokens = 100) {
+    writeFileSync(
+      join(workdir, 'logs', 'ralph-issue-98.jsonl'),
+      JSON.stringify({
+        type: 'message_start',
+        message: { model: 'mystery-model-x', usage: { input_tokens: inputTokens } },
+      }) + '\n',
+    )
+  }
+
+  it('a valid RALPH_CONTEXT_WINDOW is applied to the computed pct', () => {
+    writeUnknownModelStream(100)
+    capture({ env: envFor({ RALPH_CONTEXT_WINDOW: '1000' }) })
+    const events = readEvents()
+    expect(events[0].context_end_tokens).toBe(100)
+    expect(events[0].model).toBe('mystery-model-x')
+    expect(events[0].context_end_pct).toBeCloseTo(0.1, 10)
+  })
+
+  it('RALPH_CONTEXT_WINDOW="0" is ignored => unknown model has no window => pct null', () => {
+    writeUnknownModelStream(100)
+    capture({ env: envFor({ RALPH_CONTEXT_WINDOW: '0' }) })
+    const events = readEvents()
+    expect(events[0].context_end_pct).toBeNull()
+  })
+
+  it('RALPH_CONTEXT_WINDOW="-5" is ignored => pct null for unknown model', () => {
+    writeUnknownModelStream(100)
+    capture({ env: envFor({ RALPH_CONTEXT_WINDOW: '-5' }) })
+    const events = readEvents()
+    expect(events[0].context_end_pct).toBeNull()
+  })
+
+  it('RALPH_CONTEXT_WINDOW="abc" is ignored => pct null for unknown model', () => {
+    writeUnknownModelStream(100)
+    capture({ env: envFor({ RALPH_CONTEXT_WINDOW: 'abc' }) })
+    const events = readEvents()
+    expect(events[0].context_end_pct).toBeNull()
+  })
+
+  it('RALPH_CONTEXT_WINDOW="" (empty) is ignored => pct null for unknown model', () => {
+    writeUnknownModelStream(100)
+    capture({ env: envFor({ RALPH_CONTEXT_WINDOW: '' }) })
+    const events = readEvents()
+    expect(events[0].context_end_pct).toBeNull()
+  })
+
+  it('RALPH_CONTEXT_WINDOW absent + KNOWN model => window resolved from model id (opus=1M)', () => {
+    writeFileSync(
+      join(workdir, 'logs', 'ralph-issue-98.jsonl'),
+      JSON.stringify({
+        type: 'message_start',
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 12_345 } },
+      }) + '\n',
+    )
+    const env = envFor()
+    delete env.RALPH_CONTEXT_WINDOW
+    capture({ env })
+    const events = readEvents()
+    expect(events[0].context_end_pct).toBe(0.012345)
+  })
+})

--- a/packages/ralph/lib/issue-event.js
+++ b/packages/ralph/lib/issue-event.js
@@ -33,6 +33,98 @@ function lastResultLine(rawStreamJson) {
   return found
 }
 
+// Find the LAST `message_start` event in the stream-json. It may appear EITHER
+// as a bare `{type:'message_start',...}` line OR wrapped in a `stream_event`
+// envelope (`{type:'stream_event',event:{type:'message_start',...}}`). Returns
+// the UNWRAPPED message_start object (so callers always see `.message`). Skips
+// blank / garbage / non-JSON lines gracefully. Never throws.
+export function lastMessageStart(rawStreamJson) {
+  if (!rawStreamJson) return null
+  let found = null
+  for (const line of rawStreamJson.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let obj
+    try {
+      obj = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!obj || typeof obj !== 'object') continue
+    if (obj.type === 'message_start') {
+      found = obj
+    } else if (obj.type === 'stream_event' && obj.event?.type === 'message_start') {
+      found = obj.event
+    }
+  }
+  return found
+}
+
+// Model-id-prefix → context-window map. Defaults: opus/sonnet/fable = 1M,
+// haiku = 200k. An unknown model resolves to null (we'd rather emit no pct than
+// a wrong one). DEFAULT documented in templates/ralph.config.sh.
+const CONTEXT_WINDOW_DEFAULT = 1_000_000
+const CONTEXT_WINDOW_HAIKU = 200_000
+
+// Resolve the context window for a model id. Resolution order:
+//   1. explicit numeric `override` (finite, > 0) — wins over everything.
+//   2. model-id-prefix map (opus|sonnet|fable → 1M; haiku → 200k).
+//   3. null (unknown model, no override).
+// A non-numeric / empty / <= 0 / non-finite override is IGNORED (falls to map).
+export function resolveContextWindow(model, override) {
+  const n = Number(override)
+  if (Number.isFinite(n) && n > 0) return n
+  const id = typeof model === 'string' ? model.toLowerCase() : ''
+  if (!id) return null
+  if (id.includes('opus') || id.includes('sonnet') || id.includes('fable')) {
+    return CONTEXT_WINDOW_DEFAULT
+  }
+  if (id.includes('haiku')) return CONTEXT_WINDOW_HAIKU
+  return null
+}
+
+// Combined: extract the end-of-job context occupancy from the raw stream and
+// resolve it against the model's window. The statusline value = the INPUT side
+// of the MOST RECENT model request = input + cache_read + cache_creation of the
+// LAST message_start (NOT the cumulative result usage). Returns:
+//   context_end_tokens — number (0 if no message_start / no usage)
+//   context_end_pct     — tokens/window rounded to 6 dp, or null if window
+//                          unknown or tokens unavailable
+//   model               — model id string from the last message_start, or null
+// Degrades to safe defaults on any malformed input; never throws.
+export function computeContextEnd(rawStreamJson, windowOverride) {
+  const ms = lastMessageStart(rawStreamJson)
+  const message = ms && typeof ms.message === 'object' ? ms.message : null
+  const usage = message && typeof message.usage === 'object' ? message.usage : {}
+  const model = message && typeof message.model === 'string' ? message.model : null
+
+  // Coerce each field numerically before summing: a finite numeric string
+  // (e.g. "500") contributes its number, while null/undefined/NaN/Infinity/
+  // garbage contribute 0. This guarantees context_end_tokens is ALWAYS a
+  // finite number and never a concatenated string (e.g. "50000").
+  const num = (v) => {
+    const n = Number(v)
+    return Number.isFinite(n) ? n : 0
+  }
+  const tokens =
+    num(usage.input_tokens) +
+    num(usage.cache_read_input_tokens) +
+    num(usage.cache_creation_input_tokens)
+
+  const window = resolveContextWindow(model, windowOverride)
+  // pct is a plain ratio rounded to 6 decimal places (e.g. 0.012345); 6 dp keeps
+  // small occupancies meaningful against a 1M-token window. null when the window
+  // is unknown (we won't emit a wrong number) or there are no tokens to report.
+  const pct =
+    window && tokens > 0 ? Math.round((tokens / window) * 1e6) / 1e6 : null
+
+  return {
+    context_end_tokens: tokens,
+    context_end_pct: pct,
+    model,
+  }
+}
+
 function normalizeUsage(usage) {
   const u = usage && typeof usage === 'object' ? usage : {}
   return {
@@ -74,9 +166,11 @@ export function buildIssueEvent(input) {
     files = 0,
     insertions = 0,
     deletions = 0,
+    contextWindowOverride = null,
   } = input || {}
 
   const result = lastResultLine(rawStreamJson)
+  const context = computeContextEnd(rawStreamJson, contextWindowOverride)
 
   return {
     issue_number: issueNumber,
@@ -94,5 +188,10 @@ export function buildIssueEvent(input) {
     files,
     insertions,
     deletions,
+    // End-of-job context-window occupancy (#534): the statusline number, i.e.
+    // the input side of the LAST model request, and its share of the window.
+    context_end_tokens: context.context_end_tokens,
+    context_end_pct: context.context_end_pct,
+    model: context.model,
   }
 }

--- a/packages/ralph/lib/issue-event.test.js
+++ b/packages/ralph/lib/issue-event.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { buildIssueEvent } from './issue-event.js'
+import {
+  buildIssueEvent,
+  lastMessageStart,
+  resolveContextWindow,
+  computeContextEnd,
+} from './issue-event.js'
 
 // Helper: build a stream-json string from an array of JSON-able objects, one
 // per line (newline-delimited). Mirrors claude's --output-format stream-json.
@@ -20,6 +25,30 @@ const resultLine = (overrides = {}) => ({
     cache_creation_input_tokens: 25,
   },
   ...overrides,
+})
+
+// Helper: a bare `message_start` event (the shape claude emits directly).
+const messageStart = (overrides = {}) => ({
+  type: 'message_start',
+  message: {
+    model: 'claude-opus-4-8',
+    usage: {
+      input_tokens: 100,
+      cache_read_input_tokens: 200,
+      cache_creation_input_tokens: 50,
+    },
+    ...(overrides.message || {}),
+  },
+  ...(() => {
+    const { message, ...rest } = overrides
+    return rest
+  })(),
+})
+
+// Helper: a `message_start` wrapped inside a `stream_event` envelope.
+const wrappedMessageStart = (overrides = {}) => ({
+  type: 'stream_event',
+  event: messageStart(overrides),
 })
 
 const baseInput = (overrides = {}) => ({
@@ -425,5 +454,588 @@ describe('QA: buildIssueEvent — diff stats passthrough (#530)', () => {
     expect(e.files).toBe(87)
     expect(e.insertions).toBe(12_345)
     expect(e.deletions).toBe(6_789)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #534: end-of-job context-window occupancy.
+// ---------------------------------------------------------------------------
+
+describe('lastMessageStart — pure final-turn extraction', () => {
+  it('picks the LAST message_start, not the first', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 1 } },
+      }),
+      { type: 'assistant', message: {} },
+      messageStart({
+        message: {
+          model: 'claude-opus-4-8',
+          usage: {
+            input_tokens: 10,
+            cache_read_input_tokens: 20,
+            cache_creation_input_tokens: 3,
+          },
+        },
+      }),
+    ])
+    const ms = lastMessageStart(raw)
+    expect(ms.message.usage.input_tokens).toBe(10)
+  })
+
+  it('reads a single-turn stream', () => {
+    const raw = streamLines([messageStart(), resultLine()])
+    const ms = lastMessageStart(raw)
+    expect(ms.message.usage.input_tokens).toBe(100)
+  })
+
+  it('handles the wrapped stream_event envelope shape', () => {
+    const raw = streamLines([
+      wrappedMessageStart({
+        message: { model: 'claude-sonnet-4', usage: { input_tokens: 42 } },
+      }),
+    ])
+    const ms = lastMessageStart(raw)
+    expect(ms.message.usage.input_tokens).toBe(42)
+    expect(ms.message.model).toBe('claude-sonnet-4')
+  })
+
+  it('returns null when there is no message_start', () => {
+    expect(lastMessageStart(streamLines([resultLine()]))).toBeNull()
+  })
+
+  it('never throws on garbage / blank / partial lines', () => {
+    const raw = 'not json\n{partial\n\n   \n'
+    expect(() => lastMessageStart(raw)).not.toThrow()
+    expect(lastMessageStart(raw)).toBeNull()
+  })
+
+  it('tolerates empty / null input', () => {
+    expect(lastMessageStart('')).toBeNull()
+    expect(lastMessageStart(null)).toBeNull()
+  })
+})
+
+describe('resolveContextWindow — window resolution rules', () => {
+  it('maps opus -> 1_000_000', () => {
+    expect(resolveContextWindow('claude-opus-4-8', null)).toBe(1_000_000)
+  })
+
+  it('maps sonnet -> 1_000_000', () => {
+    expect(resolveContextWindow('claude-sonnet-4-5', null)).toBe(1_000_000)
+  })
+
+  it('maps fable -> 1_000_000', () => {
+    expect(resolveContextWindow('claude-fable-1', null)).toBe(1_000_000)
+  })
+
+  it('maps haiku -> 200_000', () => {
+    expect(resolveContextWindow('claude-haiku-4-5', null)).toBe(200_000)
+  })
+
+  it('unknown model with no override -> null', () => {
+    expect(resolveContextWindow('some-mystery-model', null)).toBeNull()
+  })
+
+  it('null/empty model with no override -> null', () => {
+    expect(resolveContextWindow(null, null)).toBeNull()
+    expect(resolveContextWindow('', null)).toBeNull()
+  })
+
+  it('numeric override wins over the map', () => {
+    expect(resolveContextWindow('claude-opus-4-8', 500_000)).toBe(500_000)
+  })
+
+  it('override wins even for an unknown model', () => {
+    expect(resolveContextWindow('mystery', 123_456)).toBe(123_456)
+  })
+
+  it('ignores non-positive / non-finite / non-numeric overrides (falls back to map)', () => {
+    expect(resolveContextWindow('claude-opus-4-8', 0)).toBe(1_000_000)
+    expect(resolveContextWindow('claude-opus-4-8', -5)).toBe(1_000_000)
+    expect(resolveContextWindow('claude-opus-4-8', NaN)).toBe(1_000_000)
+    expect(resolveContextWindow('claude-opus-4-8', Infinity)).toBe(1_000_000)
+    expect(resolveContextWindow('claude-opus-4-8', 'abc')).toBe(1_000_000)
+  })
+})
+
+describe('computeContextEnd — combined extraction + window resolution', () => {
+  it('sums input + cache_read + cache_creation of the LAST message_start', () => {
+    const raw = streamLines([
+      messageStart({ message: { usage: { input_tokens: 1 } } }),
+      messageStart({
+        message: {
+          model: 'claude-opus-4-8',
+          usage: {
+            input_tokens: 100,
+            cache_read_input_tokens: 200,
+            cache_creation_input_tokens: 50,
+          },
+        },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(350)
+    expect(c.model).toBe('claude-opus-4-8')
+    expect(c.context_end_pct).toBeCloseTo(350 / 1_000_000, 10)
+  })
+
+  it('does NOT use the cumulative result usage', () => {
+    const raw = streamLines([
+      messageStart({ message: { usage: { input_tokens: 100 } } }),
+      resultLine({ usage: { input_tokens: 999_999 } }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(100)
+  })
+
+  it('handles cache_read / cache_creation present', () => {
+    const raw = streamLines([
+      messageStart({
+        message: {
+          usage: {
+            input_tokens: 5,
+            cache_read_input_tokens: 10,
+            cache_creation_input_tokens: 15,
+          },
+        },
+      }),
+    ])
+    expect(computeContextEnd(raw, null).context_end_tokens).toBe(30)
+  })
+
+  it('unknown model, no override -> tokens + model emitted, pct null', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery-x', usage: { input_tokens: 42 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(42)
+    expect(c.model).toBe('mystery-x')
+    expect(c.context_end_pct).toBeNull()
+  })
+
+  it('RALPH_CONTEXT_WINDOW override applies the pct', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery-x', usage: { input_tokens: 100 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, 1000)
+    expect(c.context_end_pct).toBeCloseTo(0.1, 10)
+  })
+
+  it('no message_start -> 0 tokens, null model, null pct', () => {
+    const c = computeContextEnd(streamLines([resultLine()]), null)
+    expect(c.context_end_tokens).toBe(0)
+    expect(c.model).toBeNull()
+    expect(c.context_end_pct).toBeNull()
+  })
+
+  it('garbled / missing usage degrades to 0, never throws', () => {
+    const raw = streamLines([{ type: 'message_start', message: {} }])
+    let c
+    expect(() => {
+      c = computeContextEnd(raw, null)
+    }).not.toThrow()
+    expect(c.context_end_tokens).toBe(0)
+    expect(c.context_end_pct).toBeNull()
+  })
+
+  it('garbage stream never throws', () => {
+    expect(() => computeContextEnd('garbage\n{broken', null)).not.toThrow()
+    const c = computeContextEnd('garbage\n{broken', null)
+    expect(c.context_end_tokens).toBe(0)
+  })
+})
+
+describe('buildIssueEvent — context-window occupancy fields (#534)', () => {
+  it('emits context_end_tokens / context_end_pct / model from the last message_start', () => {
+    const raw = streamLines([
+      messageStart({
+        message: {
+          model: 'claude-opus-4-8',
+          usage: {
+            input_tokens: 1000,
+            cache_read_input_tokens: 2000,
+            cache_creation_input_tokens: 500,
+          },
+        },
+      }),
+      resultLine(),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.context_end_tokens).toBe(3500)
+    expect(e.model).toBe('claude-opus-4-8')
+    expect(e.context_end_pct).toBeCloseTo(3500 / 1_000_000, 10)
+  })
+
+  it('contextWindowOverride input is threaded through', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery', usage: { input_tokens: 250 } },
+      }),
+    ])
+    const e = buildIssueEvent(
+      baseInput({ rawStreamJson: raw, contextWindowOverride: 1000 }),
+    )
+    expect(e.context_end_pct).toBeCloseTo(0.25, 10)
+  })
+
+  it('unknown model, no override -> tokens + model, pct null', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery', usage: { input_tokens: 7 } },
+      }),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.context_end_tokens).toBe(7)
+    expect(e.model).toBe('mystery')
+    expect(e.context_end_pct).toBeNull()
+  })
+
+  it('no message_start -> 0 tokens, null model/pct (graceful)', () => {
+    const raw = streamLines([resultLine()])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.context_end_tokens).toBe(0)
+    expect(e.model).toBeNull()
+    expect(e.context_end_pct).toBeNull()
+  })
+
+  it('garbage stream -> safe defaults, never throws', () => {
+    let e
+    expect(() => {
+      e = buildIssueEvent(baseInput({ rawStreamJson: 'garbage\n{broken' }))
+    }).not.toThrow()
+    expect(e.context_end_tokens).toBe(0)
+    expect(e.context_end_pct).toBeNull()
+    expect(e.model).toBeNull()
+  })
+
+  it('null input does not throw and yields safe context defaults', () => {
+    const e = buildIssueEvent(null)
+    expect(e.context_end_tokens).toBe(0)
+    expect(e.context_end_pct).toBeNull()
+    expect(e.model).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#534): adversarial context-window cases the happy path
+// missed — mixed shapes, ordering, partial/typed usage, override precedence,
+// rounding precision, and safe degradation.
+// ---------------------------------------------------------------------------
+
+describe('QA: lastMessageStart — mixed shapes + ordering (#534)', () => {
+  it('LAST-wins when an EARLY one is bare and the LATER one is stream_event-wrapped', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 1 } },
+      }),
+      wrappedMessageStart({
+        message: { model: 'claude-sonnet-4', usage: { input_tokens: 222 } },
+      }),
+    ])
+    const ms = lastMessageStart(raw)
+    // Returns the UNWRAPPED event, so callers always see `.message` directly.
+    expect(ms.type).toBe('message_start')
+    expect(ms.message.usage.input_tokens).toBe(222)
+    expect(ms.message.model).toBe('claude-sonnet-4')
+  })
+
+  it('LAST-wins when an EARLY one is wrapped and the LATER one is bare', () => {
+    const raw = streamLines([
+      wrappedMessageStart({
+        message: { model: 'claude-sonnet-4', usage: { input_tokens: 1 } },
+      }),
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 333 } },
+      }),
+    ])
+    const ms = lastMessageStart(raw)
+    expect(ms.message.usage.input_tokens).toBe(333)
+    expect(ms.message.model).toBe('claude-opus-4-8')
+  })
+
+  it('takes the message_start that appears AFTER the result line (by position, not assuming order)', () => {
+    const raw = streamLines([
+      messageStart({ message: { usage: { input_tokens: 11 } } }),
+      resultLine(),
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 444 } },
+      }),
+    ])
+    const ms = lastMessageStart(raw)
+    expect(ms.message.usage.input_tokens).toBe(444)
+  })
+
+  it('a wrapped envelope whose inner event is NOT message_start is ignored', () => {
+    const raw = streamLines([
+      messageStart({ message: { usage: { input_tokens: 7 } } }),
+      { type: 'stream_event', event: { type: 'content_block_delta' } },
+    ])
+    const ms = lastMessageStart(raw)
+    expect(ms.message.usage.input_tokens).toBe(7)
+  })
+})
+
+describe('QA: computeContextEnd — message_start AFTER result (#534)', () => {
+  it('sums the LAST message_start even when it follows the result line', () => {
+    const raw = streamLines([
+      messageStart({ message: { usage: { input_tokens: 5 } } }),
+      resultLine({ usage: { input_tokens: 999_999 } }),
+      messageStart({
+        message: {
+          model: 'claude-opus-4-8',
+          usage: {
+            input_tokens: 100,
+            cache_read_input_tokens: 200,
+            cache_creation_input_tokens: 50,
+          },
+        },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(350)
+    expect(c.model).toBe('claude-opus-4-8')
+  })
+})
+
+describe('QA: computeContextEnd — partial usage fields (#534)', () => {
+  it('only input_tokens present (no cache fields) sums correctly, no NaN', () => {
+    const raw = streamLines([
+      messageStart({ message: { usage: { input_tokens: 100 } } }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(100)
+    expect(Number.isNaN(c.context_end_tokens)).toBe(false)
+  })
+
+  it('only cache fields present (no input_tokens) sums correctly, no NaN', () => {
+    const raw = streamLines([
+      messageStart({
+        message: {
+          usage: { cache_read_input_tokens: 10, cache_creation_input_tokens: 15 },
+        },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(25)
+    expect(Number.isNaN(c.context_end_tokens)).toBe(false)
+  })
+
+  it('usage entirely missing => 0 tokens, never NaN', () => {
+    const raw = streamLines([{ type: 'message_start', message: { model: 'claude-opus-4-8' } }])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(0)
+    expect(Number.isNaN(c.context_end_tokens)).toBe(false)
+    expect(c.context_end_pct).toBeNull()
+  })
+
+  it('usage values explicitly null => treated as 0 (?? catches null), no NaN', () => {
+    const raw = streamLines([
+      messageStart({
+        message: {
+          model: 'claude-opus-4-8',
+          usage: {
+            input_tokens: null,
+            cache_read_input_tokens: null,
+            cache_creation_input_tokens: null,
+          },
+        },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(0)
+    expect(Number.isNaN(c.context_end_tokens)).toBe(false)
+    expect(c.context_end_pct).toBeNull()
+  })
+
+  // ----- BUG SURFACE: string usage values -----
+  // The dev's sum uses `(usage.x ?? 0)`, which only substitutes for null/undefined.
+  // A STRING value (e.g. "500") survives `??` and is then `+`-combined, so JS does
+  // STRING CONCATENATION instead of numeric addition. The correct behavior is a
+  // NUMBER. These tests assert the correct behavior and are EXPECTED TO FAIL until
+  // the dev coerces usage values numerically (e.g. Number(x) || 0). Do not relax.
+  it('BUG: string input_tokens "500" must sum as the NUMBER 500, not concatenate', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: '500' } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(typeof c.context_end_tokens).toBe('number')
+    expect(c.context_end_tokens).toBe(500)
+    expect(Number.isNaN(c.context_end_tokens)).toBe(false)
+  })
+
+  it('BUG: mixed string + number usage must add numerically (string "500" + number 10 = 510)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: {
+          model: 'claude-opus-4-8',
+          usage: { input_tokens: '500', cache_read_input_tokens: 10 },
+        },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(typeof c.context_end_tokens).toBe('number')
+    expect(c.context_end_tokens).toBe(510)
+  })
+})
+
+describe('QA: computeContextEnd — model edge cases (#534)', () => {
+  it('model missing => model null, pct null (no window), tokens still emitted', () => {
+    const raw = streamLines([
+      { type: 'message_start', message: { usage: { input_tokens: 42 } } },
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.model).toBeNull()
+    expect(c.context_end_pct).toBeNull()
+    expect(c.context_end_tokens).toBe(42)
+  })
+
+  it('model non-string (number) => model null, pct null, tokens emitted', () => {
+    const raw = streamLines([
+      { type: 'message_start', message: { model: 12345, usage: { input_tokens: 42 } } },
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.model).toBeNull()
+    expect(c.context_end_pct).toBeNull()
+    expect(c.context_end_tokens).toBe(42)
+  })
+
+  it('model empty string => model "" (or null), pct null, tokens emitted', () => {
+    const raw = streamLines([
+      { type: 'message_start', message: { model: '', usage: { input_tokens: 42 } } },
+    ])
+    const c = computeContextEnd(raw, null)
+    // '' is a string so model passes through as ''; window unknown -> pct null.
+    expect(c.context_end_pct).toBeNull()
+    expect(c.context_end_tokens).toBe(42)
+  })
+})
+
+describe('QA: resolveContextWindow — override precedence (#534)', () => {
+  it('override BEATS a known model map value (opus + 50000 => 50000)', () => {
+    expect(resolveContextWindow('claude-opus-4-8', 50_000)).toBe(50_000)
+  })
+
+  it('override applies to computed pct (opus + 50000 => pct uses 50000)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 5000 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, 50_000)
+    expect(c.context_end_pct).toBeCloseTo(0.1, 10)
+  })
+
+  it('invalid overrides (0, -10, NaN, Infinity, "abc", "") fall back to the opus map', () => {
+    for (const bad of [0, -10, NaN, Infinity, 'abc', '']) {
+      expect(resolveContextWindow('claude-opus-4-8', bad)).toBe(1_000_000)
+    }
+  })
+
+  it('numeric STRING override "50000" is honored (coerced via Number)', () => {
+    expect(resolveContextWindow('claude-opus-4-8', '50000')).toBe(50_000)
+  })
+})
+
+describe('QA: computeContextEnd — unknown model + override interplay (#534)', () => {
+  it('unknown model, no override => tokens + model, pct null', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery-x', usage: { input_tokens: 42 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(42)
+    expect(c.model).toBe('mystery-x')
+    expect(c.context_end_pct).toBeNull()
+  })
+
+  it('unknown model WITH a valid override => pct computed from the override', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery-x', usage: { input_tokens: 100 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, 400)
+    expect(c.context_end_pct).toBeCloseTo(0.25, 10)
+  })
+})
+
+describe('QA: computeContextEnd — zero tokens with known window (#534)', () => {
+  it('zero tokens + a known window => pct null (intentional, per dev choice)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 0 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_tokens).toBe(0)
+    expect(c.model).toBe('claude-opus-4-8')
+    expect(c.context_end_pct).toBeNull()
+  })
+
+  it('zero tokens + an explicit override window => still pct null', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery', usage: { input_tokens: 0 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, 1000)
+    expect(c.context_end_pct).toBeNull()
+  })
+})
+
+describe('QA: computeContextEnd — rounding / precision (#534)', () => {
+  it('rounds an exact 6-dp ratio precisely (12345 / 1_000_000 = 0.012345)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 12_345 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_pct).toBe(0.012345)
+  })
+
+  it('a tiny occupancy stays non-zero at 6 dp (350 / 1_000_000 = 0.00035)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 350 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_pct).toBe(0.00035)
+    expect(c.context_end_pct).toBeGreaterThan(0)
+  })
+
+  it('rounds beyond 6 dp (1 / 1_000_000 = 0.000001, exact)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 1 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_pct).toBe(0.000001)
+  })
+})
+
+describe('QA: buildIssueEvent — context fields always present + safe (#534)', () => {
+  it('buildIssueEvent(undefined) still emits the three context fields safely', () => {
+    const e = buildIssueEvent(undefined)
+    expect(e).toHaveProperty('context_end_tokens', 0)
+    expect(e).toHaveProperty('context_end_pct', null)
+    expect(e).toHaveProperty('model', null)
+  })
+
+  it('empty stream string emits zero/null context fields', () => {
+    const e = buildIssueEvent(baseInput({ rawStreamJson: '' }))
+    expect(e.context_end_tokens).toBe(0)
+    expect(e.context_end_pct).toBeNull()
+    expect(e.model).toBeNull()
   })
 })

--- a/packages/ralph/templates/ralph.config.sh
+++ b/packages/ralph/templates/ralph.config.sh
@@ -19,6 +19,13 @@ AUTO_MERGE="true"
 MERGE_POLL_INTERVAL=30
 MERGE_POLL_MAX=40
 
+# Context-window override (tokens) for end-of-job occupancy metrics. Leave
+# unset/empty to auto-resolve from the run's model id (opus/sonnet/fable =
+# 1_000_000, haiku = 200_000; default 1_000_000 for the opus family). Set a
+# positive integer to override, e.g. RALPH_CONTEXT_WINDOW=200000 for a 200k
+# model. A non-numeric or <= 0 value is ignored.
+# RALPH_CONTEXT_WINDOW=1000000
+
 # Per-issue effort tiering (dark-launch foundation). Gates the Tier 2 /
 # Heavy triage path. 0 = off (the default): the heavy tier is unavailable
 # and triage falls back to Tier 1, so behavior is unchanged.


### PR DESCRIPTION
Closes #534

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/issue-event.test.js`, `packages/ralph/lib/capture-issue-event.test.js`
- Before implementation (red): new tests for `lastMessageStart` / `resolveContextWindow` / `computeContextEnd` and the three new `buildIssueEvent` fields (`context_end_tokens`, `context_end_pct`, `model`) failed because the helpers weren't exported and the fields were `undefined`.
- After implementation (green): all 737 ralph tests pass; 553 frontend tests pass; lint clean (0 errors); build clean.

Implementation:
- `packages/ralph/lib/issue-event.js` — three pure helpers: `lastMessageStart` (handles bare `message_start` AND `stream_event`-wrapped shapes, last-wins), `resolveContextWindow` (override > prefix map opus/sonnet/fable=1M, haiku=200k > null), `computeContextEnd` (sums input+cache_read+cache_creation of the LAST `message_start`; pct = tokens/window @ 6dp or null). `buildIssueEvent` emits `context_end_tokens`, `context_end_pct`, `model`.
- `packages/ralph/lib/capture-issue-event.js` — reads/validates `RALPH_CONTEXT_WINDOW` env, threads as `contextWindowOverride`.
- `packages/ralph/templates/ralph.config.sh` — documents the `RALPH_CONTEXT_WINDOW` tunable (auto-exported via `set -a` to the capture subprocess).

## QA scenarios added
- Last-wins across MIXED shapes (bare vs `stream_event`-wrapped, both orderings); `message_start` after the `result` line; partial usage (only input, only cache, missing, null); model missing/non-string/empty; override precedence (beats map; `0`/`-10`/`NaN`/`Infinity`/`"abc"`/`""` ignored; numeric-string honored); unknown-model→pct null; zero-tokens-with-known-window→pct null; garbled/empty stream + `buildIssueEvent(null)`; 6dp rounding exactness; entrypoint `RALPH_CONTEXT_WINDOW` wiring.
- **Bug found & fixed (blocked until green):** the token sum used `?? 0`, which left a string `usage` value (e.g. `"500"`) to **concatenate** instead of add, leaking a non-numeric `context_end_tokens`/bogus `context_end_pct`. Fixed with a finite-numeric `num()` coercion so the field is always a finite number. Tests at `packages/ralph/lib/issue-event.test.js`.

## Review verdict
- APPROVE. Reviewer judged the three pure helpers to have clean boundaries; the `lastMessageStart`/`lastResultLine` near-duplication and the two-layer override validation were each assessed and deemed justified (distinct return contracts / defense-in-depth at the untrusted env boundary). No blocking findings.

## Docs updated
- `packages/ralph/README.md` — added `context_end_tokens` / `context_end_pct` / `model` rows to the per-issue stream field table, a `RALPH_CONTEXT_WINDOW` row to the configuration reference, and prose noting the fields come from the last `message_start` and degrade to `0`/`null`.

## Notes
- Tier 1 / Standard run (full team: dev → QA → review → writer).
- `RALPH_CONTEXT_WINDOW` reaches the capture subprocess via the existing `set -a` in `ralph.sh` (no loop edit needed).