### PR TITLE
feat(ralph): agent selection in ralph init (flag, TTY prompt, non-interactive default)

### DIFF
--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -191,12 +191,18 @@ ralph init --agent claude    # write RALPH_AGENT="claude" (same as the default)
 ralph init                   # interactive prompt on a TTY, else defaults to claude
 ```
 
-When you run `ralph init` in an interactive terminal without `--agent`, it
-prompts `Which coding agent? [claude]/codex:` — a blank answer takes the
-default. An unrecognized value (a typo, a model name, anything not `claude`
-or `codex`) is **not fatal**: Ralph warns, falls back to `claude`, and writes
-the valid fallback into the config so an unattended run is never aborted by a
-typo. The value is case-insensitive and trimmed.
+The `--agent` value is case-insensitive and trimmed, and it is **validated
+before anything is written**: an invalid value (a typo, a model name, anything
+that is not `claude` or `codex`) is **rejected** with
+`❌ Unknown agent '<x>'. Valid agents: claude, codex.` and a nonzero exit, so a
+mistyped flag never silently falls back to `claude`.
+
+When you run `ralph init` in an interactive terminal **without** `--agent`, it
+prompts `Use Codex instead of Claude Code? [y/N]:` — answer `y`/`yes` for
+`codex`; a blank answer or anything else keeps the default `claude`. This
+prompt path never aborts: a stray keystroke just lands on the safe default. When
+stdin is **not** a TTY and no flag is passed, `ralph init` skips the prompt and
+defaults to `claude` silently, so an unattended run is never blocked.
 
 To switch an existing project, edit `RALPH_AGENT` in `ralph.config.sh` by hand
 (or delete the file and re-run `ralph init --agent <name>`). `ralph doctor`

--- a/packages/ralph/lib/agent-registry.js
+++ b/packages/ralph/lib/agent-registry.js
@@ -15,7 +15,7 @@
 //     template, and jq output-stream filter program).
 
 const DEFAULT_AGENT = 'claude'
-const VALID_AGENTS = ['claude', 'codex']
+export const VALID_AGENTS = ['claude', 'codex']
 
 // The STATIC argv template each agent CLI is invoked with. This is the base
 // only — the env-dependent Codex `-m <model>` flag and the `-` stdin marker are

--- a/packages/ralph/lib/commands/init.js
+++ b/packages/ralph/lib/commands/init.js
@@ -8,7 +8,8 @@ import { join } from 'node:path'
 import { execa } from 'execa'
 import { detectStack } from '../detect-stack.js'
 import { templatePath } from '../paths.js'
-import { resolveAgent } from '../agent-registry.js'
+import { resolveAgent, VALID_AGENTS } from '../agent-registry.js'
+import { confirm } from '../utils/prompt.js'
 
 class InitAbort extends Error {
   constructor(message, exitCode = 1) {
@@ -27,17 +28,33 @@ export async function initCommand({
   agent: agentFlag = null,
   isTTY = Boolean(process.stdin && process.stdin.isTTY),
   promptAgent = defaultPromptAgent,
+  ask = confirm,
 } = {}) {
   const fs = wrapFs(fsImpl)
   const out = (m) => stdout.write(m + '\n')
   const err = (m) => stderr.write(m + '\n')
 
+  // #560: an explicit --agent flag is validated EARLY and REJECTED hard on a
+  // typo (before any file writes), so we never silently write claude when the
+  // user clearly meant a specific agent. The non-flag paths (interactive prompt
+  // and the "claude" default) still fall back gracefully via resolveAgent so an
+  // unattended overnight run is never aborted by a stray keystroke at the prompt.
+  if (agentFlag != null && String(agentFlag).trim() !== '') {
+    const normalized = String(agentFlag).trim().toLowerCase()
+    if (!VALID_AGENTS.includes(normalized)) {
+      err(
+        `❌ Unknown agent '${agentFlag}'. Valid agents: ${VALID_AGENTS.join(', ')}.`,
+      )
+      throw new InitAbort(`unknown agent '${agentFlag}'`, 1)
+    }
+  }
+
   // #554: pick the coding agent. Priority: explicit --agent flag > interactive
   // prompt (only when a TTY and no flag) > "claude" default. Whatever we land
-  // on runs through the registry so a typo falls back to claude with a warning.
+  // on runs through the registry so a typo at the prompt falls back to claude.
   let agentChoice = agentFlag
   if (!agentChoice && isTTY) {
-    agentChoice = await promptAgent({ stdout, stderr })
+    agentChoice = await promptAgent({ stdout, ask })
   }
   const { agent, warning } = resolveAgent({ RALPH_AGENT: agentChoice ?? 'claude' })
   if (warning) err(`⚠️  ${warning}`)
@@ -122,20 +139,14 @@ export async function initCommand({
   }
 }
 
-// Interactive agent picker. Reads a single line from stdin; blank/anything
-// unrecognized is left for resolveAgent to normalize (=> claude). Kept tiny and
-// dependency-injectable so tests never touch real stdin.
-async function defaultPromptAgent({ stdout = process.stdout } = {}) {
-  const { createInterface } = await import('node:readline')
-  const rl = createInterface({ input: process.stdin, output: stdout })
-  try {
-    const answer = await new Promise((res) => {
-      rl.question('Which coding agent? [claude]/codex: ', (a) => res(a))
-    })
-    return (answer || '').trim() || 'claude'
-  } finally {
-    rl.close()
-  }
+// Interactive agent picker. Built on the shared `confirm` helper (#560) rather
+// than a bespoke readline: a yes/no keeps the default (claude) as the safe path
+// for a blank answer. `ask` is injectable so tests never touch real stdin.
+async function defaultPromptAgent({ stdout = process.stdout, ask = confirm } = {}) {
+  const useCodex = await ask('Use Codex instead of Claude Code? [y/N]: ', {
+    output: stdout,
+  })
+  return useCodex ? 'codex' : 'claude'
 }
 
 function wrapFs(fsImpl) {

--- a/packages/ralph/lib/init.test.js
+++ b/packages/ralph/lib/init.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Volume } from 'memfs'
-import { initCommand } from './commands/init.js'
+import { initCommand, InitAbort } from './commands/init.js'
 
 const PROJECT = '/project'
 
@@ -180,20 +180,95 @@ describe('initCommand — agent selection (#554)', () => {
     expect(cfg).toContain('RALPH_AGENT="codex"')
   })
 
-  it('falls back to claude (with a warning) when --agent is a typo', async () => {
+  it('rejects an invalid --agent flag with a clear message and writes nothing (#560)', async () => {
     const { vol } = setup()
     const stderr = makeStream()
+    let caught
+    try {
+      await initCommand({
+        cwd: PROJECT,
+        stdout: makeStream(),
+        stderr,
+        exec: makeExec(defaultGitHandlers()),
+        fs: vol,
+        agent: 'codx',
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(InitAbort)
+    expect(caught.exitCode).toBeGreaterThan(0)
+    // Error names the bad value and lists the valid agents.
+    const err = stderr.output()
+    expect(err).toContain("codx")
+    expect(err).toContain('claude')
+    expect(err).toContain('codex')
+    // Aborts BEFORE any file writes.
+    expect(vol.existsSync(`${PROJECT}/ralph.config.sh`)).toBe(false)
+  })
+
+  it('writes RALPH_AGENT="claude" when --agent claude is passed (no prompt)', async () => {
+    const { vol } = setup()
+    let asked = false
     await initCommand({
       cwd: PROJECT,
       stdout: makeStream(),
-      stderr,
+      stderr: makeStream(),
       exec: makeExec(defaultGitHandlers()),
       fs: vol,
-      agent: 'codx',
+      isTTY: true,
+      agent: 'claude',
+      promptAgent: async () => {
+        asked = true
+        return 'codex'
+      },
+    })
+    expect(asked).toBe(false)
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('RALPH_AGENT="claude"')
+  })
+
+  it('written config carries the RALPH_AGENT explanatory comments from the template', async () => {
+    const { vol, run } = setup()
+    await run()
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('Coding agent Ralph drives')
+    expect(cfg).toContain('# RALPH_CODEX_MODEL=')
+  })
+
+  it('default prompt is built on the injected confirm helper: true => codex', async () => {
+    const { vol } = setup()
+    let askedQuestion = null
+    await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      isTTY: true,
+      ask: (question) => {
+        askedQuestion = question
+        return Promise.resolve(true)
+      },
+    })
+    expect(askedQuestion).toBeTruthy()
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('RALPH_AGENT="codex"')
+  })
+
+  it('default prompt is built on the injected confirm helper: false => claude', async () => {
+    const { vol } = setup()
+    await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      isTTY: true,
+      ask: () => Promise.resolve(false),
     })
     const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
     expect(cfg).toContain('RALPH_AGENT="claude"')
-    expect(stderr.output()).toContain('unrecognized')
   })
 
   it('prompts for the agent when interactive and no flag is given', async () => {
@@ -274,11 +349,30 @@ describe('QA: initCommand — agent selection (adversarial #554)', () => {
     expect(cfg).toContain('RALPH_AGENT="codex"')
   })
 
-  it('an INVALID --agent value writes claude (never the garbage value) + warns', async () => {
-    const { cfg, result } = await runWith({ agent: 'gpt-9000' })
-    expect(cfg).toContain('RALPH_AGENT="claude"')
-    expect(cfg).not.toContain('gpt-9000')
-    expect(result.agent).toBe('claude')
+  it('an INVALID --agent flag is rejected (never written) with a clear message (#560)', async () => {
+    const { vol } = setup()
+    const stderr = makeStream()
+    let caught
+    try {
+      await initCommand({
+        cwd: PROJECT,
+        stdout: makeStream(),
+        stderr,
+        exec: makeExec(defaultGitHandlers()),
+        fs: vol,
+        agent: 'gpt-9000',
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(InitAbort)
+    expect(caught.exitCode).toBeGreaterThan(0)
+    const err = stderr.output()
+    expect(err).toContain('gpt-9000')
+    expect(err).toContain('claude')
+    expect(err).toContain('codex')
+    // Never wrote the garbage value into a config.
+    expect(vol.existsSync(`${PROJECT}/ralph.config.sh`)).toBe(false)
   })
 
   it('the written RALPH_AGENT line is a single, valid, quoted bash assignment', async () => {
@@ -308,6 +402,161 @@ describe('QA: initCommand — agent selection (adversarial #554)', () => {
     const { parseConfigAgent } = await import('./read-config-agent.js')
     const { cfg } = await runWith({ agent: 'codex' })
     expect(parseConfigAgent(cfg)).toBe('codex')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QA augmentation (#560): early --agent flag REJECTION guard. A typo aborts
+// hard BEFORE any git/exec calls and BEFORE any file write, but blank/empty/
+// whitespace flags are NOT a typo — they fall through to the graceful default.
+// Adversarial values (shell/newline injection) must be rejected, never written.
+// ---------------------------------------------------------------------------
+
+describe('QA: initCommand — early --agent rejection guard (#560)', () => {
+  // Runs init recording every injected-exec call so we can prove the guard
+  // fires BEFORE any git detection. Returns the volume, streams and exec.
+  function harness(overrides = {}) {
+    const vol = Volume.fromJSON({ [`${PROJECT}/.keep`]: '' }, '/')
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const exec = makeExec(defaultGitHandlers())
+    const run = () =>
+      initCommand({
+        cwd: PROJECT,
+        stdout,
+        stderr,
+        exec,
+        fs: vol,
+        isTTY: false,
+        ...overrides,
+      })
+    return { vol, stdout, stderr, exec, run }
+  }
+
+  const ALL_OUTPUTS = [
+    `${PROJECT}/ralph.config.sh`,
+    `${PROJECT}/PROMPT.md`,
+    `${PROJECT}/.env.local.example`,
+    `${PROJECT}/ralph-notify.sh.example`,
+    `${PROJECT}/.claude/commands/ralph.md`,
+    `${PROJECT}/.gitignore`,
+  ]
+
+  it('a whitespace-only flag is NOT rejected — it falls through to the claude default (no prompt when not TTY)', async () => {
+    let asked = false
+    const { vol, exec, run } = harness({
+      agent: '   ',
+      promptAgent: async () => {
+        asked = true
+        return 'codex'
+      },
+    })
+    // Guard treats trim()==='' as "no flag": no throw, git detection runs.
+    await expect(run()).resolves.toMatchObject({ agent: 'claude' })
+    expect(asked).toBe(false)
+    expect(exec.calls.length).toBeGreaterThan(0)
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('RALPH_AGENT="claude"')
+  })
+
+  it('an empty-string flag is NOT rejected — falls through to the claude default', async () => {
+    const { vol, run } = harness({ agent: '' })
+    await expect(run()).resolves.toMatchObject({ agent: 'claude' })
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('RALPH_AGENT="claude"')
+  })
+
+  it('a valid flag padded with whitespace ("  codex  ") is accepted and written with NO leaked whitespace in the bash assignment', async () => {
+    const { vol, run } = harness({ agent: '  codex  ' })
+    await run()
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    const assignmentLines = cfg
+      .split('\n')
+      .filter((l) => /^\s*RALPH_AGENT\s*=/.test(l))
+    expect(assignmentLines).toHaveLength(1)
+    // A leaked space (e.g. RALPH_AGENT=" codex ") would be invalid/misleading
+    // bash once sourced; the value must be the bare, trimmed token.
+    expect(assignmentLines[0]).toBe('RALPH_AGENT="codex"')
+  })
+
+  it('normalizes a valid uppercase flag ("CLAUDE") to lowercase claude, not rejected', async () => {
+    const { vol, run } = harness({ agent: 'CLAUDE' })
+    const result = await run()
+    expect(result.agent).toBe('claude')
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('RALPH_AGENT="claude"')
+  })
+
+  it('rejecting an invalid flag writes NOTHING at all (every output file absent) and throws with exitCode === 1', async () => {
+    const { vol, run } = harness({ agent: 'codx' })
+    let caught
+    try {
+      await run()
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(InitAbort)
+    // Exact nonzero code, not merely > 0 — a future refactor to exitCode 0 must fail here.
+    expect(caught.exitCode).toBe(1)
+    for (const p of ALL_OUTPUTS) {
+      expect(vol.existsSync(p)).toBe(false)
+    }
+  })
+
+  it('rejection happens BEFORE any git/exec call — the injected exec is never invoked', async () => {
+    const { exec, run } = harness({ agent: 'not-an-agent' })
+    await expect(run()).rejects.toBeInstanceOf(InitAbort)
+    // Early exit: resolveProjectRoot / branch detection never ran.
+    expect(exec.calls).toHaveLength(0)
+  })
+
+  it('a shell-injection value ("codex"; rm -rf /") is rejected, echoed verbatim, and never written', async () => {
+    const evil = 'codex"; rm -rf /'
+    const { vol, stderr, exec, run } = harness({ agent: evil })
+    let caught
+    try {
+      await run()
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(InitAbort)
+    expect(exec.calls).toHaveLength(0)
+    // The raw (dangerous) value is surfaced to the user so the typo is visible,
+    // but it never reaches a sourced config file.
+    expect(stderr.output()).toContain(evil)
+    expect(vol.existsSync(`${PROJECT}/ralph.config.sh`)).toBe(false)
+  })
+
+  it('a newline-injection value ("claude\\ncodex") is rejected, not silently accepted as claude', async () => {
+    const { vol, run } = harness({ agent: 'claude\ncodex' })
+    await expect(run()).rejects.toBeInstanceOf(InitAbort)
+    expect(vol.existsSync(`${PROJECT}/ralph.config.sh`)).toBe(false)
+  })
+
+  it('the default confirm prompt asks the exact yes/no question and maps true => codex', async () => {
+    const vol = Volume.fromJSON({ [`${PROJECT}/.keep`]: '' }, '/')
+    let askedQuestion = null
+    let askedOpts = null
+    await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      isTTY: true,
+      // No promptAgent override: exercise the REAL defaultPromptAgent, which
+      // must route through the injected `ask` (confirm) helper.
+      ask: (question, opts) => {
+        askedQuestion = question
+        askedOpts = opts
+        return Promise.resolve(true)
+      },
+    })
+    // Lock the phrasing so a rename of the prompt is caught by CI.
+    expect(askedQuestion).toBe('Use Codex instead of Claude Code? [y/N]: ')
+    expect(askedOpts).toMatchObject({ output: expect.anything() })
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('RALPH_AGENT="codex"')
   })
 })
 


### PR DESCRIPTION
Closes #560

## Dev/TDD
- Tests added/modified: `packages/ralph/lib/init.test.js`
- Before implementation (red): the two existing tests asserting the OLD silent-fallback-on-invalid-flag behavior (`falls back to claude ... when --agent is a typo`, and the QA `an INVALID --agent value writes claude`) were rewritten to assert rejection; new tests for the confirm-based prompt (`true => codex`, `false => claude`) failed/timed out because the `ask` seam was unwired. All failed for the right reason (behavior not yet implemented).
- After implementation (green): full ralph package suite passes — **40 files, 1070 tests**.

Implementation:
- `agent-registry.js`: export `VALID_AGENTS` so init reuses the single source of truth (no hardcoded list).
- `init.js`: an explicit `--agent <invalid>` flag is now **validated early and rejected** (`❌ Unknown agent '<x>'. Valid agents: claude, codex.`, `InitAbort` exit 1) *before any file writes*. The prompt/default paths still fall back to `claude` gracefully via `resolveAgent` so an unattended run never aborts on a stray keystroke. The bespoke readline picker was replaced with one built on the shared `confirm` helper (`Use Codex instead of Claude Code? [y/N]:`), injected via `ask = confirm` mirroring `startCommand`.

## QA scenarios added
9 adversarial tests in `packages/ralph/lib/init.test.js` (`QA: initCommand — early --agent rejection guard (#560)`):
- whitespace-only (`'   '`) and empty (`''`) flags fall through to the claude default (not rejected, no prompt when non-TTY)
- valid padded flag `'  codex  '` writes a clean `RALPH_AGENT="codex"` (no whitespace leaks into the bash assignment)
- uppercase valid `'CLAUDE'` normalizes, not rejected
- invalid flag writes **nothing** (all six init output files absent) and exits with `exitCode === 1` exactly
- rejection happens **before** any git/exec call (`exec.calls` empty)
- shell-injection (`'codex"; rm -rf /'`) and newline-injection (`'claude\ncodex'`) values are rejected, never written, raw value echoed in the error
- the default `confirm`-based prompt receives the exact yes/no question and maps `true => codex`

## Review verdict
- **APPROVE** (round 1). No blocking findings. Reviewer confirmed the early-reject guard is a clean rule (not a symptom-patch), the double-normalization is justified by the two different semantics (hard-fail flag vs graceful prompt/default), and the `ask = confirm` injection matches the established `startCommand` convention. Non-blocking notes only: an optional `isValidAgent` registry helper, and that the yes/no prompt can't express a future 3rd agent (a consequence of the mandated "reuse confirm" AC).

## Docs updated
- `packages/ralph/README.md`: rewrote the "Choosing the coding agent" section for the final behavior — invalid `--agent` is now rejected (not silent fallback), and the TTY prompt text is now `Use Codex instead of Claude Code? [y/N]:`. The `RALPH_AGENT` config-field runtime-fallback row was left intact (unchanged by #560).

## Notes
- `package-lock.json` had a pre-existing unrelated modification in the working tree; it was **not** included in this commit.
- Validation: `npm test` (ralph, 1070 pass), `npm run lint` (0 errors, 26 pre-existing warnings in `src/`), `npm run build` (success).