### PR TITLE
feat(ralph): record resolved context_window on per-issue metrics events

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -424,12 +424,14 @@ with these fields:
 | `context_end_tokens` | End-of-job context-window occupancy — the statusline number. The sum of `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` from the **last** `message_start` event (not the cumulative `result` usage). `0` when no `message_start` or usage is present. |
 | `context_end_pct` | `context_end_tokens / window`, rounded to 6 decimal places. `null` when the model's window is unknown or tokens are `0`. The window resolves from the model id (`opus`/`sonnet`/`fable` = 1,000,000; `haiku` = 200,000; default 1,000,000 for the opus family) or from the [`RALPH_CONTEXT_WINDOW`](#configuration-reference) override. |
 | `model` | The model id from the last `message_start`, or `null` if absent. |
+| `context_window` | The resolved context window in tokens — the **same** window that backs `context_end_pct` (single source of truth). Resolves from the model id (`opus`/`sonnet`/`fable` = 1,000,000; `haiku` = 200,000) or from the [`RALPH_CONTEXT_WINDOW`](#configuration-reference) override. `null` when the window is unknown. |
 
 `subtype`, `total_cost_usd`, `num_turns`, `duration_ms`, and `usage` are
 all pulled from the **last** parseable `result` line of the raw
 stream-json; blank, garbage, and non-JSON lines are skipped, and the
 fields default to zero/`null` when no `result` line is present.
-`context_end_tokens`, `context_end_pct`, and `model` are pulled from the
+`context_end_tokens`, `context_end_pct`, `model`, and `context_window`
+are pulled from the
 **last** `message_start` event (bare or wrapped in a `stream_event`
 envelope) and degrade to `0`/`null` when none is present.
 

--- a/packages/ralph/lib/issue-event.js
+++ b/packages/ralph/lib/issue-event.js
@@ -91,6 +91,8 @@ export function resolveContextWindow(model, override) {
 //   context_end_pct     — tokens/window rounded to 6 dp, or null if window
 //                          unknown or tokens unavailable
 //   model               — model id string from the last message_start, or null
+//   context_window      — the resolved window in tokens (same window backing
+//                          context_end_pct), or null when the window is unknown
 // Degrades to safe defaults on any malformed input; never throws.
 export function computeContextEnd(rawStreamJson, windowOverride) {
   const ms = lastMessageStart(rawStreamJson)
@@ -122,6 +124,7 @@ export function computeContextEnd(rawStreamJson, windowOverride) {
     context_end_tokens: tokens,
     context_end_pct: pct,
     model,
+    context_window: window,
   }
 }
 
@@ -193,5 +196,6 @@ export function buildIssueEvent(input) {
     context_end_tokens: context.context_end_tokens,
     context_end_pct: context.context_end_pct,
     model: context.model,
+    context_window: context.context_window,
   }
 }

--- a/packages/ralph/lib/issue-event.test.js
+++ b/packages/ralph/lib/issue-event.test.js
@@ -1024,6 +1024,142 @@ describe('QA: computeContextEnd — rounding / precision (#534)', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// #553: surface the RESOLVED context_window alongside context_end_pct so the
+// recorded window is guaranteed identical to the one behind the pct.
+// ---------------------------------------------------------------------------
+
+describe('computeContextEnd — resolved context_window (#553)', () => {
+  it('opus -> 1_000_000', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 100 } },
+      }),
+    ])
+    expect(computeContextEnd(raw, null).context_window).toBe(1_000_000)
+  })
+
+  it('sonnet -> 1_000_000', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-sonnet-4-5', usage: { input_tokens: 100 } },
+      }),
+    ])
+    expect(computeContextEnd(raw, null).context_window).toBe(1_000_000)
+  })
+
+  it('fable -> 1_000_000', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-fable-1', usage: { input_tokens: 100 } },
+      }),
+    ])
+    expect(computeContextEnd(raw, null).context_window).toBe(1_000_000)
+  })
+
+  it('haiku -> 200_000', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-haiku-4-5', usage: { input_tokens: 100 } },
+      }),
+    ])
+    expect(computeContextEnd(raw, null).context_window).toBe(200_000)
+  })
+
+  it('unrecognized model id -> null', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery-x', usage: { input_tokens: 100 } },
+      }),
+    ])
+    expect(computeContextEnd(raw, null).context_window).toBeNull()
+  })
+
+  it('honors the override argument (returns the overridden value)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 100 } },
+      }),
+    ])
+    expect(computeContextEnd(raw, 500_000).context_window).toBe(500_000)
+  })
+
+  it('override applies even for an unknown model', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery-x', usage: { input_tokens: 100 } },
+      }),
+    ])
+    expect(computeContextEnd(raw, 123_456).context_window).toBe(123_456)
+  })
+
+  it('the returned window equals the one implied by context_end_pct (tokens / window)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 12_345 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    // pct === tokens / window, so window === tokens / pct.
+    expect(c.context_end_tokens / c.context_window).toBe(c.context_end_pct)
+  })
+})
+
+describe('buildIssueEvent — emits context_window after model (#553)', () => {
+  it('emits context_window (1_000_000 for opus) in the context cluster', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 100 } },
+      }),
+      resultLine(),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.context_window).toBe(1_000_000)
+  })
+
+  it('positions context_window IMMEDIATELY AFTER model in key order', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 100 } },
+      }),
+      resultLine(),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    const keys = Object.keys(e)
+    expect(keys.indexOf('context_window')).toBe(keys.indexOf('model') + 1)
+  })
+
+  it('honors the contextWindowOverride input', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery', usage: { input_tokens: 100 } },
+      }),
+    ])
+    const e = buildIssueEvent(
+      baseInput({ rawStreamJson: raw, contextWindowOverride: 1000 }),
+    )
+    expect(e.context_window).toBe(1000)
+  })
+
+  it('context_window is null for an unrecognized model with no override', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'mystery', usage: { input_tokens: 7 } },
+      }),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.context_window).toBeNull()
+  })
+
+  it('context_window is ALWAYS present (null) on garbage / null input', () => {
+    expect(buildIssueEvent(baseInput({ rawStreamJson: 'garbage\n{broken' }))).toHaveProperty(
+      'context_window',
+      null,
+    )
+    expect(buildIssueEvent(null)).toHaveProperty('context_window', null)
+  })
+})
+
 describe('QA: buildIssueEvent — context fields always present + safe (#534)', () => {
   it('buildIssueEvent(undefined) still emits the three context fields safely', () => {
     const e = buildIssueEvent(undefined)
@@ -1037,5 +1173,215 @@ describe('QA: buildIssueEvent — context fields always present + safe (#534)', 
     expect(e.context_end_tokens).toBe(0)
     expect(e.context_end_pct).toBeNull()
     expect(e.model).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#553): the resolved context_window is the SINGLE SOURCE OF
+// TRUTH behind context_end_pct. These adversarial tests target invariants the
+// happy-path #553 suite did not: the pct/window/tokens consistency guarantee
+// (both directions), context_window fall-back on INVALID overrides routed
+// THROUGH computeContextEnd/buildIssueEvent (not just resolveContextWindow),
+// case-insensitive + substring model matching reflected in the window, and
+// haiku / invalid-override flow through buildIssueEvent.
+// ---------------------------------------------------------------------------
+
+describe('QA: computeContextEnd — pct/window/tokens consistency invariant (#553)', () => {
+  // The core "single source of truth" guarantee, both directions:
+  //   - window non-null  => round(tokens/window, 6dp) === pct
+  //   - window null      => pct MUST be null (never a bare/invented number)
+  const scenarios = [
+    { name: 'opus, small tokens', model: 'claude-opus-4-8', override: null, tokens: 350 },
+    { name: 'opus, exact-6dp tokens', model: 'claude-opus-4-8', override: null, tokens: 12_345 },
+    { name: 'opus, awkward tokens (rounding)', model: 'claude-opus-4-8', override: null, tokens: 7 },
+    { name: 'haiku, tokens', model: 'claude-haiku-4-5', override: null, tokens: 33_333 },
+    { name: 'sonnet, big tokens', model: 'claude-sonnet-4-5', override: null, tokens: 987_654 },
+    { name: 'unknown model, no override (window null)', model: 'mystery-x', override: null, tokens: 500 },
+    { name: 'unknown model + valid override', model: 'mystery-x', override: 40_000, tokens: 10_000 },
+    { name: 'opus + override beats map', model: 'claude-opus-4-8', override: 250_000, tokens: 12_500 },
+    { name: 'opus + INVALID override (falls to map)', model: 'claude-opus-4-8', override: 0, tokens: 12_345 },
+  ]
+
+  for (const { name, model, override, tokens } of scenarios) {
+    it(`[${name}] window null <=> pct null, and pct === round(tokens/window)`, () => {
+      const raw = streamLines([
+        messageStart({ message: { model, usage: { input_tokens: tokens } } }),
+      ])
+      const c = computeContextEnd(raw, override)
+      if (c.context_window === null) {
+        // No window we trust => we must NOT emit a percentage.
+        expect(c.context_end_pct).toBeNull()
+      } else {
+        // pct is EXACTLY the 6-dp rounding of tokens/window — same window that
+        // produced pct is the one surfaced in context_window.
+        const expected = Math.round((tokens / c.context_window) * 1e6) / 1e6
+        expect(c.context_end_pct).toBe(expected)
+      }
+    })
+  }
+
+  it('whenever context_end_pct is non-null, context_window is a positive finite number', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-sonnet-4-5', usage: { input_tokens: 4321 } },
+      }),
+    ])
+    const c = computeContextEnd(raw, null)
+    expect(c.context_end_pct).not.toBeNull()
+    expect(Number.isFinite(c.context_window)).toBe(true)
+    expect(c.context_window).toBeGreaterThan(0)
+  })
+})
+
+describe('QA: computeContextEnd — context_window fall-back on invalid overrides (#553)', () => {
+  // resolveContextWindow ignores bad overrides; verify the IGNORING is visible
+  // on the RESOLVED context_window field routed through computeContextEnd, not
+  // just via resolveContextWindow directly.
+  const mkRaw = (model) =>
+    streamLines([
+      messageStart({ message: { model, usage: { input_tokens: 100 } } }),
+    ])
+
+  for (const bad of [0, -5, NaN, Infinity, -Infinity, 'abc', '', null, undefined]) {
+    it(`invalid override ${String(bad)} on opus => context_window falls back to 1_000_000`, () => {
+      expect(computeContextEnd(mkRaw('claude-opus-4-8'), bad).context_window).toBe(
+        1_000_000,
+      )
+    })
+  }
+
+  for (const bad of [0, -5, NaN, Infinity, 'abc']) {
+    it(`invalid override ${String(bad)} on an UNKNOWN model => context_window stays null`, () => {
+      const c = computeContextEnd(mkRaw('mystery-x'), bad)
+      expect(c.context_window).toBeNull()
+      expect(c.context_end_pct).toBeNull()
+    })
+  }
+
+  it('valid numeric-string override "50000" on unknown model => context_window 50000', () => {
+    const c = computeContextEnd(mkRaw('mystery-x'), '50000')
+    expect(c.context_window).toBe(50_000)
+    // and the pct is computed from that very window
+    expect(c.context_end_pct).toBe(Math.round((100 / 50_000) * 1e6) / 1e6)
+  })
+
+  it('valid override with trailing/leading whitespace " 2000 " is coerced (Number) and wins', () => {
+    const c = computeContextEnd(mkRaw('mystery-x'), ' 2000 ')
+    expect(c.context_window).toBe(2000)
+  })
+})
+
+describe('QA: computeContextEnd — case-insensitive + substring model matching drives the window (#553)', () => {
+  const mkRaw = (model) =>
+    streamLines([
+      messageStart({ message: { model, usage: { input_tokens: 100 } } }),
+    ])
+
+  it('ALL-CAPS opus id "CLAUDE-OPUS-4-8" resolves to 1_000_000', () => {
+    expect(computeContextEnd(mkRaw('CLAUDE-OPUS-4-8'), null).context_window).toBe(
+      1_000_000,
+    )
+  })
+
+  it('mixed-case "Claude-Haiku-4-5" resolves to 200_000', () => {
+    expect(computeContextEnd(mkRaw('Claude-Haiku-4-5'), null).context_window).toBe(
+      200_000,
+    )
+  })
+
+  it('a vendor-prefixed id merely CONTAINING "sonnet" resolves to 1_000_000', () => {
+    expect(
+      computeContextEnd(mkRaw('bedrock/anthropic.SONNET-custom'), null).context_window,
+    ).toBe(1_000_000)
+  })
+
+  it('an id containing "fable" as a substring resolves to 1_000_000', () => {
+    expect(computeContextEnd(mkRaw('internal-fable-preview'), null).context_window).toBe(
+      1_000_000,
+    )
+  })
+
+  it('an id containing NONE of the known substrings stays null', () => {
+    expect(computeContextEnd(mkRaw('gpt-4o'), null).context_window).toBeNull()
+  })
+})
+
+describe('QA: buildIssueEvent — context_window flows + is never undefined (#553)', () => {
+  it('valid haiku stream => context_window 200_000 flows through buildIssueEvent', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-haiku-4-5', usage: { input_tokens: 100 } },
+      }),
+      resultLine(),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw }))
+    expect(e.context_window).toBe(200_000)
+  })
+
+  it('haiku + override => the OVERRIDDEN value flows through (override wins over 200_000)', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-haiku-4-5', usage: { input_tokens: 100 } },
+      }),
+    ])
+    const e = buildIssueEvent(
+      baseInput({ rawStreamJson: raw, contextWindowOverride: 12_000 }),
+    )
+    expect(e.context_window).toBe(12_000)
+  })
+
+  it('INVALID override (0) on opus stream => context_window falls back to 1_000_000', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-opus-4-8', usage: { input_tokens: 100 } },
+      }),
+    ])
+    const e = buildIssueEvent(
+      baseInput({ rawStreamJson: raw, contextWindowOverride: 0 }),
+    )
+    expect(e.context_window).toBe(1_000_000)
+  })
+
+  it('context_window is a present key (never undefined) across malformed inputs', () => {
+    const inputs = [
+      null,
+      undefined,
+      baseInput({ rawStreamJson: '' }),
+      baseInput({ rawStreamJson: 'not json\n{broken' }),
+      baseInput({ rawStreamJson: streamLines([{ type: 'message_start', message: {} }]) }),
+      baseInput({ rawStreamJson: streamLines([resultLine()]) }),
+    ]
+    for (const input of inputs) {
+      const e = buildIssueEvent(input)
+      expect('context_window' in e).toBe(true)
+      expect(e.context_window).not.toBeUndefined()
+    }
+  })
+
+  it('context_window equals context.context_window: matches computeContextEnd for the same stream/override', () => {
+    const raw = streamLines([
+      messageStart({
+        message: { model: 'claude-sonnet-4-5', usage: { input_tokens: 4321 } },
+      }),
+    ])
+    const e = buildIssueEvent(baseInput({ rawStreamJson: raw, contextWindowOverride: null }))
+    const c = computeContextEnd(raw, null)
+    expect(e.context_window).toBe(c.context_window)
+    expect(e.context_end_pct).toBe(c.context_end_pct)
+  })
+
+  it('event-level invariant: context_window null <=> context_end_pct null', () => {
+    const rawKnown = streamLines([
+      messageStart({ message: { model: 'claude-opus-4-8', usage: { input_tokens: 5 } } }),
+    ])
+    const rawUnknown = streamLines([
+      messageStart({ message: { model: 'mystery-x', usage: { input_tokens: 5 } } }),
+    ])
+    const known = buildIssueEvent(baseInput({ rawStreamJson: rawKnown }))
+    const unknown = buildIssueEvent(baseInput({ rawStreamJson: rawUnknown }))
+    expect(known.context_window).not.toBeNull()
+    expect(known.context_end_pct).not.toBeNull()
+    expect(unknown.context_window).toBeNull()
+    expect(unknown.context_end_pct).toBeNull()
   })
 })


### PR DESCRIPTION
Closes #553

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/issue-event.test.js`
- Before implementation (red): 13 new tests failed for the right reason — `context_window` was absent/`undefined` on both the `computeContextEnd` result and the `buildIssueEvent` output (e.g. `expected undefined ... "context_window" with value null`). Cases: opus/sonnet/fable → 1000000, haiku → 200000, unknown → null, override honored, override wins for unknown model, window matches `tokens / context_end_pct`, `buildIssueEvent` emits it immediately after `model`, always present (null) on garbage/null input.
- After implementation (green): all 787 tests pass (30 files).

Source change is a minimal 2-line passthrough: `computeContextEnd` returns the already-resolved `window` variable as `context_window` (the single value that also backs `context_end_pct` — guaranteed identical), and `buildIssueEvent` forwards `context.context_window` immediately after `model`. No new logic, no id→name mapping table, window resolution unchanged.

## QA scenarios added
- pct/window/tokens consistency invariant sweep (9 scenarios): when `context_window` is null, `context_end_pct` must also be null; when non-null, `context_end_pct` must equal `round(tokens/context_window, 6dp)` — both directions.
- Override fall-back through `computeContextEnd`: `0, -5, NaN, Infinity, -Infinity, "abc", "", null, undefined` ignored (fall back to map/null); valid numeric-string `"50000"` and whitespace-padded `" 2000 "` coerced and win.
- Case-insensitive + substring model matching driving the window (`CLAUDE-OPUS-...`, `bedrock/anthropic.SONNET-custom`, `internal-fable-preview`, `gpt-4o`→null).
- `buildIssueEvent` flow: valid haiku stream → 200000; haiku + override → overridden value wins; invalid override → falls back; `context_window` always present (never undefined) across null/undefined/empty/garbage/missing-message inputs; field ordering (after `model`) locked in.
- All added in `packages/ralph/lib/issue-event.test.js`.

## Review verdict
- Approved. Single source of truth confirmed (reuses existing `window` var, no re-resolution); no display-name/mapping table added; `heartbeat.js`, `issue-metrics.js`, `capture-issue-event.js`, `ralph.sh`, and `RALPH_CYCLE_EVENT` all untouched; purely additive passthrough with no spaghetti/oversized-file concerns. No blocking findings.

## Docs updated
- `packages/ralph/README.md` — added a `context_window` row to the per-issue schema table (after `model`) and extended the "pulled from the last `message_start`" sentence to list `context_window`.
- `packages/ralph/lib/issue-event.js` — added a `context_window` line to the `computeContextEnd` JSDoc so the docstring matches the code.
- `RALPH_MONITORING_PLAN.md`: verified already absent (never tracked, not on disk) — the delete criterion is already satisfied; nothing created.

## Notes
- `npm test` (ralph package): 787 pass. `npm run lint` (repo): 0 errors (26 pre-existing warnings in `src/`, unrelated to this diff which only touches `packages/ralph/`).
- `npm ci` fails on a pre-existing, unrelated lockfile mismatch (`@emnapi/wasi-threads`); node_modules was already present, so tests/lint ran directly.