### PR TITLE
test(ralph): agent-aware dependency check + auth probe (#559)

### DIFF
--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -290,6 +290,63 @@ describe('cycleCommand — preflight failure', () => {
   })
 })
 
+// #559: the preflight must resolve the agent from ralph.config.sh and run THAT
+// agent's auth probe — so a Codex-only machine (no ~/.claude credentials, but a
+// logged-in codex CLI) passes, and a codex auth failure is caught in preflight
+// rather than mid-loop. The claude path above is unchanged.
+describe('cycleCommand — preflight is agent-aware (#559)', () => {
+  // A codex-only machine: config selects codex, ~/.claude creds are ABSENT, and
+  // `codex login status` exits 0. Preflight must pass and the cycle proceeds.
+  const codexOnlyDeps = (overrides = {}) =>
+    baseDeps({
+      // No claude credentials file on this machine; everything else exists.
+      exists: (path) => !String(path).includes('.claude'),
+      readFile: (p) =>
+        String(p).endsWith('ralph.config.sh') ? 'RALPH_AGENT=codex\n' : '',
+      ...overrides,
+    })
+
+  it('a Codex-only machine passes preflight (no claude creds, codex login ok)', async () => {
+    const deps = codexOnlyDeps()
+    const result = await cycleCommand(deps)
+    // Not preflight-failed: with the queue empty (default), it reaches the
+    // queue-empty branch — proof preflight let it through.
+    expect(result.status).not.toBe('preflight-failed')
+    // It probed codex login status, never a claude credentials file.
+    expect(deps.exec.calls.some((c) => c.key === 'codex login status')).toBe(true)
+  })
+
+  it('catches a codex auth failure in preflight (login status non-zero)', async () => {
+    const deps = codexOnlyDeps({
+      exec: makeExec({
+        ...baseHandlers(),
+        'codex login status': { exitCode: 1, stdout: '', stderr: 'not logged in' },
+      }),
+    })
+    const result = await cycleCommand(deps)
+    expect(result.exitCode).toBe(1)
+    expect(result.status).toBe('preflight-failed')
+    expect(result.reason).toMatch(/codex/i)
+    // Failure is caught in preflight — the queue is never touched.
+    expect(deps.exec.calls.some((c) => c.key.startsWith('gh issue list'))).toBe(false)
+  })
+
+  it('a codex "login not required" (exit 0) is treated as authenticated', async () => {
+    const deps = codexOnlyDeps({
+      exec: makeExec({
+        ...baseHandlers(),
+        'codex login status': {
+          exitCode: 0,
+          stdout: '',
+          stderr: 'Login is not required. Uses managed credentials.',
+        },
+      }),
+    })
+    const result = await cycleCommand(deps)
+    expect(result.status).not.toBe('preflight-failed')
+  })
+})
+
 describe('cycleCommand — lock held', () => {
   it('returns lock-held and notifies skipped when another instance holds the lock', async () => {
     const deps = baseDeps({


### PR DESCRIPTION
Closes #559

The auth-probe module, agent-aware `checkDeps`, doctor's agent reporting, and
the preflight's use of `probeAgentAuth` all landed with the parent PRs
(#574 Codex support, #577 agent registry). Verifying #559's acceptance
criteria against `main` showed every one already implemented and tested —
**except** two: *"a Codex-only machine passes cycle preflight"* and *"an auth
failure is caught in preflight rather than mid-loop"* had no test. This PR
closes that gap.

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/commands/cycle.test.js`
- Before implementation (red): the existing `cycle.test.js` covered only the
  Claude credentials preflight path (`preflight-failed when claude credentials
  file is missing`); there was no test proving the preflight resolves the agent
  from `ralph.config.sh` and runs the codex login-status probe.
- After implementation (green): added a `preflight is agent-aware (#559)`
  block — codex-only machine passes preflight (no `~/.claude` creds, `codex
  login status` exit 0), codex auth failure is caught in preflight, and a
  codex "login not required" exit-0 is treated as authenticated. All 1057
  ralph-package tests pass (was 1054).

## QA scenarios added
- Codex-only machine with **absent** `~/.claude` credentials but a logged-in
  codex CLI — asserts `status !== 'preflight-failed'` and that `codex login
  status` was actually invoked (never a claude credentials file).
- Codex `login status` non-zero — asserts `preflight-failed`, reason names
  codex, and the queue (`gh issue list`) is never touched (failure caught in
  preflight, not mid-loop).
- Codex "Login is not required." with exit 0 — treated as authenticated
  (exit-code-only contract). The adversarial exit-code-only cases were already
  covered at the unit level in `agent-auth.test.js` (#554).

## Review verdict
- Approved. Test-only addition; no source change was required because the
  behavior was already implemented by the parent PRs. New tests follow the
  existing `cycle.test.js` harness (`baseDeps`/`makeExec`) and conventions.

## Docs updated
- none — the diff is test-only and implies no doc change.

## Notes
- TDD note: the implementation predated this issue (delivered by #574/#577),
  so the work here is the missing test coverage that pins the Codex-only
  preflight acceptance criteria. No production code changed.
- Validation: `npm run lint` (0 errors), `npm test` (553 frontend), ralph
  package `npm test` (1057), `npm run build` — all pass.