### PR TITLE
feat(ralph): agent registry as single source of agent knowledge

### DIFF
--- a/packages/ralph/lib/agent-invocation.js
+++ b/packages/ralph/lib/agent-invocation.js
@@ -11,52 +11,34 @@
 // call gh) and approvals disabled for full autonomy — the loop is unattended.
 //
 // Pure and injectable: `buildAgentInvocation(env)` takes an env object and
-// returns `{agent, cli, args}`; `emitShellAssignments(inv)` renders bash. When
-// run as a script it reads process.env and prints the assignments to stdout.
+// returns `{agent, cli, args, streamFilter}`; `emitShellAssignments(inv)`
+// renders bash. When run as a script it reads process.env and prints the
+// assignments to stdout.
 
 import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
 import { resolveAgent, agentSpec } from './agent-registry.js'
 
-// Claude's stream-json flags — unchanged from the original ralph.sh pipeline.
-const CLAUDE_ARGS = [
-  '-p',
-  '--dangerously-skip-permissions',
-  '--output-format',
-  'stream-json',
-  '--verbose',
-  '--include-partial-messages',
-]
-
 export function buildAgentInvocation(env = {}) {
   const { agent } = resolveAgent(env)
   const spec = agentSpec(agent)
 
+  // The STATIC argv base comes from the registry spec (single source of truth).
+  // For claude that's byte-for-byte the flags the loop has always used, so the
+  // Claude pipeline is unchanged.
+  const args = [...spec.argv]
+
   if (agent === 'codex') {
+    // Compose the env-dependent parts on top of the static base.
     const model = (env.RALPH_CODEX_MODEL || '').trim()
-    const args = [
-      'exec',
-      '--json',
-      '--sandbox',
-      'workspace-write',
-      // Full autonomy for an unattended loop: never prompt for approval, and
-      // keep network access inside the workspace-write sandbox so the agent can
-      // run git/gh/npm just like Claude does.
-      '-c',
-      'approval_policy="never"',
-      '-c',
-      'sandbox_workspace_write.network_access=true',
-    ]
     if (model) {
       args.push('-m', model)
     }
     // Prompt is piped on stdin; `-` makes Codex read it from there.
     args.push('-')
-    return { agent, cli: spec.cli, args }
   }
 
-  // Default / claude.
-  return { agent, cli: spec.cli, args: [...CLAUDE_ARGS] }
+  return { agent, cli: spec.cli, args, streamFilter: spec.streamFilter }
 }
 
 // POSIX single-quote escaping: wrap in single quotes, and turn any embedded
@@ -65,12 +47,13 @@ function shQuote(s) {
   return `'${String(s).replace(/'/g, `'\\''`)}'`
 }
 
-export function emitShellAssignments({ agent, cli, args }) {
+export function emitShellAssignments({ agent, cli, args, streamFilter }) {
   const quotedArgs = args.map(shQuote).join(' ')
   return [
     `RALPH_RESOLVED_AGENT=${shQuote(agent)}`,
     `RALPH_AGENT_CLI=${shQuote(cli)}`,
     `RALPH_AGENT_ARGS=(${quotedArgs})`,
+    `RALPH_AGENT_STREAM_FILTER=${shQuote(streamFilter ?? '')}`,
   ].join('\n')
 }
 

--- a/packages/ralph/lib/agent-invocation.test.js
+++ b/packages/ralph/lib/agent-invocation.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { buildAgentInvocation, emitShellAssignments } from './agent-invocation.js'
+import { agentSpec } from './agent-registry.js'
 
 describe('buildAgentInvocation — resolve the agent CLI + argv (#554)', () => {
   it('defaults to claude with the stream-json argv unchanged', () => {
@@ -53,6 +54,29 @@ describe('buildAgentInvocation — resolve the agent CLI + argv (#554)', () => {
   })
 })
 
+describe('buildAgentInvocation — args derive from the registry spec.argv (#555)', () => {
+  it('claude argv is byte-for-byte the exact 6-flag stream-json array', () => {
+    // The Claude pipeline MUST stay unchanged: prove the argv equals the exact
+    // static template (sourced from spec.argv, not a local const).
+    expect(buildAgentInvocation({}).args).toEqual([
+      '-p',
+      '--dangerously-skip-permissions',
+      '--output-format',
+      'stream-json',
+      '--verbose',
+      '--include-partial-messages',
+    ])
+    expect(buildAgentInvocation({}).args).toEqual(agentSpec('claude').argv)
+  })
+
+  it('codex argv starts with the spec.argv static base, then composes model/stdin', () => {
+    const base = agentSpec('codex').argv
+    const inv = buildAgentInvocation({ RALPH_AGENT: 'codex' })
+    // The static base is a prefix of the composed argv.
+    expect(inv.args.slice(0, base.length)).toEqual(base)
+  })
+})
+
 describe('emitShellAssignments — eval-able bash', () => {
   it('emits RALPH_RESOLVED_AGENT, RALPH_AGENT_CLI and a quoted arg array', () => {
     const sh = emitShellAssignments(buildAgentInvocation({ RALPH_AGENT: 'codex' }))
@@ -64,6 +88,18 @@ describe('emitShellAssignments — eval-able bash', () => {
     expect(sh).toContain(`'approval_policy="never"'`)
   })
 
+  it('emits RALPH_AGENT_STREAM_FILTER single-quoted from the spec (AC#6)', () => {
+    const sh = emitShellAssignments(buildAgentInvocation({ RALPH_AGENT: 'codex' }))
+    expect(sh).toContain('RALPH_AGENT_STREAM_FILTER=')
+    // The value is the codex jq program, single-quoted.
+    expect(sh).toContain(`RALPH_AGENT_STREAM_FILTER='${agentSpec('codex').streamFilter}'`)
+  })
+
+  it('emits the claude stream filter unchanged for the default agent (AC#6)', () => {
+    const sh = emitShellAssignments(buildAgentInvocation({}))
+    expect(sh).toContain(`RALPH_AGENT_STREAM_FILTER='${agentSpec('claude').streamFilter}'`)
+  })
+
   it('safely single-quotes a value containing a single quote', () => {
     const sh = emitShellAssignments({
       agent: 'codex',
@@ -72,5 +108,180 @@ describe('emitShellAssignments — eval-able bash', () => {
     })
     // Standard POSIX single-quote escaping: ' -> '\''
     expect(sh).toContain(`'it'\\''s'`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#555)
+// ---------------------------------------------------------------------------
+
+// Reimplement the POSIX single-quote rule independently so the assertions below
+// don't just re-derive the production shQuote — they encode the RULE the shell
+// actually obeys: wrap in single quotes, and every embedded ' becomes '\''.
+function posixSingleQuote(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`
+}
+
+// Extract the RALPH_AGENT_STREAM_FILTER=... value line from the emitted block.
+// The filter is multi-line, so the value runs to the end of the block (it is
+// the LAST assignment emitted). Everything after the `=` is the quoted value.
+function extractStreamFilterValue(sh) {
+  const marker = '\nRALPH_AGENT_STREAM_FILTER='
+  const idx = sh.indexOf(marker)
+  if (idx === -1) throw new Error('no RALPH_AGENT_STREAM_FILTER assignment found')
+  return sh.slice(idx + marker.length)
+}
+
+describe('QA: emitShellAssignments — streamFilter is shell-inert (AC#6)', () => {
+  it('emits FOUR eval-able assignment lines in the documented order', () => {
+    const sh = emitShellAssignments(buildAgentInvocation({ RALPH_AGENT: 'codex' }))
+    const lines = sh.split('\n')
+    expect(lines[0]).toMatch(/^RALPH_RESOLVED_AGENT=/)
+    expect(lines[1]).toMatch(/^RALPH_AGENT_CLI=/)
+    expect(lines[2]).toMatch(/^RALPH_AGENT_ARGS=\(/)
+    // The stream filter is multi-line, so it is the LAST assignment; its own
+    // first line begins the assignment, remaining lines are the filter body.
+    const filterStart = lines.findIndex((l) => l.startsWith('RALPH_AGENT_STREAM_FILTER='))
+    expect(filterStart).toBe(3)
+  })
+
+  it('wraps the multi-line jq filter in a SINGLE pair of single quotes', () => {
+    // Everything inside single quotes is literal to bash: newlines, ", |, //,
+    // $ and the ↳/✗ glyphs are all inert. Prove the value opens and closes with
+    // a single quote and contains no unescaped interior single quote.
+    for (const agent of ['claude', 'codex']) {
+      const sh = emitShellAssignments(buildAgentInvocation({ RALPH_AGENT: agent }))
+      const value = extractStreamFilterValue(sh)
+      expect(value.startsWith("'")).toBe(true)
+      expect(value.endsWith("'")).toBe(true)
+      // Neither production filter contains a single quote, so after stripping
+      // the outer quotes there must be zero single quotes left in the body.
+      const body = value.slice(1, -1)
+      expect(body).not.toContain("'")
+    }
+  })
+
+  it('preserves the codex filter byte-for-byte (special chars $ " | // ✗ newline)', () => {
+    const filter = agentSpec('codex').streamFilter
+    // Precondition: this filter really does carry the hostile characters.
+    expect(filter).toContain('\n')
+    expect(filter).toContain('"')
+    expect(filter).toContain('$') // e.g. "  $ " command prefix
+    expect(filter).toContain('✗')
+    expect(filter).toContain('//')
+
+    const sh = emitShellAssignments(buildAgentInvocation({ RALPH_AGENT: 'codex' }))
+    const value = extractStreamFilterValue(sh)
+    // The emitted value equals the POSIX-quoted original exactly. Since the
+    // filter has no single quote, this is the original wrapped in '...'; the
+    // substring between the outer quotes is byte-for-byte the filter.
+    expect(value).toBe(posixSingleQuote(filter))
+    expect(value.slice(1, -1)).toBe(filter)
+  })
+
+  it('preserves the claude filter byte-for-byte (special chars ↳ " | // newline)', () => {
+    const filter = agentSpec('claude').streamFilter
+    expect(filter).toContain('\n')
+    expect(filter).toContain('↳')
+    const sh = emitShellAssignments(buildAgentInvocation({}))
+    const value = extractStreamFilterValue(sh)
+    expect(value).toBe(posixSingleQuote(filter))
+    expect(value.slice(1, -1)).toBe(filter)
+  })
+
+  it('POSIX-escapes a single quote inside a filter (\' -> \'\\\'\') without breaking the wrap', () => {
+    // The production filters have no single quote, but the emitter MUST handle
+    // one correctly if a future filter contains it — otherwise the eval breaks.
+    const hostile = `fromjson? // empty | "it's a ↳ $x" | "==> result:"`
+    const sh = emitShellAssignments({
+      agent: 'codex',
+      cli: 'codex',
+      args: [],
+      streamFilter: hostile,
+    })
+    const value = extractStreamFilterValue(sh)
+    // The whole value is the POSIX-quoted hostile string...
+    expect(value).toBe(posixSingleQuote(hostile))
+    // ...and it literally contains the '\'' escape sequence for the apostrophe.
+    expect(value).toContain(`'\\''`)
+  })
+
+  it('emits RALPH_AGENT_STREAM_FILTER even when streamFilter is missing (empty single-quoted)', () => {
+    const sh = emitShellAssignments({ agent: 'claude', cli: 'claude', args: [] })
+    expect(sh).toContain("RALPH_AGENT_STREAM_FILTER=''")
+  })
+})
+
+describe('QA: buildAgentInvocation — spec/invocation round-trip consistency (#555)', () => {
+  it('claude streamFilter round-trips through buildAgentInvocation', () => {
+    expect(buildAgentInvocation({}).streamFilter).toBe(agentSpec('claude').streamFilter)
+  })
+
+  it('codex streamFilter round-trips through buildAgentInvocation', () => {
+    expect(buildAgentInvocation({ RALPH_AGENT: 'codex' }).streamFilter).toBe(
+      agentSpec('codex').streamFilter,
+    )
+  })
+
+  it('a fallen-back agent uses the CLAUDE streamFilter (resolved==fallback)', () => {
+    expect(buildAgentInvocation({ RALPH_AGENT: 'gpt-9000' }).streamFilter).toBe(
+      agentSpec('claude').streamFilter,
+    )
+  })
+
+  it('claude args equal spec.argv byte-for-byte (no env-dependent tail)', () => {
+    expect(buildAgentInvocation({}).args).toEqual(agentSpec('claude').argv)
+  })
+
+  it('codex args START WITH spec.argv, then append the env-dependent tail', () => {
+    const base = agentSpec('codex').argv
+    const inv = buildAgentInvocation({ RALPH_AGENT: 'codex', RALPH_CODEX_MODEL: 'gpt-5-codex' })
+    expect(inv.args.slice(0, base.length)).toEqual(base)
+    // Tail is exactly the composed model pair plus the stdin marker.
+    expect(inv.args.slice(base.length)).toEqual(['-m', 'gpt-5-codex', '-'])
+  })
+})
+
+describe('QA: buildAgentInvocation — codex model composition edge cases (#555)', () => {
+  it('trims surrounding whitespace from RALPH_CODEX_MODEL before passing it', () => {
+    const inv = buildAgentInvocation({
+      RALPH_AGENT: 'codex',
+      RALPH_CODEX_MODEL: '  gpt-5-codex  ',
+    })
+    const i = inv.args.indexOf('-m')
+    expect(i).toBeGreaterThanOrEqual(0)
+    expect(inv.args[i + 1]).toBe('gpt-5-codex')
+  })
+
+  it('places the -m <model> pair BEFORE the trailing "-" stdin marker', () => {
+    const inv = buildAgentInvocation({
+      RALPH_AGENT: 'codex',
+      RALPH_CODEX_MODEL: 'gpt-5-codex',
+    })
+    const mIdx = inv.args.indexOf('-m')
+    const stdinIdx = inv.args.lastIndexOf('-')
+    expect(mIdx).toBeGreaterThanOrEqual(0)
+    expect(stdinIdx).toBeGreaterThan(mIdx + 1) // model value sits between them
+    // The stdin marker is the very last arg.
+    expect(inv.args[inv.args.length - 1]).toBe('-')
+  })
+
+  it('with no model, the trailing "-" stdin marker is still the last arg (no -m)', () => {
+    const inv = buildAgentInvocation({ RALPH_AGENT: 'codex' })
+    expect(inv.args).not.toContain('-m')
+    expect(inv.args[inv.args.length - 1]).toBe('-')
+  })
+
+  it('a whitespace-only model is treated as unset (no -m, stdin marker present)', () => {
+    const inv = buildAgentInvocation({ RALPH_AGENT: 'codex', RALPH_CODEX_MODEL: '\t \n' })
+    expect(inv.args).not.toContain('-m')
+    expect(inv.args[inv.args.length - 1]).toBe('-')
+  })
+
+  it('does NOT compose a model or stdin marker for claude', () => {
+    const inv = buildAgentInvocation({ RALPH_CODEX_MODEL: 'gpt-5-codex' })
+    expect(inv.agent).toBe('claude')
+    expect(inv.args).not.toContain('-m')
+    expect(inv.args).not.toContain('-')
   })
 })

--- a/packages/ralph/lib/agent-registry.js
+++ b/packages/ralph/lib/agent-registry.js
@@ -11,10 +11,62 @@
 //     overnight run is never aborted by a typo, and the resolved (fallen-back)
 //     agent is what telemetry records so the typo stays auditable.
 //   agentSpec(agent) — the per-agent spec object (CLI name, orchestrator
-//     template filename, dependency name, auth-probe kind).
+//     template filename, dependency name, auth-probe kind, static CLI argv
+//     template, and jq output-stream filter program).
 
 const DEFAULT_AGENT = 'claude'
 const VALID_AGENTS = ['claude', 'codex']
+
+// The STATIC argv template each agent CLI is invoked with. This is the base
+// only — the env-dependent Codex `-m <model>` flag and the `-` stdin marker are
+// composed on top of this in agent-invocation.js. For claude these six flags
+// are the exact stream-json flags the loop has always used, so the Claude
+// pipeline is byte-for-byte unchanged.
+const CLAUDE_ARGV = [
+  '-p',
+  '--dangerously-skip-permissions',
+  '--output-format',
+  'stream-json',
+  '--verbose',
+  '--include-partial-messages',
+]
+const CODEX_ARGV = [
+  'exec',
+  '--json',
+  '--sandbox',
+  'workspace-write',
+  // Full autonomy for an unattended loop: never prompt for approval, and keep
+  // network access inside the workspace-write sandbox so the agent can run
+  // git/gh/npm just like Claude does.
+  '-c',
+  'approval_policy="never"',
+  '-c',
+  'sandbox_workspace_write.network_access=true',
+]
+
+// The jq output-stream filter each agent's pretty-printer uses (moved verbatim
+// out of templates/ralph.sh — byte-for-byte the same programs, so the rendered
+// log output is unchanged). Both are cosmetic; the authoritative metrics parse
+// happens in Node (capture-issue-event.js via parseAgentStream), never here.
+const CLAUDE_STREAM_FILTER = `fromjson? // empty
+  | if .type == "assistant" then
+      (.message.content[]? | select(.type=="text").text // empty)
+    elif .type == "user" then
+      (.message.content[]? | select(.type=="tool_result") | "  ↳ tool_result")
+    elif .type == "result" then
+      "==> result: " + (.subtype // "ok")
+    else empty end`
+const CODEX_STREAM_FILTER = `fromjson? // empty
+  | if .type == "item.completed" then
+      (.item
+        | if (.type // "") == "agent_message" or (.type // "") == "assistant_message" then (.text // .message // empty)
+          elif (.type // "") == "command_execution" then ("  $ " + (.command // ""))
+          elif (.type // "") == "error" then ("  ✗ " + (.message // "error"))
+          else empty end)
+    elif .type == "turn.completed" then "==> result: success"
+    elif .type == "turn.failed" then "==> result: error"
+    elif .type == "error" then "==> result: error"
+    else empty end`
 
 const SPECS = {
   claude: {
@@ -22,12 +74,16 @@ const SPECS = {
     orchestratorTemplate: 'prompt-team.md',
     dependency: 'claude',
     authProbe: 'credentials-file',
+    argv: CLAUDE_ARGV,
+    streamFilter: CLAUDE_STREAM_FILTER,
   },
   codex: {
     cli: 'codex',
     orchestratorTemplate: 'prompt-team-codex.md',
     dependency: 'codex',
     authProbe: 'login-status',
+    argv: CODEX_ARGV,
+    streamFilter: CODEX_STREAM_FILTER,
   },
 }
 
@@ -60,5 +116,6 @@ export function agentSpec(agent) {
       `agentSpec: unknown agent '${agent}'. Valid: ${VALID_AGENTS.join(', ')}.`,
     )
   }
-  return { ...spec }
+  // Copy the argv array too so a caller mutating it can't corrupt the registry.
+  return { ...spec, argv: [...spec.argv] }
 }

--- a/packages/ralph/lib/agent-registry.test.js
+++ b/packages/ralph/lib/agent-registry.test.js
@@ -58,6 +58,30 @@ describe('resolveAgent — reads RALPH_AGENT from env', () => {
   })
 })
 
+// The exact static argv template Claude has always used — asserted here so a
+// drift in the registry is caught (the Claude pipeline must stay unchanged).
+const CLAUDE_ARGV = [
+  '-p',
+  '--dangerously-skip-permissions',
+  '--output-format',
+  'stream-json',
+  '--verbose',
+  '--include-partial-messages',
+]
+
+// The static base Codex argv (env-dependent `-m <model>` and the `-` stdin
+// marker are composed in agent-invocation.js, NOT here).
+const CODEX_ARGV = [
+  'exec',
+  '--json',
+  '--sandbox',
+  'workspace-write',
+  '-c',
+  'approval_policy="never"',
+  '-c',
+  'sandbox_workspace_write.network_access=true',
+]
+
 describe('agentSpec — per-agent knowledge', () => {
   it('returns the claude spec', () => {
     expect(agentSpec('claude')).toEqual({
@@ -65,6 +89,8 @@ describe('agentSpec — per-agent knowledge', () => {
       orchestratorTemplate: 'prompt-team.md',
       dependency: 'claude',
       authProbe: 'credentials-file',
+      argv: CLAUDE_ARGV,
+      streamFilter: expect.any(String),
     })
   })
 
@@ -74,12 +100,58 @@ describe('agentSpec — per-agent knowledge', () => {
       orchestratorTemplate: 'prompt-team-codex.md',
       dependency: 'codex',
       authProbe: 'login-status',
+      argv: CODEX_ARGV,
+      streamFilter: expect.any(String),
     })
   })
 
   it('throws on an unknown agent', () => {
     expect(() => agentSpec('gpt')).toThrow()
     expect(() => agentSpec()).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AC#5 (#555): the spec is now COMPLETE — it carries the static argv template
+// AND the jq output-stream filter, so bash holds no agent knowledge.
+// ---------------------------------------------------------------------------
+
+describe('agentSpec — argv static template (AC#5)', () => {
+  it('claude argv is the exact 6-flag stream-json template', () => {
+    expect(agentSpec('claude').argv).toEqual(CLAUDE_ARGV)
+  })
+
+  it('codex argv is the exact static base (no -m, no stdin marker)', () => {
+    const argv = agentSpec('codex').argv
+    expect(argv).toEqual(CODEX_ARGV)
+    expect(argv).not.toContain('-m')
+    expect(argv).not.toContain('-')
+  })
+
+  it('returns a fresh argv array copy each call (no shared mutation)', () => {
+    const a = agentSpec('claude').argv
+    a.push('HACKED')
+    expect(agentSpec('claude').argv).toEqual(CLAUDE_ARGV)
+  })
+})
+
+describe('agentSpec — streamFilter jq program (AC#5)', () => {
+  it('claude has a non-empty jq filter string rendering stream-json events', () => {
+    const f = agentSpec('claude').streamFilter
+    expect(typeof f).toBe('string')
+    expect(f.length).toBeGreaterThan(0)
+    expect(f).toContain('fromjson? // empty')
+    expect(f).toContain('.type == "assistant"')
+    expect(f).toContain('==> result: ')
+  })
+
+  it('codex has a non-empty jq filter string rendering codex JSONL events', () => {
+    const f = agentSpec('codex').streamFilter
+    expect(typeof f).toBe('string')
+    expect(f.length).toBeGreaterThan(0)
+    expect(f).toContain('fromjson? // empty')
+    expect(f).toContain('item.completed')
+    expect(f).toContain('turn.completed')
   })
 })
 
@@ -162,5 +234,80 @@ describe('QA: agentSpec — returns an independent copy (no shared mutation)', (
   it('throws (not returns undefined) for null / empty-string agent', () => {
     expect(() => agentSpec(null)).toThrow()
     expect(() => agentSpec('')).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#555): registry immutability is COMPLETE, and streamFilter
+// content is a real jq program (not a placeholder). The registry is the single
+// source of agent knowledge, so a caller corrupting a returned value must never
+// leak back into the next reader.
+// ---------------------------------------------------------------------------
+
+describe('QA: agentSpec — returned argv is fully insulated from mutation', () => {
+  it('push()-ing onto the returned argv does not affect the next call', () => {
+    const first = agentSpec('claude').argv
+    first.push('--evil')
+    expect(agentSpec('claude').argv).toEqual(CLAUDE_ARGV)
+    expect(agentSpec('claude').argv).not.toContain('--evil')
+  })
+
+  it('splice()-ing the returned argv does not affect the next call', () => {
+    const first = agentSpec('codex').argv
+    first.splice(0, first.length) // empty it out entirely
+    expect(first.length).toBe(0)
+    expect(agentSpec('codex').argv).toEqual(CODEX_ARGV)
+  })
+
+  it('reverse()-ing the returned argv (in-place) does not affect the next call', () => {
+    const first = agentSpec('claude').argv
+    first.reverse()
+    // The mutated copy is reversed...
+    expect(first[0]).toBe('--include-partial-messages')
+    // ...but the registry still yields the original order.
+    expect(agentSpec('claude').argv).toEqual(CLAUDE_ARGV)
+  })
+
+  it('two successive calls return DISTINCT argv array instances', () => {
+    expect(agentSpec('codex').argv).not.toBe(agentSpec('codex').argv)
+  })
+})
+
+describe('QA: agentSpec — scalar fields are insulated by the top-level spread', () => {
+  it('reassigning a returned scalar (dependency, orchestratorTemplate) is harmless', () => {
+    const s = agentSpec('claude')
+    s.dependency = 'HACKED'
+    s.orchestratorTemplate = 'evil.md'
+    s.authProbe = 'nope'
+    const fresh = agentSpec('claude')
+    expect(fresh.dependency).toBe('claude')
+    expect(fresh.orchestratorTemplate).toBe('prompt-team.md')
+    expect(fresh.authProbe).toBe('credentials-file')
+  })
+
+  it('reassigning a returned streamFilter does not corrupt the registry', () => {
+    // Strings are immutable; a caller can only REASSIGN the property on their
+    // own copy. Prove that reassignment cannot leak into the next reader.
+    const original = agentSpec('codex').streamFilter
+    const s = agentSpec('codex')
+    s.streamFilter = 'evil // empty'
+    expect(agentSpec('codex').streamFilter).toBe(original)
+    expect(agentSpec('codex').streamFilter).not.toBe('evil // empty')
+  })
+})
+
+describe('QA: agentSpec — streamFilter is a real jq program, not a placeholder', () => {
+  it('both filters begin with fromjson? and expose a "==> result:" line', () => {
+    for (const agent of ['claude', 'codex']) {
+      const f = agentSpec(agent).streamFilter
+      expect(typeof f).toBe('string')
+      // A non-trivial program (guards against an accidental empty/one-token filter).
+      expect(f.trim().length).toBeGreaterThan(20)
+      // Must start the pipeline by parsing the JSON line safely.
+      expect(f.startsWith('fromjson?')).toBe(true)
+      // Must emit the sentinel the pretty-printer relies on; an empty or
+      // placeholder filter would silently blank the rendered log.
+      expect(f).toContain('==> result:')
+    }
   })
 })

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -53,20 +53,26 @@ mkdir -p logs
 # Resolve which coding-agent CLI to drive (claude, the default, or codex) and
 # the exact argv to invoke it with. lib/agent-invocation.js is the single source
 # of truth — it reads RALPH_AGENT / RALPH_CODEX_MODEL from the env we just
-# sourced and prints eval-able bash setting RALPH_RESOLVED_AGENT, RALPH_AGENT_CLI
-# and the RALPH_AGENT_ARGS array. For claude the argv is byte-for-byte the flags
-# the loop has always used, so the Claude path is unchanged.
+# sourced and prints eval-able bash setting RALPH_RESOLVED_AGENT, RALPH_AGENT_CLI,
+# the RALPH_AGENT_ARGS array and RALPH_AGENT_STREAM_FILTER. For claude the argv is
+# byte-for-byte the flags the loop has always used, so the Claude path is
+# unchanged. This bash holds NO agent-specific knowledge of its own.
 resolve_agent_invocation() {
-  local sh
-  if sh="$(node "$RALPH_PKG_DIR/lib/agent-invocation.js" 2>/dev/null)"; then
-    eval "$sh"
+  local sh _err
+  # Fail fast: bash has no agent defaults to fall back to. If the node bridge
+  # fails or yields nothing, abort loudly rather than silently guessing.
+  # Capture stderr to a temp file so stdout stays PRISTINE for eval: a node
+  # Deprecation/Experimental warning (or nvm/shim banner) on a SUCCESSFUL run
+  # must never be folded into $sh, or eval would choke on the warning line.
+  _err="$(mktemp)"
+  if ! sh="$(node "$RALPH_PKG_DIR/lib/agent-invocation.js" 2>"$_err")" || [ -z "$sh" ]; then
+    echo "ralph.sh: failed to resolve agent invocation from lib/agent-invocation.js. Aborting." >&2
+    cat "$_err" >&2
+    rm -f "$_err"
+    exit 1
   fi
-  # Defensive defaults if resolution somehow failed: fall back to Claude's argv.
-  RALPH_RESOLVED_AGENT="${RALPH_RESOLVED_AGENT:-claude}"
-  RALPH_AGENT_CLI="${RALPH_AGENT_CLI:-claude}"
-  if [ -z "${RALPH_AGENT_ARGS+x}" ]; then
-    RALPH_AGENT_ARGS=(-p --dangerously-skip-permissions --output-format stream-json --verbose --include-partial-messages)
-  fi
+  rm -f "$_err"
+  eval "$sh"
 }
 resolve_agent_invocation
 export RALPH_RESOLVED_AGENT
@@ -78,43 +84,19 @@ export RALPH_RESOLVED_AGENT
 # fed to jq (which would fail with "Invalid numeric literal"). jq uses
 # `fromjson?` so any stray non-JSON line on stdout is skipped, not fatal.
 #
-# The Claude filter renders stream-json events; the Codex filter renders
-# `codex exec --json` JSONL events. Both are cosmetic — the authoritative
-# metrics parse happens in Node (capture-issue-event.js via parseAgentStream),
-# never here.
+# The jq stream filter is agent-specific and comes from RALPH_AGENT_STREAM_FILTER
+# (resolved from the JS registry via lib/agent-invocation.js), so this bash holds
+# no agent knowledge. The filter is cosmetic — the authoritative metrics parse
+# happens in Node (capture-issue-event.js via parseAgentStream), never here.
 #
 # Args: $1 = prompt-builder script path, $2 = log file path, $3 = raw jsonl path
 # (optional). Sets the global `claude_failed` to "1" when the agent exits
 # non-zero, else "0" (name kept for the telemetry sidecar's RALPH_CLAUDE_EXIT).
-JQ_STREAM_FILTER_CLAUDE='fromjson? // empty
-  | if .type == "assistant" then
-      (.message.content[]? | select(.type=="text").text // empty)
-    elif .type == "user" then
-      (.message.content[]? | select(.type=="tool_result") | "  ↳ tool_result")
-    elif .type == "result" then
-      "==> result: " + (.subtype // "ok")
-    else empty end'
-
-JQ_STREAM_FILTER_CODEX='fromjson? // empty
-  | if .type == "item.completed" then
-      (.item
-        | if (.type // "") == "agent_message" or (.type // "") == "assistant_message" then (.text // .message // empty)
-          elif (.type // "") == "command_execution" then ("  $ " + (.command // ""))
-          elif (.type // "") == "error" then ("  ✗ " + (.message // "error"))
-          else empty end)
-    elif .type == "turn.completed" then "==> result: success"
-    elif .type == "turn.failed" then "==> result: error"
-    elif .type == "error" then "==> result: error"
-    else empty end'
-
 run_agent_stream() {
   prompt_script="$1"
   log_file="$2"
   raw_jsonl="${3:-}"
-  local stream_filter="$JQ_STREAM_FILTER_CLAUDE"
-  if [ "${RALPH_RESOLVED_AGENT:-claude}" = "codex" ]; then
-    stream_filter="$JQ_STREAM_FILTER_CODEX"
-  fi
+  local stream_filter="$RALPH_AGENT_STREAM_FILTER"
   # Truncate the unique per-issue log ONCE up front, then have BOTH the stderr
   # tee and the stdout tee APPEND. This removes a truncate-vs-append race: if
   # the stdout `tee` opened with O_TRUNC while the stderr `tee -a` was already

--- a/packages/ralph/test/loop.adversarial.test.js
+++ b/packages/ralph/test/loop.adversarial.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { spawnSync } from 'node:child_process'
+import { spawnSync, execFileSync } from 'node:child_process'
 import {
   mkdtempSync,
   rmSync,
@@ -14,6 +14,12 @@ import { join } from 'node:path'
 import { templatePath } from '../lib/paths.js'
 
 const RALPH_TEMPLATE = templatePath('ralph.sh')
+// Resolve the REAL node binary so the stub can delegate agent-invocation.js
+// (the JS→bash bridge) to it; the loop now FAILS FAST if that resolution yields
+// nothing, so the bridge must run for real. build-prompt.js stays an echo.
+const REAL_NODE = execFileSync('node', ['-e', 'process.stdout.write(process.execPath)'], {
+  encoding: 'utf8',
+}).trim()
 
 // Adversarial / edge-case companions to test/loop.test.js. These reuse the same
 // stub-on-PATH harness but exercise the corners of the issue #505 fix that the
@@ -116,6 +122,11 @@ exit 0
   writeStub(
     'node',
     `#!/bin/bash
+# The JS→bash agent bridge must run for real (the loop fails fast without it);
+# everything else (build-prompt.js) just needs to emit a dummy prompt.
+case "$*" in
+  *agent-invocation.js*) exec "${REAL_NODE}" "$@" ;;
+esac
 echo "PROMPT"
 exit 0
 `
@@ -433,6 +444,74 @@ exit 0
     expect(edits, 'claude_failed must have triggered an --add-label claude-failed edit').toMatch(
       /--add-label claude-failed/
     )
+  })
+
+  it('resolves the agent even when the node bridge prints a warning to STDERR (#555)', () => {
+    // Regression: resolve_agent_invocation must capture the bridge's stderr
+    // SEPARATELY so stdout stays pristine for eval. Here the node stub delegates
+    // agent-invocation.js to REAL_NODE (emitting valid RALPH_AGENT_* assignments
+    // on stdout) AND prints a node-style warning to stderr. If stderr were folded
+    // into $sh (the old 2>&1 bug), eval would hit the warning line and die with a
+    // syntax error, RALPH_AGENT_ARGS would never be set, and under `set -u` the
+    // loop would abort with an unbound-variable error. The loop must still drain.
+    writeStub(
+      'node',
+      `#!/bin/bash
+case "$*" in
+  *agent-invocation.js*)
+    "${REAL_NODE}" "$@"
+    echo "(node:12345) ExperimentalWarning: some transitive dep warning" >&2
+    exit 0
+    ;;
+esac
+echo "PROMPT"
+exit 0
+`
+    )
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+echo '{"type":"result","subtype":"success"}'
+exit 0
+`
+    )
+    // Count drains after #88 is resolved (CLOSED) so the loop terminates.
+    writeStub(
+      'gh',
+      `#!/bin/bash
+DONE="${join(workdir, 'done88.txt')}"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  case "$*" in
+    *sort:created-asc*) echo "88"; touch "$DONE"; exit 0 ;;
+    *) [ -f "$DONE" ] && echo "0" || echo "1"; exit 0 ;;
+  esac
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *labels*) echo "" ;;
+    *state*)  echo "CLOSED" ;;
+    *)        echo "" ;;
+  esac
+  exit 0
+fi
+exit 0
+`
+    )
+
+    const res = runLoop()
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}`).toBeNull()
+    expect(res.status).toBe(0)
+    // eval must NOT have choked on the warning line, and set -u must NOT have
+    // tripped on an unset RALPH_AGENT_ARGS.
+    expect(`${res.stdout}\n${res.stderr}`).not.toMatch(
+      /syntax error|unbound variable|RALPH_AGENT_ARGS/,
+    )
+    // The abort branch must NOT have fired despite the stderr noise.
+    expect(res.stderr).not.toMatch(/failed to resolve agent invocation/)
+    // The loop resolved the agent and drained the queue normally.
+    expect(res.stdout).toContain('==> result: success')
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
   })
 
   it('empty queue: exits cleanly with 0 ok / 0 failed when count is "0" immediately', () => {


### PR DESCRIPTION
Closes #555

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/agent-registry.test.js`, `packages/ralph/lib/agent-invocation.test.js`, `packages/ralph/test/loop.adversarial.test.js`
- Before implementation (red): new assertions failed because `agentSpec(...)` had no `argv` (`Cannot read properties of undefined (reading 'push')`) and no `streamFilter` (`expected undefined to be a string`); the invocation tests failed for the missing `RALPH_AGENT_STREAM_FILTER=` emission and the `spec.argv`-derived args.
- After implementation (green): full ralph suite **1047 tests pass (38 files)**; repo-root frontend **553 tests pass**.

### What changed
- `lib/agent-registry.js` is now the SINGLE source of agent-specific knowledge. The per-agent spec (`agentSpec`) gained `argv` (static CLI argv template) and `streamFilter` (jq output-stream program), joining `cli`/`orchestratorTemplate`/`dependency`/`authProbe`. `argv` is deep-copied on return so callers can't corrupt the registry.
- `lib/agent-invocation.js` sources the base argv from `spec.argv` (composing the env-dependent codex `-m <model>` + `-` stdin marker on top) and emits a 4th eval-able assignment `RALPH_AGENT_STREAM_FILTER=`.
- `templates/ralph.sh` no longer hardcodes the two jq filters or the `if codex` branch — it uses `$RALPH_AGENT_STREAM_FILTER` — and now FAILS FAST (`exit 1` with a clear message) if the node bridge yields nothing, instead of silently falling back to Claude defaults.
- The Claude invocation is byte-for-byte unchanged (same cli, same 6-flag argv, same jq filter program) — a Claude run is behaviourally unchanged.

## QA scenarios added
- Registry immutability: mutating the returned `argv` (push/splice/reverse) or reassigning scalar/`streamFilter` fields does not affect a subsequent `agentSpec` call.
- `emitShellAssignments` shell-safety: the multi-line jq filter (containing newlines, `"`, `|`, `//`, `$`, `↳`, `✗`) is single-quoted and preserved byte-for-byte; a filter containing a `'` is POSIX-escaped; missing `streamFilter` emits `RALPH_AGENT_STREAM_FILTER=''`.
- Spec/invocation round-trip: `buildAgentInvocation(...).streamFilter` and `.argv` match `agentSpec(...)`; codex args start with `spec.argv` then append the env tail; `-m <model>` comes before the trailing `-` stdin marker; whitespace-only model treated as unset.
- streamFilter content sanity: both filters begin with `fromjson?` and mention `==> result:`.
- Regression (added round 2): the loop resolves the agent even when the node bridge prints a warning to STDERR on a successful (exit 0) run — proving the fail-fast no longer folds stderr into the eval string. Paths: `packages/ralph/test/loop.adversarial.test.js`.

## Review verdict
- APPROVED (round 2). Round 1 found one blocking defect: the fail-fast used `2>&1`, merging node's stderr into the eval string, so a noisy-but-successful node run (e.g. a DeprecationWarning) would corrupt `eval` and abort the loop under `set -u` — a latent regression vs the old `2>/dev/null`. Fixed by capturing stderr to a `mktemp` temp file (stdout stays pristine for `eval`; stderr echoed only on the failure path) plus the STDERR-noise regression test above. Reviewer empirically verified the test fails without the fix and passes with it, and confirmed no other regressions.

## Docs updated
- `packages/ralph/lib/agent-invocation.js` — header docstring return shape updated to `{agent, cli, args, streamFilter}`.
- `packages/ralph/lib/agent-registry.js` — header docstring `agentSpec` field list updated to include the static argv template and jq stream filter.
- No user-facing doc change: `RALPH_AGENT` config was already documented (introduced by the earlier Codex change); #555 is an internal consolidation with an unchanged user-facing contract.

## Notes
- Validated locally: `npm test` (root, 553), `packages/ralph` `npm test` (1047), `npm run lint` (0 errors, 26 pre-existing warnings in unrelated `src/` files), `npm run build` (succeeds).
- Tier 1 / Standard full-team run (dev → QA → review → writer).