### PR TITLE
docs(ralph): Codex agent documentation + experimental labeling

### DIFF
--- a/packages/ralph/CONTRIBUTING.md
+++ b/packages/ralph/CONTRIBUTING.md
@@ -57,6 +57,25 @@ instead of shipping a skewed Codex prompt. The forked orchestrator prose is not
 asserted, so you are free to word each agent's delegation instructions
 differently — just keep the shared structure in lockstep.
 
+### Codex maturity, sandbox, and network — do not "tighten" these
+
+- **The Codex path is experimental.** It is unit- and stub-tested (registry,
+  stream parsing, invocation argv, auth probe, template parity, and the full
+  bash loop against a stubbed `codex`), but it has **not** been run end-to-end
+  against a live `codex` CLI. The default Claude path is unchanged and fully
+  exercised. Keep the README's experimental callout honest — do not upgrade the
+  claim until a real live run has happened.
+- **The `workspace-write` sandbox is a *partial* boundary.** In design testing
+  it did not block a write to the system temp directory, so the Codex
+  orchestrator's stay-inside-the-project rule — not the sandbox — is what
+  contains a run. The `## Absolute restrictions` note in
+  `prompt-team-codex.md` documents this deliberately; do not delete it.
+- **Network access is required and enabled on purpose.** `codex exec` runs with
+  `sandbox_workspace_write.network_access=true` (see `lib/agent-registry.js`)
+  because the loop must run `gh`, `npm`, and `git push` every iteration.
+  Disabling network access breaks the loop — no PR can be opened or merged. Do
+  not "harden" it away.
+
 ## Manual smoke test (pre-release recipe)
 
 The package is dogfooded against the host repo continuously, but

--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -218,6 +218,25 @@ the same team roles, triage tiers, PR flow, and telemetry; only the
 orchestrator template and the invoked CLI differ. For Codex you can also pin a
 model with `RALPH_CODEX_MODEL` (see [Configuration reference](#configuration-reference)).
 
+### Codex sandbox and network access
+
+Ralph runs `codex exec` with a **`workspace-write` sandbox** and network access
+left on (`sandbox_workspace_write.network_access=true`), with approvals disabled
+so the unattended loop never blocks on a prompt.
+
+- **The sandbox is a *partial* boundary, not a substitute for the prompt's
+  stay-inside-the-project rule.** During design the `workspace-write` sandbox did
+  **not** prevent a write to the system temp directory. Treat it as defense in
+  depth, not containment: the orchestrator's "never touch files outside the
+  project root" instruction — not the sandbox — is what keeps a run contained.
+  Do not over-trust the sandbox.
+- **Network access is mandatory.** Ralph's loop drives `gh`, `npm`, and
+  `git push` on every iteration, so with network access disabled those commands
+  fail and no PR can be opened or merged. This is why the Codex sandbox is
+  configured with network access enabled; if you tighten it, the loop stops
+  working. (Claude Code runs unsandboxed and likewise needs network — the
+  requirement is not Codex-specific.)
+
 ## Scheduling Ralph (macOS launchd)
 
 Beyond the manual `ralph start` flow, Ralph can run on a launchd


### PR DESCRIPTION
Closes #563

## Dev/TDD
- Skipped: docs-only change (README.md + CONTRIBUTING.md prose). No behavioral impact on code, so no tests were added per Tier 0 / Light triage.

## QA scenarios added
- Skipped (trivial — light path)

## Review verdict
- Light review over the docs-only diff: **APPROVED**, no blocking findings. Every claim was cross-checked against source. Verified: `CODEX_ARGV` in `lib/agent-registry.js` contains `--sandbox workspace-write`, `approval_policy="never"`, and `sandbox_workspace_write.network_access=true` exactly as documented; the sandbox partial-boundary / system-temp note exists under `## Absolute restrictions` in `prompt-team-codex.md`. No overstated verification claims.

## Docs updated
- `packages/ralph/README.md` — added a **Codex sandbox and network access** subsection: the workspace-write sandbox is a **partial** boundary (did not block a system-temp write in testing) and is **not** a substitute for the prompt's stay-inside-the-project rule; network access is **mandatory** (gh/npm/git push all fail without it), which is why it is enabled in the sandbox config.
- `packages/ralph/CONTRIBUTING.md` — added a **Codex maturity, sandbox, and network — do not "tighten" these** steering note for contributors: the Codex path is experimental (unit/stub-tested, not run live end-to-end); the sandbox is a partial boundary; network access is required and enabled on purpose.

## Notes
Most of the issue's acceptance criteria were already satisfied by documentation that landed inline with the earlier feature slices (#582/#585/#588/#591/#577), which is why the README already covered the config reference (`RALPH_AGENT`, `RALPH_CODEX_MODEL`), the agent-dependent CLI dependency, the metrics table (the `agent` field, Codex cost-always-zero, model-null-when-unset, the reasoning-token fold into `output_tokens`), the Codex auth troubleshooting entry (exit-code-only check, login-not-required success), the experimental labeling, and the Claude-path-unchanged statement. This PR fills the three remaining honest gaps: the sandbox **partial**-boundary caveat surfaced in the user-facing README (it previously lived only in the orchestrator template), the **mandatory network-access** requirement and its consequence, and the contributor steering doc (CONTRIBUTING.md).

Validation (all green): `npm run lint` OK; `npm test` 553 pass; `npm run build` OK; ralph package `npm test` 1080 pass.