### PR TITLE
feat(ralph): configurable task source — GitHub issues or local folder

### DIFF
--- a/packages/ralph/CONTRIBUTING.md
+++ b/packages/ralph/CONTRIBUTING.md
@@ -34,28 +34,40 @@ Three runtime deps (`commander`, `execa`, `picocolors`); tests use
 
 ## Orchestrator templates: edit both, always
 
-Ralph ships **two** orchestrator templates, one per coding agent:
+Ralph ships **three** orchestrator templates:
 
-- `templates/prompt-team.md` — the Claude Code orchestrator.
-- `templates/prompt-team-codex.md` — the Codex orchestrator.
+- `templates/prompt-team.md` — the Claude Code orchestrator (GitHub source).
+- `templates/prompt-team-codex.md` — the Codex orchestrator (GitHub source).
+- `templates/prompt-team-folder.md` — the folder-mode orchestrator (#565),
+  selected by `build-prompt.js` when `TASK_SOURCE=folder`. It composes the
+  **same** shared role files as the other two but forks the intake and
+  completion prose: it reads a local task file, moves it `todo → in-progress`,
+  commits straight to `DEV_BRANCH`, and moves the file to `done/` (no PR/merge).
+  It is **not** covered by `template-parity.test.js` (that test asserts only the
+  Claude ↔ Codex pair), so its shared skeleton can drift — keep it in sync by
+  hand when you touch a role placeholder or a numbered step that all templates
+  share.
 
-The shared specialist roles (`templates/roles/*.md`) are composed into both via
+The shared specialist roles (`templates/roles/*.md`) are composed into all via
 the same `{{ROLE_DEV}}` / `{{ROLE_QA}}` / `{{ROLE_REVIEW}}` / `{{ROLE_WRITER}}` /
-`{{ROLE_EXPLORER}}` placeholders, and both consume the same `{{INSTALL_CMD}}`,
+`{{ROLE_EXPLORER}}` placeholders, and all consume the same `{{INSTALL_CMD}}`,
 `{{TEST_CMD}}`, branch, merge, and `{{RALPH_HEAVY_TIER}}` variables. Only the
 **orchestrator body** is forked — it describes how each agent delegates (Claude
-Code's subagents vs. Codex's sequential-persona degradation), so the two bodies
-are deliberately not identical.
+Code's subagents vs. Codex's sequential-persona degradation) and, for the
+folder template, how intake/completion differ from the GitHub flow, so the
+bodies are deliberately not identical.
 
-**When you change one orchestrator template, change the other to match.** Any
+**When you change one orchestrator template, change the others to match.** Any
 edit to a shared placeholder, a numbered step heading, the `## Absolute
-restrictions` block, or a PR-body section name must land in **both** files.
-`lib/template-parity.test.js` enforces this in CI: it asserts that both
-templates carry the same role placeholders, variables, step headings,
-restriction rules, and PR-body sections, so a one-sided edit fails the suite
-instead of shipping a skewed Codex prompt. The forked orchestrator prose is not
-asserted, so you are free to word each agent's delegation instructions
-differently — just keep the shared structure in lockstep.
+restrictions` block, or a PR-body section name must land in **all** the files it
+applies to. `lib/template-parity.test.js` enforces this **for the Claude ↔ Codex
+pair** in CI: it asserts that both GitHub templates carry the same role
+placeholders, variables, step headings, restriction rules, and PR-body sections,
+so a one-sided edit fails the suite instead of shipping a skewed Codex prompt.
+The folder template is **not** in that assertion, so keep it in sync by hand.
+The forked orchestrator prose is not asserted, so you are free to word each
+agent's delegation instructions differently — just keep the shared structure in
+lockstep.
 
 ### Codex maturity, sandbox, and network — do not "tighten" these
 

--- a/packages/ralph/README.md
+++ b/packages/ralph/README.md
@@ -9,6 +9,11 @@ scripts into a reusable CLI so any project can opt in with a single
 By default the coding agent is **Claude Code**. Ralph can also drive the
 **OpenAI Codex** CLI instead — see [Choosing the coding agent](#choosing-the-coding-agent).
 
+By default Ralph draws its work from **GitHub issues** (the flow described
+above). It can instead pull tasks from a **local `.ralph/tasks/` folder** with
+no GitHub remote, auth, or `gh` dependency — committing straight to your dev
+branch with no PR. See [Choosing the task source](#choosing-the-task-source).
+
 > **⚠️ Codex support is experimental.** The Codex path is unit- and
 > stub-tested (registry, stream parsing, invocation argv, auth probe, template
 > parity, and the full bash loop driven against a stubbed `codex` emitting the
@@ -40,7 +45,11 @@ will check for you (`git`, `gh`, `tmux`, `jq`, `curl`) and **one coding-agent
 CLI** — either `claude` (the default) **or** `codex`, depending on which agent
 you configure. Only the selected agent's CLI is required; `ralph doctor`
 validates that one and never asks a Codex-only machine to install `claude` (or
-vice-versa). macOS, Linux, and WSL2 are supported.
+vice-versa). `gh` is required **only** for the default GitHub task source — in
+folder mode (`TASK_SOURCE=folder`) `ralph doctor` skips it, so a repo with no
+GitHub remote needs only `git`, the agent CLI, and `jq` (see
+[Choosing the task source](#choosing-the-task-source)). macOS, Linux, and WSL2
+are supported.
 
 ## Quick start
 
@@ -237,6 +246,122 @@ so the unattended loop never blocks on a prompt.
   working. (Claude Code runs unsandboxed and likewise needs network — the
   requirement is not Codex-specific.)
 
+## Choosing the task source
+
+Ralph draws its work from one **task source** per project, recorded as
+`TASK_SOURCE` in `ralph.config.sh`:
+
+- **`github`** (default) — today's behavior, unchanged. Ralph resolves open
+  GitHub issues via `gh`, opens a PR per issue, and waits for the merge.
+- **`folder`** — a fully-local mode. Tasks live as numbered markdown files under
+  a gitignored `.ralph/tasks/` tree whose directories encode status. Ralph
+  drains an autonomous queue, does the work, commits **directly to the dev
+  branch**, and moves the task file to a terminal directory. No PRs, no
+  auto-merge, and no `gh` dependency — folder mode needs only `git`, the agent
+  CLI, and `jq`.
+
+Pick the source at `ralph init` time:
+
+```bash
+ralph init --source folder    # write TASK_SOURCE="folder"
+ralph init --source github    # write TASK_SOURCE="github" (same as the default)
+ralph init                    # interactive prompt on a TTY, else defaults to github
+```
+
+The `--source` value is case-insensitive and trimmed, and it is **validated
+before anything is written**: an invalid value is **rejected** with
+`❌ Unknown task source '<x>'. Valid sources: github, folder.` and a nonzero
+exit, so a mistyped flag never silently falls back.
+
+When you run `ralph init` in an interactive terminal **without** `--source`, it
+prompts `Draw tasks from a local .ralph/tasks/ folder instead of GitHub? [y/N]:`
+— answer `y`/`yes` for `folder`; a blank answer or anything else keeps the
+default `github`. When stdin is **not** a TTY and no flag is passed, `ralph
+init` skips the prompt and defaults to `github` silently, so existing
+automation keeps working unchanged.
+
+To switch an existing project, edit `TASK_SOURCE` in `ralph.config.sh` by hand.
+The bash loop, the prompt builder, and `ralph doctor`/`cycle` preflight all read
+this one value, so the loop and prompt consistently honor it on every run.
+
+### Folder-mode layout
+
+In folder mode, `ralph init` scaffolds the `.ralph/tasks/` tree (empty
+directories only — no README or example task). The tree separates an autonomous
+lane (`afk`) from a human-in-the-loop parking lot (`hitl`):
+
+```
+.ralph/tasks/
+  afk/todo/           # queued — Ralph picks the lowest-numbered file here
+  afk/in-progress/    # the task Ralph is currently working
+  afk/done/           # resolved successfully
+  afk/failed/         # failed, crashed, or left unfinished
+  hitl/todo/          # staging only — Ralph NEVER auto-picks from here
+```
+
+Ralph's autonomous loop only ever picks from `afk/todo/`. The `hitl` lane is a
+human-only parking lot for tasks you are not ready to release to the robot; you
+activate a task by **moving its file** `hitl/todo → afk/todo` (there is no
+command for this — it is a plain file move). The whole `.ralph/tasks/` tree is
+gitignored, so task files and their status moves never pollute your work
+commits; the loop also `mkdir -p`s any missing status directory before use, so a
+partial or freshly-cloned tree never crashes a run.
+
+### Task-file format
+
+Each task is a numbered markdown file (e.g. `001-fix-login.md`). The **leading
+integer is the task's stable identity** — it drives the branch/log/telemetry
+keys (analogous to today's `issue-N`) and stays constant as the file moves
+between status directories. The file is YAML-ish frontmatter (`title`, optional
+`labels`) delimited by `---`, followed by a markdown body:
+
+```markdown
+---
+title: Fix login redirect loop
+labels: bug, auth
+---
+
+When a session expires mid-request the app redirects to `/login` in a loop.
+Reproduce by ... and fix so the user lands on the originally requested page.
+```
+
+The `title` and body map 1:1 onto a GitHub issue's title and body, so the
+prompt fills the same way regardless of source. `labels` accepts a comma list
+(`bug, auth`) or a bracketed list (`[bug, auth]`).
+
+**Numbering rule** (a spec for a future task-authoring skill; the skill itself
+is out of scope): the next number is `max(N) + 1` scanned across **all**
+directories in **both** lanes, so a number is never reused — even by a task
+already in `done/`, `failed/`, or the `hitl` parking lot.
+
+### How Ralph works a folder task
+
+Each iteration Ralph picks the lowest-numbered file in `afk/todo/` (the folder
+analog of GitHub's `sort:created-asc`), then runs the same team flow described
+in [How Ralph resolves issues](#how-ralph-resolves-issues) — only the intake and
+completion differ:
+
+- The agent moves the file `todo → in-progress` when it starts, resolves the
+  task, commits directly to `DEV_BRANCH` (no branch, no PR, no merge), and moves
+  the file to `done/` on success.
+- The bash loop owns the **failure sweep**: on a non-zero exit, a file left in
+  `in-progress/`, or a no-op (the agent exited 0 but left the file in `todo/`),
+  bash moves the task to `failed/` so the queue always advances and no task is
+  silently lost.
+- The **zero-progress guard** still applies: if the same task is re-selected on
+  consecutive iterations with no state change, Ralph stops rather than spin
+  forever.
+
+Per-task telemetry works exactly as in GitHub mode: the same
+`.ralph/metrics/issues.jsonl` stream and daily heartbeat rollup serve both
+sources, keyed on the task id, with the terminal directory (`done`/`failed`) as
+the outcome and the frontmatter labels recorded (see
+[Monitoring data model](#monitoring-data-model)).
+
+> **Accepted tradeoff:** committing straight to the dev branch means folder mode
+> has no per-task rollback boundary — a bad autonomous commit lands directly on
+> `DEV_BRANCH`.
+
 ## Scheduling Ralph (macOS launchd)
 
 Beyond the manual `ralph start` flow, Ralph can run on a launchd
@@ -300,6 +425,7 @@ be committed. Re-running `ralph init` never overwrites it.
 | --------------------- | ------------------------------------ | ----------------------------------------------------------------------- |
 | `RALPH_AGENT`         | `claude`                             | Coding agent Ralph drives: `claude` (default, Claude Code) or `codex` (OpenAI Codex CLI, **experimental**). Unset or unrecognized falls back to `claude` (with a warning). Set by `ralph init --agent <name>` / the interactive picker. |
 | `RALPH_CODEX_MODEL`   | unset (ships commented-out)          | Model id for the Codex agent (ignored when `RALPH_AGENT=claude`). Unset/empty lets Codex use its configured default and leaves the telemetry `model` field `null`. Example: `RALPH_CODEX_MODEL="gpt-5-codex"`. |
+| `TASK_SOURCE`         | `github`                             | Where Ralph draws work from: `github` (default, resolves open GitHub issues via `gh` and opens PRs) or `folder` (local `.ralph/tasks/` tree, commits straight to `DEV_BRANCH`, no PR, no `gh`). Unset/unrecognized falls back to `github`. Set by `ralph init --source <name>` / the interactive picker. See [Choosing the task source](#choosing-the-task-source). |
 | `INSTALL_CMD`         | autodetected (e.g. `npm ci`)         | Command Ralph runs at the start of each iteration. Empty = ask the agent. |
 | `TEST_CMD`            | autodetected (e.g. `npm test`)       | Test command run before opening a PR. Empty = skip.                    |
 | `LINT_CMD`            | autodetected (e.g. `npm run lint`)   | Lint command run before opening a PR. Empty = skip.                    |

--- a/packages/ralph/bin/ralph.js
+++ b/packages/ralph/bin/ralph.js
@@ -33,9 +33,14 @@ program
   .description('Initialize Ralph in the current project (config + templates + slash command)')
   .option('--reset-prompt', 'Overwrite an existing PROMPT.md with the package template')
   .option('--agent <name>', 'Coding agent to configure: claude (default) or codex')
+  .option('--source <github|folder>', 'Task source: github (default) or folder')
   .action(async (opts) => {
     try {
-      await initCommand({ resetPrompt: Boolean(opts.resetPrompt), agent: opts.agent ?? null })
+      await initCommand({
+        resetPrompt: Boolean(opts.resetPrompt),
+        agent: opts.agent ?? null,
+        source: opts.source ?? null,
+      })
     } catch (e) {
       if (e instanceof InitAbort) {
         process.exit(e.exitCode ?? 1)

--- a/packages/ralph/lib/build-prompt.js
+++ b/packages/ralph/lib/build-prompt.js
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path'
 import { interpolate } from './interpolate.js'
 import { templatePath } from './paths.js'
 import { resolveAgent, agentSpec } from './agent-registry.js'
+import { resolveSource } from './task-source.js'
 
 export function buildPrompt({
   projectRoot = process.cwd(),
@@ -15,8 +16,12 @@ export function buildPrompt({
   // #554: select the orchestrator template from the resolved agent's spec
   // (prompt-team.md for claude, prompt-team-codex.md for codex) instead of
   // hardcoding one filename. Role composition + interpolation are unchanged.
+  // #565: when TASK_SOURCE=folder, select the folder-mode orchestrator instead;
+  // the github path (default) is the existing agent-selected template, unchanged.
   const { agent } = resolveAgent(env)
-  const templateName = agentSpec(agent).orchestratorTemplate
+  const source = resolveSource(env)
+  const templateName =
+    source === 'folder' ? 'prompt-team-folder.md' : agentSpec(agent).orchestratorTemplate
   const orchestratorTemplate = fs.readFileSync(templatePath(templateName), 'utf8')
   const devRole = fs.readFileSync(templatePath('roles/dev.md'), 'utf8').toString()
   const qaRole = fs.readFileSync(templatePath('roles/qa.md'), 'utf8').toString()
@@ -38,6 +43,7 @@ export function buildPrompt({
     MERGE_POLL_INTERVAL: env.MERGE_POLL_INTERVAL ?? '30',
     MERGE_POLL_MAX: env.MERGE_POLL_MAX ?? '40',
     RALPH_HEAVY_TIER: env.RALPH_HEAVY_TIER ?? '0',
+    TASK_SOURCE: source,
     PROJECT_ROOT: projectRoot,
     PROJECT_PROMPT: projectPrompt,
   }

--- a/packages/ralph/lib/build-prompt.test.js
+++ b/packages/ralph/lib/build-prompt.test.js
@@ -21,6 +21,7 @@ function makeStderr() {
 function setupFs({ projectFiles = {} } = {}) {
   const orchestratorTemplate = readFileSync(templatePath('prompt-team.md'), 'utf8')
   const codexTemplate = readFileSync(templatePath('prompt-team-codex.md'), 'utf8')
+  const folderTemplate = readFileSync(templatePath('prompt-team-folder.md'), 'utf8')
   const devRole = readFileSync(templatePath('roles/dev.md'), 'utf8')
   const qaRole = readFileSync(templatePath('roles/qa.md'), 'utf8')
   const reviewerRole = readFileSync(templatePath('roles/reviewer.md'), 'utf8')
@@ -30,6 +31,7 @@ function setupFs({ projectFiles = {} } = {}) {
   vol.mkdirSync(templatePath('roles'), { recursive: true })
   vol.writeFileSync(templatePath('prompt-team.md'), orchestratorTemplate)
   vol.writeFileSync(templatePath('prompt-team-codex.md'), codexTemplate)
+  vol.writeFileSync(templatePath('prompt-team-folder.md'), folderTemplate)
   vol.writeFileSync(templatePath('roles/dev.md'), devRole)
   vol.writeFileSync(templatePath('roles/qa.md'), qaRole)
   vol.writeFileSync(templatePath('roles/reviewer.md'), reviewerRole)
@@ -1846,6 +1848,93 @@ describe('buildPrompt', () => {
       expect(query).not.toBeNull()
       expect(query).toContain('-label:claude-working')
       expect(query).toContain('-label:claude-failed')
+    })
+  })
+
+  describe('task source selection (#565)', () => {
+    it('uses the github orchestrator by default (TASK_SOURCE unset)', () => {
+      const vol = setupFs()
+      const out = buildPrompt({ projectRoot: PROJECT, env: {}, fs: vol })
+      expect(out).toContain('# Ralph Loop — Team orchestrator')
+      expect(out).not.toMatch(/folder/i)
+    })
+
+    it('selects the folder orchestrator when TASK_SOURCE=folder', () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { TASK_SOURCE: 'folder' },
+        fs: vol,
+      })
+      expect(out).toMatch(/folder/i)
+      expect(out).toContain('.ralph/tasks/afk')
+    })
+
+    it('normalizes a mixed-case / padded TASK_SOURCE to folder', () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { TASK_SOURCE: '  FOLDER  ' },
+        fs: vol,
+      })
+      expect(out).toContain('.ralph/tasks/afk')
+    })
+
+    it('falls back to the github orchestrator on an unrecognized TASK_SOURCE', () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { TASK_SOURCE: 'gitlab' },
+        fs: vol,
+      })
+      expect(out).toContain('# Ralph Loop — Team orchestrator')
+    })
+
+    it('composes all five roles and interpolates vars in the folder orchestrator', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '## Stack\nGo' } })
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: {
+          TASK_SOURCE: 'folder',
+          INSTALL_CMD: 'go mod download',
+          TEST_CMD: 'go test ./...',
+          LINT_CMD: 'golangci-lint run',
+          DEV_BRANCH: 'dev',
+        },
+        fs: vol,
+      })
+      for (const p of ['{{ROLE_DEV}}', '{{ROLE_QA}}', '{{ROLE_REVIEW}}', '{{ROLE_WRITER}}', '{{ROLE_EXPLORER}}']) {
+        expect(out).not.toContain(p)
+      }
+      expect(out).not.toMatch(/\{\{[A-Z_]+\}\}/)
+      expect(out).toContain('go test ./...')
+      expect(out).toContain('## Stack\nGo')
+    })
+
+    it('the folder orchestrator commits to DEV_BRANCH and opens NO PR', () => {
+      const vol = setupFs()
+      const out = buildPrompt({
+        projectRoot: PROJECT,
+        env: { TASK_SOURCE: 'folder', DEV_BRANCH: 'dev' },
+        fs: vol,
+      })
+      // Folder mode commits straight to the dev branch — no PR / auto-merge flow.
+      expect(out).toContain('dev')
+      expect(out).not.toMatch(/gh pr create/)
+      expect(out).not.toMatch(/gh pr merge/)
+      expect(out).not.toMatch(/gh issue/)
+    })
+
+    it('does not warn on unknown placeholders for the folder orchestrator', () => {
+      const vol = setupFs({ projectFiles: { 'PROMPT.md': '' } })
+      const stderr = makeStderr()
+      buildPrompt({
+        projectRoot: PROJECT,
+        env: { TASK_SOURCE: 'folder' },
+        fs: vol,
+        stderr,
+      })
+      expect(stderr.calls).toHaveLength(0)
     })
   })
 

--- a/packages/ralph/lib/capture-issue-event.js
+++ b/packages/ralph/lib/capture-issue-event.js
@@ -28,6 +28,14 @@
 //                           model for Codex (null when unset — never guessed).
 //   RALPH_DURATION_MS     - loop-measured wall-clock duration (ms); used when
 //                           the stream self-reports none (Codex).
+//   TASK_SOURCE           - task source ('github' default | 'folder'). In folder
+//                           mode the event's number comes from RALPH_TASK_ID, the
+//                           verdict from RALPH_TASK_OUTCOME, and NO gh PR diff is
+//                           fetched (folder mode opens no PRs).
+//   RALPH_TASK_ID         - folder-mode task id (numeric); recorded as the event
+//                           issue_number when TASK_SOURCE=folder.
+//   RALPH_TASK_OUTCOME    - folder-mode terminal directory ('done'|'failed'|...);
+//                           done => pass, failed => fail, else unknown.
 //
 // On success appends one `RALPH_ISSUE_EVENT <json>` line via appendIssueEvent.
 
@@ -38,6 +46,17 @@ import { buildIssueEvent } from './issue-event.js'
 import { appendIssueEvent } from './issue-metrics.js'
 import { fetchPrDiffStats as realFetchPrDiffStats } from './pr-diff-stats.js'
 import { resolveAgent } from './agent-registry.js'
+import { resolveSource } from './task-source.js'
+
+// #565: map a folder task's terminal directory (RALPH_TASK_OUTCOME) to a
+// verdict. `done` => pass, `failed` => fail; anything else (in-progress, todo,
+// unset) => unknown. Returned as the verdictOverride into buildIssueEvent.
+function verdictFromOutcome(outcome) {
+  const o = (outcome || '').trim().toLowerCase()
+  if (o === 'done') return 'pass'
+  if (o === 'failed') return 'fail'
+  return 'unknown'
+}
 
 function readFileSafe(path) {
   if (!path || !existsSync(path)) return ''
@@ -69,9 +88,17 @@ export function captureIssueEvent({
     const rawStreamJson = readFileSafe(env.RALPH_RAW_JSONL_PATH)
     const stderrLog = readFileSafe(env.RALPH_STDERR_LOG_PATH)
 
-    const issueNumber = Number.parseInt(env.RALPH_ISSUE_NUMBER, 10)
+    // #565: in folder mode the "issue number" is the numeric task id
+    // (RALPH_TASK_ID) and the verdict comes from the terminal task directory
+    // (RALPH_TASK_OUTCOME) rather than issue labels/state. github mode reads
+    // RALPH_ISSUE_NUMBER exactly as before.
+    const source = resolveSource(env)
+    const numberEnv = source === 'folder' ? env.RALPH_TASK_ID : env.RALPH_ISSUE_NUMBER
+    const issueNumber = Number.parseInt(numberEnv, 10)
     const claudeExitCode = Number.parseInt(env.RALPH_CLAUDE_EXIT, 10)
     const resolvedIssueNumber = Number.isNaN(issueNumber) ? null : issueNumber
+    const verdictOverride =
+      source === 'folder' ? verdictFromOutcome(env.RALPH_TASK_OUTCOME) : null
 
     // Optional context-window override; null unless a finite positive number.
     const cw = Number(env.RALPH_CONTEXT_WINDOW)
@@ -89,12 +116,16 @@ export function captureIssueEvent({
 
     // Best-effort: never lets a slow/failed gh call abort the loop. The real
     // fetcher already degrades to zeros internally; this guard also covers an
-    // injected fetcher that throws so the event is still written.
+    // injected fetcher that throws so the event is still written. #565: folder
+    // mode opens no PRs, so there is nothing to diff — skip the gh call entirely
+    // and record zeros.
     let diff = { additions: 0, deletions: 0, changedFiles: 0 }
-    try {
-      diff = fetchDiffStats(resolvedIssueNumber) || diff
-    } catch (e) {
-      log(`capture-issue-event: diff stats unavailable (${e && e.message ? e.message : e})`)
+    if (source !== 'folder') {
+      try {
+        diff = fetchDiffStats(resolvedIssueNumber) || diff
+      } catch (e) {
+        log(`capture-issue-event: diff stats unavailable (${e && e.message ? e.message : e})`)
+      }
     }
 
     const event = buildIssueEvent({
@@ -113,6 +144,7 @@ export function captureIssueEvent({
       agent,
       model: configuredModel,
       durationMs,
+      verdictOverride,
     })
 
     appendIssueEvent(projectRoot, event)

--- a/packages/ralph/lib/capture-issue-event.qa.test.js
+++ b/packages/ralph/lib/capture-issue-event.qa.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { captureIssueEvent } from './capture-issue-event.js'
+import { metricsPath } from './issue-metrics.js'
+
+// QA augmentation for #565. The dev's capture-issue-event.test.js locks the
+// happy folder-mode paths. These attack the telemetry sidecar's "never break the
+// loop, never call gh in folder mode" contract under adversarial inputs.
+
+let workdir
+
+function envFor(overrides = {}) {
+  return {
+    PROJECT_ROOT: workdir,
+    RALPH_RUN_ID: 'ralph-abc-1718000000',
+    RALPH_CLAUDE_EXIT: '0',
+    RALPH_DEV_BRANCH: 'dev',
+    RALPH_RAW_JSONL_PATH: join(workdir, 'logs', 'x.jsonl'),
+    RALPH_STDERR_LOG_PATH: join(workdir, 'logs', 'x.log'),
+    ...overrides,
+  }
+}
+
+const folderEnv = (overrides = {}) =>
+  envFor({ TASK_SOURCE: 'folder', RALPH_TASK_ID: '7', RALPH_TASK_OUTCOME: 'done', ...overrides })
+
+function readEvents() {
+  const p = metricsPath(workdir)
+  if (!existsSync(p)) return []
+  return readFileSync(p, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l.slice('RALPH_ISSUE_EVENT '.length)))
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'ralph-capture-qa-'))
+  mkdirSync(join(workdir, 'logs'), { recursive: true })
+})
+
+afterEach(() => {
+  if (workdir && existsSync(workdir)) rmSync(workdir, { recursive: true, force: true })
+})
+
+describe('captureIssueEvent — folder telemetry adversarial (#565 QA)', () => {
+  it('folder mode NEVER calls the gh diff fetcher, even when it would throw', () => {
+    const fetchDiffStats = () => {
+      throw new Error('gh must not be called in folder mode')
+    }
+    // Must not throw and must still write a zeroed-diff event.
+    expect(() =>
+      captureIssueEvent({ env: folderEnv(), fetchDiffStats }),
+    ).not.toThrow()
+    const e = readEvents()[0]
+    expect(e.files).toBe(0)
+    expect(e.insertions).toBe(0)
+    expect(e.deletions).toBe(0)
+  })
+
+  it('RALPH_TASK_OUTCOME verdict is case-insensitive (DONE → pass, FAILED → fail)', () => {
+    captureIssueEvent({ env: folderEnv({ RALPH_TASK_OUTCOME: 'DONE' }), fetchDiffStats: () => ({}) })
+    expect(readEvents()[0].verdict).toBe('pass')
+  })
+
+  it('the folder verdict override beats a stray claude-failed label', () => {
+    captureIssueEvent({
+      env: folderEnv({ RALPH_TASK_OUTCOME: 'done', RALPH_ISSUE_LABELS: 'claude-failed' }),
+      fetchDiffStats: () => ({}),
+    })
+    // Even though a claude-failed label is present, the terminal-dir outcome wins.
+    expect(readEvents()[0].verdict).toBe('pass')
+  })
+
+  it('a non-numeric RALPH_TASK_ID becomes a null issue_number (never NaN in JSON)', () => {
+    captureIssueEvent({
+      env: folderEnv({ RALPH_TASK_ID: 'not-a-number' }),
+      fetchDiffStats: () => ({}),
+    })
+    const e = readEvents()[0]
+    expect(e.issue_number).toBe(null)
+  })
+
+  it('reads RALPH_TASK_ID (not RALPH_ISSUE_NUMBER) as the number in folder mode', () => {
+    captureIssueEvent({
+      env: folderEnv({ RALPH_TASK_ID: '42', RALPH_ISSUE_NUMBER: '98' }),
+      fetchDiffStats: () => ({}),
+    })
+    expect(readEvents()[0].issue_number).toBe(42)
+  })
+
+  it('a garbage TASK_SOURCE resolves to github and DOES read RALPH_ISSUE_NUMBER', () => {
+    // resolveSource falls back to github; the sidecar then reads the issue number.
+    let called = 0
+    captureIssueEvent({
+      env: envFor({ TASK_SOURCE: 'gitlab', RALPH_ISSUE_NUMBER: '55', RALPH_TASK_ID: '7' }),
+      fetchDiffStats: () => {
+        called++
+        return { additions: 0, deletions: 0, changedFiles: 0 }
+      },
+    })
+    expect(readEvents()[0].issue_number).toBe(55)
+    expect(called).toBe(1)
+  })
+
+  it('a telemetry crash (unwritable project root) never throws out of the sidecar', () => {
+    expect(() =>
+      captureIssueEvent({
+        env: folderEnv({ PROJECT_ROOT: '/nonexistent/\0/root' }),
+        fetchDiffStats: () => ({}),
+      }),
+    ).not.toThrow()
+  })
+})

--- a/packages/ralph/lib/capture-issue-event.test.js
+++ b/packages/ralph/lib/capture-issue-event.test.js
@@ -450,6 +450,72 @@ describe('QA: captureIssueEvent — RALPH_CONTEXT_WINDOW wiring (#534)', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// #565: folder task source. The task id (RALPH_TASK_ID) is the event's
+// issue_number, the terminal directory (RALPH_TASK_OUTCOME: done|failed) drives
+// the verdict, frontmatter labels flow through RALPH_ISSUE_LABELS, and NO gh PR
+// diff is fetched (folder mode opens no PRs). The github path is unchanged.
+// ---------------------------------------------------------------------------
+describe('captureIssueEvent — folder task source (#565)', () => {
+  const folderEnv = (overrides = {}) =>
+    envFor({
+      TASK_SOURCE: 'folder',
+      RALPH_TASK_ID: '7',
+      RALPH_TASK_OUTCOME: 'done',
+      ...overrides,
+    })
+
+  it('uses RALPH_TASK_ID as the event issue_number in folder mode', () => {
+    capture({ env: folderEnv() })
+    expect(readEvents()[0].issue_number).toBe(7)
+  })
+
+  it('maps RALPH_TASK_OUTCOME=done to a pass verdict', () => {
+    capture({ env: folderEnv({ RALPH_TASK_OUTCOME: 'done' }) })
+    expect(readEvents()[0].verdict).toBe('pass')
+  })
+
+  it('maps RALPH_TASK_OUTCOME=failed to a fail verdict', () => {
+    capture({ env: folderEnv({ RALPH_TASK_OUTCOME: 'failed' }) })
+    expect(readEvents()[0].verdict).toBe('fail')
+  })
+
+  it('maps an unknown/absent outcome to unknown', () => {
+    capture({ env: folderEnv({ RALPH_TASK_OUTCOME: 'in-progress' }) })
+    expect(readEvents()[0].verdict).toBe('unknown')
+  })
+
+  it('does NOT call the PR diff fetcher in folder mode (no PR to diff)', () => {
+    let calls = 0
+    const fetchDiffStats = () => {
+      calls++
+      return { additions: 9, deletions: 9, changedFiles: 9 }
+    }
+    captureIssueEvent({ env: folderEnv(), fetchDiffStats })
+    expect(calls).toBe(0)
+    const e = readEvents()[0]
+    expect(e.files).toBe(0)
+    expect(e.insertions).toBe(0)
+    expect(e.deletions).toBe(0)
+  })
+
+  it('records the agent for a folder-mode event', () => {
+    capture({ env: folderEnv({ RALPH_AGENT: 'codex' }) })
+    expect(readEvents()[0].agent).toBe('codex')
+  })
+
+  it('github mode still fetches PR diff stats (no regression)', () => {
+    let calls = 0
+    const fetchDiffStats = () => {
+      calls++
+      return { additions: 4, deletions: 2, changedFiles: 1 }
+    }
+    captureIssueEvent({ env: envFor(), fetchDiffStats })
+    expect(calls).toBe(1)
+    expect(readEvents()[0].files).toBe(1)
+  })
+})
+
 describe('captureIssueEvent — agent selection (#554)', () => {
   it('records agent "claude" by default (RALPH_AGENT unset)', () => {
     writeFileSync(

--- a/packages/ralph/lib/commands/cycle.js
+++ b/packages/ralph/lib/commands/cycle.js
@@ -23,6 +23,9 @@ import { templatePath } from '../paths.js'
 import { resolveAgent } from '../agent-registry.js'
 import { probeAgentAuth } from '../agent-auth.js'
 import { readConfigAgent } from '../read-config-agent.js'
+import { readConfigSource } from '../read-config-source.js'
+import { resolveSource } from '../task-source.js'
+import { queueCount as folderQueueCountLib } from '../folder-queue.js'
 
 const SEARCH_QUERY =
   'state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge'
@@ -51,6 +54,7 @@ export async function cycleCommand({
   pingFail = defaultPingFail,
   runQueueOnce = defaultRunQueueOnce,
   readFile = realReadFileSync,
+  folderQueueCount = defaultFolderQueueCount,
   now = Date.now,
   claudeCredentialsPath = resolve(homedir(), '.claude', '.credentials.json'),
   processEnv = process.env,
@@ -86,6 +90,13 @@ export async function cycleCommand({
     }
   }
 
+  // #565: resolve the task source from ralph.config.sh (folder mode does not
+  // need gh auth, and draws the queue from the local .ralph/tasks tree). The
+  // github path (default) is unchanged.
+  const configPath = resolve(root, 'ralph.config.sh')
+  const configSourceRaw = readConfigSource(configPath, { exists, readFile })
+  const source = resolveSource({ TASK_SOURCE: configSourceRaw || processEnv.TASK_SOURCE })
+
   const preflight = await runPreflight({
     exec,
     exists,
@@ -93,6 +104,7 @@ export async function cycleCommand({
     root,
     claudeCredentialsPath,
     processEnv,
+    source,
   })
   if (!preflight.ok) {
     err(`❌ ralph cycle: pré-checagem falhou (${preflight.reason}).`)
@@ -147,7 +159,10 @@ export async function cycleCommand({
       await notify(`🧹 ralph cycle: limpou ${cleared.length} orphans em ${repoSlug}: ${list}`)
     }
 
-    const queueCount = await getQueueCount(exec, root)
+    const queueCount =
+      source === 'folder'
+        ? await getFolderQueueCount(folderQueueCount, root)
+        : await getQueueCount(exec, root)
     if (queueCount === 0) {
       out('ℹ️  ralph cycle: fila vazia, encerrando.')
       emitEvent({
@@ -259,10 +274,14 @@ function loadEnvIfExists(exists, loadEnv, path) {
   }
 }
 
-async function runPreflight({ exec, exists, readFile, root, claudeCredentialsPath, processEnv = {} }) {
-  const ghAuth = await exec('gh', ['auth', 'status'], { cwd: root, reject: false })
-  if (!ghAuth || ghAuth.exitCode !== 0) {
-    return { ok: false, reason: 'gh not authenticated' }
+async function runPreflight({ exec, exists, readFile, root, claudeCredentialsPath, processEnv = {}, source = 'github' }) {
+  // #565: gh auth is only required for the github task source. In folder mode
+  // the loop never touches gh, so a missing/broken gh must not block the cycle.
+  if (source === 'github') {
+    const ghAuth = await exec('gh', ['auth', 'status'], { cwd: root, reject: false })
+    if (!ghAuth || ghAuth.exitCode !== 0) {
+      return { ok: false, reason: 'gh not authenticated' }
+    }
   }
 
   const configPath = resolve(root, 'ralph.config.sh')
@@ -324,6 +343,21 @@ async function getQueueCount(exec, root) {
   const raw = (result?.stdout || '').trim()
   const n = Number.parseInt(raw, 10)
   return Number.isFinite(n) ? n : 0
+}
+
+// #565: default folder-queue counter — counts .md tasks in .ralph/tasks/afk/
+// todo via the folder-queue library. Injectable in tests via folderQueueCount.
+function defaultFolderQueueCount({ root }) {
+  return folderQueueCountLib(resolve(root, '.ralph', 'tasks'))
+}
+
+async function getFolderQueueCount(folderQueueCount, root) {
+  try {
+    const n = await folderQueueCount({ root })
+    return Number.isFinite(n) ? n : 0
+  } catch {
+    return 0
+  }
 }
 
 function ageInMinutes(nowMs, isoStartedAt) {

--- a/packages/ralph/lib/commands/cycle.test.js
+++ b/packages/ralph/lib/commands/cycle.test.js
@@ -347,6 +347,70 @@ describe('cycleCommand — preflight is agent-aware (#559)', () => {
   })
 })
 
+// #565: in folder mode the preflight must NOT require gh auth, and the queue
+// count comes from the local .ralph/tasks/afk/todo tree instead of `gh issue
+// list`. The github path (default) is unchanged — all the tests above still
+// drive it through gh.
+describe('cycleCommand — folder task source (#565)', () => {
+  const folderDeps = (overrides = {}) =>
+    baseDeps({
+      readFile: (p) =>
+        String(p).endsWith('ralph.config.sh') ? 'TASK_SOURCE=folder\n' : '',
+      ...overrides,
+    })
+
+  it('does NOT run gh auth status in folder mode', async () => {
+    const deps = folderDeps({
+      // one task in the folder queue → proceeds past queue-empty
+      folderQueueCount: async () => 1,
+    })
+    await cycleCommand(deps)
+    expect(deps.exec.calls.some((c) => c.key === 'gh auth status')).toBe(false)
+  })
+
+  it('a broken gh auth does NOT fail folder-mode preflight', async () => {
+    const deps = folderDeps({ folderQueueCount: async () => 0 })
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh auth status': { exitCode: 1, stdout: '', stderr: 'not authenticated' },
+    })
+    deps.readFile = (p) =>
+      String(p).endsWith('ralph.config.sh') ? 'TASK_SOURCE=folder\n' : ''
+    const result = await cycleCommand(deps)
+    // reaches queue-empty (queue is 0) — proof preflight let it through.
+    expect(result.status).not.toBe('preflight-failed')
+    expect(result.status).toBe('queue-empty')
+  })
+
+  it('counts the folder queue (not gh issue list) in folder mode', async () => {
+    const deps = folderDeps({ folderQueueCount: async () => 3 })
+    await cycleCommand(deps)
+    // the gh issue-list query must NOT have been used to count the queue
+    expect(deps.exec.calls.some((c) => c.key.startsWith('gh issue list'))).toBe(false)
+  })
+
+  it('exits queue-empty when the folder queue is empty', async () => {
+    const deps = folderDeps({ folderQueueCount: async () => 0 })
+    const result = await cycleCommand(deps)
+    expect(result.status).toBe('queue-empty')
+  })
+
+  it('github mode still uses gh auth + gh issue list (no regression)', async () => {
+    const deps = baseDeps()
+    deps.exec = makeExec({
+      ...baseHandlers(),
+      'gh issue list --search state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge --limit 100 --json number -q . | length': {
+        exitCode: 0,
+        stdout: '0',
+        stderr: '',
+      },
+    })
+    await cycleCommand(deps)
+    expect(deps.exec.calls.some((c) => c.key === 'gh auth status')).toBe(true)
+    expect(deps.exec.calls.some((c) => c.key.startsWith('gh issue list'))).toBe(true)
+  })
+})
+
 describe('cycleCommand — lock held', () => {
   it('returns lock-held and notifies skipped when another instance holds the lock', async () => {
     const deps = baseDeps({

--- a/packages/ralph/lib/commands/doctor.js
+++ b/packages/ralph/lib/commands/doctor.js
@@ -2,6 +2,7 @@ import pc from 'picocolors'
 import { checkDeps, commandExists } from '../deps.js'
 import { detectPlatform } from '../platform.js'
 import { resolveAgent } from '../agent-registry.js'
+import { resolveSource } from '../task-source.js'
 
 class DoctorAbort extends Error {
   constructor(message, exitCode = 1) {
@@ -24,7 +25,9 @@ export async function doctorCommand({
   // which agent it validated. RALPH_AGENT unset => claude (behavior unchanged
   // for existing users).
   const { agent, warning } = resolveAgent(env)
-  const results = checkDeps({ hasCommand, agent })
+  // #565: gate gh on the resolved task source (folder mode does not need gh).
+  const source = resolveSource(env)
+  const results = checkDeps({ hasCommand, agent, source })
   const missingCritical = results.filter((r) => !r.present && r.critical)
   const missingNonCritical = results.filter((r) => !r.present && !r.critical)
 
@@ -74,7 +77,8 @@ export function assertCriticalDeps({
   env = process.env,
 } = {}) {
   const { agent } = resolveAgent(env)
-  const results = checkDeps({ hasCommand, agent })
+  const source = resolveSource(env)
+  const results = checkDeps({ hasCommand, agent, source })
   const missingCritical = results.filter((r) => !r.present && r.critical)
   if (missingCritical.length === 0) return { ok: true, missingCritical: [] }
   const formatted = missingCritical

--- a/packages/ralph/lib/commands/init.js
+++ b/packages/ralph/lib/commands/init.js
@@ -9,6 +9,7 @@ import { execa } from 'execa'
 import { detectStack } from '../detect-stack.js'
 import { templatePath } from '../paths.js'
 import { resolveAgent, VALID_AGENTS } from '../agent-registry.js'
+import { VALID_SOURCES, DEFAULT_SOURCE } from '../task-source.js'
 import { confirm } from '../utils/prompt.js'
 
 class InitAbort extends Error {
@@ -18,6 +19,9 @@ class InitAbort extends Error {
   }
 }
 
+// #565: VALID_SOURCES / DEFAULT_SOURCE come from the task-source registry so the
+// init flag/prompt path and the runtime resolver share one source of truth.
+
 export async function initCommand({
   cwd = process.cwd(),
   stdout = process.stdout,
@@ -26,8 +30,10 @@ export async function initCommand({
   fs: fsImpl,
   resetPrompt = false,
   agent: agentFlag = null,
+  source: sourceFlag = null,
   isTTY = Boolean(process.stdin && process.stdin.isTTY),
   promptAgent = defaultPromptAgent,
+  promptSource = defaultPromptSource,
   ask = confirm,
 } = {}) {
   const fs = wrapFs(fsImpl)
@@ -49,6 +55,20 @@ export async function initCommand({
     }
   }
 
+  // #565: an explicit --source flag is validated EARLY and REJECTED hard on a
+  // typo (before any file writes), mirroring the --agent guard above. Empty/
+  // whitespace is not a typo — it falls through to the interactive prompt or
+  // the github default.
+  if (sourceFlag != null && String(sourceFlag).trim() !== '') {
+    const normalized = String(sourceFlag).trim().toLowerCase()
+    if (!VALID_SOURCES.includes(normalized)) {
+      err(
+        `❌ Unknown task source '${sourceFlag}'. Valid sources: ${VALID_SOURCES.join(', ')}.`,
+      )
+      throw new InitAbort(`unknown task source '${sourceFlag}'`, 1)
+    }
+  }
+
   // #554: pick the coding agent. Priority: explicit --agent flag > interactive
   // prompt (only when a TTY and no flag) > "claude" default. Whatever we land
   // on runs through the registry so a typo at the prompt falls back to claude.
@@ -58,6 +78,17 @@ export async function initCommand({
   }
   const { agent, warning } = resolveAgent({ RALPH_AGENT: agentChoice ?? 'claude' })
   if (warning) err(`⚠️  ${warning}`)
+
+  // #565: resolve the task source. Priority: explicit --source flag > interactive
+  // prompt (only when a TTY and no flag) > "github" default. The flag was already
+  // validated above; a prompt/env value is normalized and falls back to github.
+  const source = await resolveSourceChoice({
+    sourceFlag,
+    isTTY,
+    promptSource,
+    stdout,
+    ask,
+  })
 
   const projectRoot = await resolveProjectRoot({ cwd, exec })
   const stackInfo = detectStack(projectRoot, fsImpl)
@@ -85,8 +116,15 @@ export async function initCommand({
       DEV_BRANCH: devBranch,
       PR_TARGET: prTarget,
       RALPH_AGENT: agent,
+      TASK_SOURCE: source,
     },
   })
+
+  // #565: in folder mode, scaffold the empty task tree so the loop has
+  // somewhere to read from on first run. github mode never creates it.
+  if (source === 'folder') {
+    scaffoldTaskTree({ fs, out, projectRoot })
+  }
 
   writeIfAbsent({
     fs,
@@ -123,7 +161,7 @@ export async function initCommand({
     lines: ['.ralph/', 'ralph-notify.sh', '.env.local'],
   })
 
-  printSummary({ out, stackInfo, mainBranch, devBranch, prTarget })
+  printSummary({ out, stackInfo, mainBranch, devBranch, prTarget, source })
 
   return {
     exitCode: 0,
@@ -136,7 +174,48 @@ export async function initCommand({
     devBranch,
     prTarget,
     agent,
+    source,
   }
+}
+
+// Resolve TASK_SOURCE. Priority: explicit --source flag > interactive prompt
+// (only when a TTY and no flag) > "github" default. Any resolved value is
+// normalized and falls back to github when unrecognized (a prompt typo never
+// aborts an unattended run).
+async function resolveSourceChoice({ sourceFlag, isTTY, promptSource, stdout, ask }) {
+  let choice = sourceFlag
+  if ((choice == null || String(choice).trim() === '') && isTTY) {
+    choice = await promptSource({ stdout, ask })
+  }
+  const normalized = String(choice ?? '').trim().toLowerCase()
+  return VALID_SOURCES.includes(normalized) ? normalized : DEFAULT_SOURCE
+}
+
+// Interactive source picker. Built on the shared `confirm` helper (matching the
+// agent picker): a yes/no keeps the default (github) as the safe path for a
+// blank answer. `ask` is injectable so tests never touch real stdin.
+async function defaultPromptSource({ stdout = process.stdout, ask = confirm } = {}) {
+  const useFolder = await ask('Draw tasks from a local .ralph/tasks/ folder instead of GitHub? [y/N]: ', {
+    output: stdout,
+  })
+  return useFolder ? 'folder' : 'github'
+}
+
+// #565: scaffold the empty folder-mode task tree. Only the afk lane has the four
+// status dirs the loop moves tasks through; the hitl lane is human-only (todo).
+function scaffoldTaskTree({ fs, out, projectRoot }) {
+  const base = join(projectRoot, '.ralph', 'tasks')
+  const dirs = [
+    join(base, 'afk', 'todo'),
+    join(base, 'afk', 'in-progress'),
+    join(base, 'afk', 'done'),
+    join(base, 'afk', 'failed'),
+    join(base, 'hitl', 'todo'),
+  ]
+  for (const dir of dirs) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+  out('✅ Scaffolded .ralph/tasks/ (afk + hitl lanes)')
 }
 
 // Interactive agent picker. Built on the shared `confirm` helper (#560) rather
@@ -274,7 +353,7 @@ function appendGitignore({ fs, out, path, lines }) {
   out('✅ Updated .gitignore')
 }
 
-function printSummary({ out, stackInfo, mainBranch, devBranch, prTarget }) {
+function printSummary({ out, stackInfo, mainBranch, devBranch, prTarget, source }) {
   const empty = (v) => (v ? v : '(empty)')
   out('')
   out('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
@@ -286,6 +365,7 @@ function printSummary({ out, stackInfo, mainBranch, devBranch, prTarget }) {
   out(`  MAIN_BRANCH:  ${mainBranch}`)
   out(`  DEV_BRANCH:   ${devBranch}`)
   out(`  PR_TARGET:    ${prTarget}`)
+  out(`  TASK_SOURCE:  ${source}`)
   out('')
   out('WhatsApp notifications (optional):')
   out(

--- a/packages/ralph/lib/deps.js
+++ b/packages/ralph/lib/deps.js
@@ -11,6 +11,10 @@ export const REQUIRED_DEPS = {
   },
   gh: {
     critical: true,
+    // Source CLI: gh is only required for the github task source (#565). When
+    // TASK_SOURCE=folder, checkDeps skips it entirely so a folder-only machine
+    // is never told to install gh. `source` defaults to 'github' below.
+    source: 'github',
     install: {
       mac: 'brew install gh',
       linux: 'apt install gh',
@@ -81,16 +85,26 @@ export const REQUIRED_DEPS = {
   },
 }
 
-// Agent-aware dependency check (#554). Shared deps (git/gh/tmux/node/npm/jq/
-// curl) are always checked. Of the agent CLIs, ONLY the selected agent's CLI is
-// included — the other agent's CLI is skipped entirely, so a Codex-only machine
-// is never told to install `claude` (and vice-versa). `agent` defaults to
-// 'claude' so existing callers see exactly today's behavior.
-export function checkDeps({ hasCommand, deps = REQUIRED_DEPS, agent = 'claude' } = {}) {
+// Agent- and source-aware dependency check (#554, #565). Shared deps (git/tmux/
+// node/npm/jq/curl) are always checked. Of the agent CLIs, ONLY the selected
+// agent's CLI is included — the other agent's CLI is skipped entirely, so a
+// Codex-only machine is never told to install `claude` (and vice-versa).
+// Source-gated deps (gh) are included only when the active TASK_SOURCE matches
+// (gh => github); a folder-only machine is never told to install gh. `agent`
+// defaults to 'claude' and `source` to 'github' so existing callers see exactly
+// today's behavior.
+export function checkDeps({
+  hasCommand,
+  deps = REQUIRED_DEPS,
+  agent = 'claude',
+  source = 'github',
+} = {}) {
   const results = []
   for (const [name, info] of Object.entries(deps)) {
     // Skip the non-selected agent's CLI.
     if (info.agent && name !== agent) continue
+    // Skip source-gated deps (gh) when the active source differs (#565).
+    if (info.source && info.source !== source) continue
     results.push({
       name,
       present: hasCommand(name),

--- a/packages/ralph/lib/deps.test.js
+++ b/packages/ralph/lib/deps.test.js
@@ -78,3 +78,31 @@ describe('checkDeps — agent-aware CLI selection (#554)', () => {
     expect(REQUIRED_DEPS.codex.agent).toBe(true)
   })
 })
+
+describe('checkDeps — source-aware gh gating (#565)', () => {
+  it('default source (github) INCLUDES gh', () => {
+    expect(names(checkDeps({ hasCommand: allPresent }))).toContain('gh')
+  })
+
+  it('source=github INCLUDES gh (explicit)', () => {
+    expect(names(checkDeps({ hasCommand: allPresent, source: 'github' }))).toContain('gh')
+  })
+
+  it('source=folder EXCLUDES gh entirely', () => {
+    const got = names(checkDeps({ hasCommand: allPresent, source: 'folder' }))
+    expect(got).not.toContain('gh')
+    // other shared deps still present
+    expect(got).toContain('git')
+    expect(got).toContain('tmux')
+  })
+
+  it('folder source still includes the selected agent CLI', () => {
+    const got = names(checkDeps({ hasCommand: allPresent, source: 'folder', agent: 'codex' }))
+    expect(got).toContain('codex')
+    expect(got).not.toContain('gh')
+  })
+
+  it('REQUIRED_DEPS marks gh with source=github', () => {
+    expect(REQUIRED_DEPS.gh.source).toBe('github')
+  })
+})

--- a/packages/ralph/lib/doctor.test.js
+++ b/packages/ralph/lib/doctor.test.js
@@ -250,6 +250,66 @@ describe('doctor / deps — agent-aware (#554)', () => {
   })
 })
 
+describe('doctor / deps — source-aware gh gating (#565)', () => {
+  it('checks gh when source is github (default)', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    await doctorCommand({ stdout, stderr, hasCommand: allPresent, platform: 'mac', env: {} })
+    expect(stdout.output()).toMatch(/✓ gh/)
+  })
+
+  it('does NOT check gh when TASK_SOURCE=folder', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: allPresent,
+      platform: 'mac',
+      env: { TASK_SOURCE: 'folder' },
+    })
+    expect(stdout.output()).not.toContain('gh')
+    // other shared deps still shown
+    expect(stdout.output()).toMatch(/✓ git/)
+  })
+
+  it('a missing gh does NOT fail doctor in folder mode', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const result = await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: (cmd) => cmd !== 'gh',
+      platform: 'mac',
+      env: { TASK_SOURCE: 'folder' },
+    })
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('a missing gh DOES fail doctor in github mode', async () => {
+    const stdout = makeStream()
+    const stderr = makeStream()
+    const result = await doctorCommand({
+      stdout,
+      stderr,
+      hasCommand: (cmd) => cmd !== 'gh',
+      platform: 'mac',
+      env: {},
+    })
+    expect(result.exitCode).toBe(1)
+    expect(result.missingCritical.map((r) => r.name)).toContain('gh')
+  })
+
+  it('assertCriticalDeps ignores a missing gh in folder mode', () => {
+    const ok = assertCriticalDeps({
+      hasCommand: (cmd) => cmd !== 'gh',
+      platform: 'mac',
+      env: { TASK_SOURCE: 'folder' },
+    })
+    expect(ok.ok).toBe(true)
+  })
+})
+
 describe('detectPlatform', () => {
   it('returns mac for darwin', () => {
     expect(detectPlatform({ platform: 'darwin' })).toBe('mac')

--- a/packages/ralph/lib/folder-queue.js
+++ b/packages/ralph/lib/folder-queue.js
@@ -1,0 +1,176 @@
+// Folder-mode task queue (#565). When TASK_SOURCE=folder, Ralph draws tasks from
+// a local `.ralph/tasks/` tree instead of GitHub. The afk lane has four status
+// directories (todo, in-progress, done, failed); the hitl lane is human-only
+// (todo). This module is the single source of truth for the folder queue's
+// mechanics and doubles as a node CLI the bash loop shells out to (mirroring
+// capture-issue-event.js / agent-invocation.js), so bash holds no task-move
+// knowledge of its own.
+//
+// Library API (injectable fs for hermetic tests):
+//   queueCount(tasksRoot, {fs})       — number of .md files in afk/todo
+//   queuePick(tasksRoot, {fs})        — lowest-numbered afk/todo task, or null
+//   locateTask(tasksRoot, id, {fs})   — which afk status dir holds a task, or null
+//   startTask/completeTask/failTask   — status moves; true on success
+//
+// CLI (for templates/ralph.sh):
+//   node folder-queue.js count <tasksRoot>       → prints the todo count
+//   node folder-queue.js pick  <tasksRoot>       → prints "<id>\t<path>" or nothing
+//   node folder-queue.js locate <tasksRoot> <id> → prints the afk status dir
+//                                                   holding the task, or nothing
+//   node folder-queue.js fail  <tasksRoot> <id>  → sweep a stuck/never-started task
+//   node folder-queue.js complete <tasksRoot> <id>
+//   node folder-queue.js start <tasksRoot> <id>
+
+import {
+  existsSync as realExistsSync,
+  readdirSync as realReaddirSync,
+  mkdirSync as realMkdirSync,
+  renameSync as realRenameSync,
+} from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+import { taskIdFromFilename } from './task-file.js'
+
+const AFK_STATUSES = ['todo', 'in-progress', 'done', 'failed']
+
+function fsFrom(fsImpl) {
+  if (!fsImpl) {
+    return {
+      existsSync: realExistsSync,
+      readdirSync: realReaddirSync,
+      mkdirSync: realMkdirSync,
+      renameSync: realRenameSync,
+    }
+  }
+  return {
+    existsSync: fsImpl.existsSync.bind(fsImpl),
+    readdirSync: fsImpl.readdirSync.bind(fsImpl),
+    mkdirSync: fsImpl.mkdirSync.bind(fsImpl),
+    renameSync: fsImpl.renameSync.bind(fsImpl),
+  }
+}
+
+// List the .md files in a directory, degrading to [] when it doesn't exist.
+function listMd(fs, dir) {
+  if (!fs.existsSync(dir)) return []
+  let entries = []
+  try {
+    entries = fs.readdirSync(dir)
+  } catch {
+    return []
+  }
+  return entries
+    .map((e) => (typeof e === 'string' ? e : e?.name))
+    .filter((name) => typeof name === 'string' && name.endsWith('.md'))
+}
+
+function todoDir(tasksRoot) {
+  return `${tasksRoot}/afk/todo`
+}
+function statusDir(tasksRoot, status) {
+  return `${tasksRoot}/afk/${status}`
+}
+
+export function queueCount(tasksRoot, { fs: fsImpl } = {}) {
+  const fs = fsFrom(fsImpl)
+  return listMd(fs, todoDir(tasksRoot)).length
+}
+
+// Lowest-numbered task in afk/todo. Returns { id, file, path } or null.
+export function queuePick(tasksRoot, { fs: fsImpl } = {}) {
+  const fs = fsFrom(fsImpl)
+  const files = listMd(fs, todoDir(tasksRoot))
+    .map((file) => ({ file, id: taskIdFromFilename(file) }))
+    .filter((x) => x.id != null)
+    .sort((a, b) => a.id - b.id)
+  if (files.length === 0) return null
+  const { file, id } = files[0]
+  return { id, file, path: `${todoDir(tasksRoot)}/${file}` }
+}
+
+// Which afk status directory currently holds the task with this id, or null.
+export function locateTask(tasksRoot, id, { fs: fsImpl } = {}) {
+  const fs = fsFrom(fsImpl)
+  const target = Number(id)
+  for (const status of AFK_STATUSES) {
+    const files = listMd(fs, statusDir(tasksRoot, status))
+    if (files.some((file) => taskIdFromFilename(file) === target)) return status
+  }
+  return null
+}
+
+// Move the file for `id` from `fromStatus` to `toStatus`. Defensively mkdir -p
+// the destination. Returns true when a matching file was moved, false otherwise.
+function move(fs, tasksRoot, id, fromStatus, toStatus) {
+  const target = Number(id)
+  const from = statusDir(tasksRoot, fromStatus)
+  const files = listMd(fs, from)
+  const file = files.find((f) => taskIdFromFilename(f) === target)
+  if (!file) return false
+  const to = statusDir(tasksRoot, toStatus)
+  try {
+    fs.mkdirSync(to, { recursive: true })
+  } catch {
+    // already exists
+  }
+  fs.renameSync(`${from}/${file}`, `${to}/${file}`)
+  return true
+}
+
+export function startTask(tasksRoot, id, { fs: fsImpl } = {}) {
+  return move(fsFrom(fsImpl), tasksRoot, id, 'todo', 'in-progress')
+}
+
+export function completeTask(tasksRoot, id, { fs: fsImpl } = {}) {
+  return move(fsFrom(fsImpl), tasksRoot, id, 'in-progress', 'done')
+}
+
+// Failure/no-op sweep: send a task to failed from wherever it currently sits
+// (a stuck in-progress task, or a never-started todo task). Returns true when
+// something was moved.
+export function failTask(tasksRoot, id, { fs: fsImpl } = {}) {
+  const fs = fsFrom(fsImpl)
+  const status = locateTask(tasksRoot, id, { fs: fsImpl })
+  if (status == null || status === 'failed') return false
+  return move(fs, tasksRoot, id, status, 'failed')
+}
+
+// --- CLI entrypoint (for templates/ralph.sh) --------------------------------
+function runCli(argv) {
+  const [cmd, tasksRoot, idArg] = argv
+  if (!cmd || !tasksRoot) {
+    process.stderr.write('usage: folder-queue.js <count|pick|locate|start|complete|fail> <tasksRoot> [id]\n')
+    return 2
+  }
+  switch (cmd) {
+    case 'count':
+      process.stdout.write(String(queueCount(tasksRoot)) + '\n')
+      return 0
+    case 'pick': {
+      const pick = queuePick(tasksRoot)
+      if (pick) process.stdout.write(`${pick.id}\t${pick.path}\n`)
+      return 0
+    }
+    case 'locate': {
+      const status = locateTask(tasksRoot, idArg)
+      if (status) process.stdout.write(status + '\n')
+      return 0
+    }
+    case 'start':
+      return startTask(tasksRoot, idArg) ? 0 : 1
+    case 'complete':
+      return completeTask(tasksRoot, idArg) ? 0 : 1
+    case 'fail':
+      return failTask(tasksRoot, idArg) ? 0 : 1
+    default:
+      process.stderr.write(`folder-queue.js: unknown command '${cmd}'\n`)
+      return 2
+  }
+}
+
+const invokedAsScript =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+if (invokedAsScript) {
+  process.exit(runCli(process.argv.slice(2)))
+}

--- a/packages/ralph/lib/folder-queue.qa.test.js
+++ b/packages/ralph/lib/folder-queue.qa.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import {
+  queueCount,
+  queuePick,
+  locateTask,
+  startTask,
+  completeTask,
+  failTask,
+} from './folder-queue.js'
+
+// QA augmentation for #565. The dev's folder-queue.test.js locks the happy-path
+// mechanics. These tests attack the FORWARD-PROGRESS invariants — the queue must
+// always drain, a task must never be silently lost, and the move state machine
+// must be idempotent under the exact sequences the bash loop drives.
+
+const ROOT = '/repo/.ralph/tasks'
+
+function volWith(files = {}) {
+  const json = {}
+  for (const [rel, body] of Object.entries(files)) {
+    json[`${ROOT}/${rel}`] = body
+  }
+  const vol = Volume.fromJSON(json)
+  for (const d of ['afk/todo', 'afk/in-progress', 'afk/done', 'afk/failed', 'hitl/todo']) {
+    vol.mkdirSync(`${ROOT}/${d}`, { recursive: true })
+  }
+  return vol
+}
+
+describe('queuePick — ordering & selection edge cases (#565 QA)', () => {
+  it('orders by numeric value, not string (2 before 10)', () => {
+    const vol = volWith({ 'afk/todo/10-j.md': 'x', 'afk/todo/2-b.md': 'y' })
+    expect(queuePick(ROOT, { fs: vol }).id).toBe(2)
+  })
+
+  it('zero-padded vs unpadded compare numerically (009 before 010, 2 before 010)', () => {
+    const vol = volWith({
+      'afk/todo/010-b.md': 'x',
+      'afk/todo/009-a.md': 'y',
+      'afk/todo/2-c.md': 'z',
+    })
+    expect(queuePick(ROOT, { fs: vol }).id).toBe(2)
+  })
+
+  it('skips a non-numbered .md and picks the lowest numbered one', () => {
+    const vol = volWith({ 'afk/todo/README.md': 'x', 'afk/todo/002-b.md': 'y' })
+    const pick = queuePick(ROOT, { fs: vol })
+    expect(pick.id).toBe(2)
+    expect(pick.file).toBe('002-b.md')
+  })
+
+  it('returns null when afk/todo holds only non-numbered .md files', () => {
+    const vol = volWith({ 'afk/todo/README.md': 'x' })
+    expect(queuePick(ROOT, { fs: vol })).toBe(null)
+  })
+
+  it('does NOT pick a task sitting in the hitl lane (afk-only queue)', () => {
+    const vol = volWith({ 'hitl/todo/001-h.md': 'x' })
+    expect(queuePick(ROOT, { fs: vol })).toBe(null)
+    expect(queueCount(ROOT, { fs: vol })).toBe(0)
+  })
+})
+
+describe('failTask — the forward-progress sweep (#565 QA, stories 16/18/19)', () => {
+  it('sweeps a stuck in-progress task → failed (agent crashed mid-task)', () => {
+    const vol = volWith({ 'afk/in-progress/003-c.md': 'body' })
+    expect(failTask(ROOT, 3, { fs: vol })).toBe(true)
+    expect(vol.existsSync(`${ROOT}/afk/in-progress/003-c.md`)).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/failed/003-c.md`)).toBe(true)
+  })
+
+  it('sweeps a never-started todo task → failed (agent exited 0 but did nothing)', () => {
+    const vol = volWith({ 'afk/todo/004-d.md': 'body' })
+    expect(failTask(ROOT, 4, { fs: vol })).toBe(true)
+    expect(vol.existsSync(`${ROOT}/afk/todo/004-d.md`)).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/failed/004-d.md`)).toBe(true)
+  })
+
+  it('is a no-op (returns false) for a task ALREADY in failed — never double-moves', () => {
+    const vol = volWith({ 'afk/failed/006-f.md': 'x' })
+    expect(failTask(ROOT, 6, { fs: vol })).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/failed/006-f.md`)).toBe(true)
+  })
+
+  it('returns false for an unknown id (nothing to sweep, no crash)', () => {
+    const vol = volWith({})
+    expect(failTask(ROOT, 999, { fs: vol })).toBe(false)
+  })
+
+  it('preserves the file BODY when sweeping (no data loss on failure)', () => {
+    const vol = volWith({ 'afk/in-progress/007-g.md': 'the original body' })
+    failTask(ROOT, 7, { fs: vol })
+    expect(vol.readFileSync(`${ROOT}/afk/failed/007-g.md`, 'utf8')).toBe('the original body')
+  })
+})
+
+describe('move state machine — idempotency & guards (#565 QA)', () => {
+  it('a full lifecycle todo→in-progress→done leaves exactly one copy in done', () => {
+    const vol = volWith({ 'afk/todo/001-a.md': 'body' })
+    expect(startTask(ROOT, 1, { fs: vol })).toBe(true)
+    expect(completeTask(ROOT, 1, { fs: vol })).toBe(true)
+    expect(vol.existsSync(`${ROOT}/afk/todo/001-a.md`)).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/in-progress/001-a.md`)).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/done/001-a.md`)).toBe(true)
+    // Re-running a move whose source is now empty is a safe no-op.
+    expect(startTask(ROOT, 1, { fs: vol })).toBe(false)
+    expect(completeTask(ROOT, 1, { fs: vol })).toBe(false)
+  })
+
+  it('completeTask on a todo task (not yet started) is a no-op — wrong source lane', () => {
+    const vol = volWith({ 'afk/todo/002-b.md': 'x' })
+    expect(completeTask(ROOT, 2, { fs: vol })).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/todo/002-b.md`)).toBe(true)
+    expect(vol.existsSync(`${ROOT}/afk/done/002-b.md`)).toBe(false)
+  })
+
+  it('mkdir -p: moves succeed even when destination dirs do not exist yet', () => {
+    // A tree with only the source file — no status dirs pre-created.
+    const vol = Volume.fromJSON({ [`${ROOT}/afk/in-progress/005-e.md`]: 'body' })
+    expect(completeTask(ROOT, 5, { fs: vol })).toBe(true)
+    expect(vol.existsSync(`${ROOT}/afk/done/005-e.md`)).toBe(true)
+  })
+
+  it('locate scans all afk statuses and reports the current one', () => {
+    const vol = volWith({ 'afk/in-progress/008-h.md': 'x' })
+    expect(locateTask(ROOT, 8, { fs: vol })).toBe('in-progress')
+    completeTask(ROOT, 8, { fs: vol })
+    expect(locateTask(ROOT, 8, { fs: vol })).toBe('done')
+  })
+})
+
+describe('queueCount — degradation (#565 QA)', () => {
+  it('counts every .md in afk/todo including non-numbered (raw file count)', () => {
+    const vol = volWith({
+      'afk/todo/001-a.md': 'x',
+      'afk/todo/002-b.md': 'y',
+      'afk/todo/README.md': 'z',
+    })
+    expect(queueCount(ROOT, { fs: vol })).toBe(3)
+  })
+
+  it('returns 0 when the whole tree is missing (never throws)', () => {
+    expect(queueCount(ROOT, { fs: Volume.fromJSON({}) })).toBe(0)
+  })
+})

--- a/packages/ralph/lib/folder-queue.test.js
+++ b/packages/ralph/lib/folder-queue.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import {
+  queueCount,
+  queuePick,
+  locateTask,
+  startTask,
+  completeTask,
+  failTask,
+} from './folder-queue.js'
+
+const ROOT = '/repo/.ralph/tasks'
+
+function volWith(files = {}) {
+  // files: { 'afk/todo/001-a.md': 'body', ... } relative to ROOT
+  const json = {}
+  for (const [rel, body] of Object.entries(files)) {
+    json[`${ROOT}/${rel}`] = body
+  }
+  // Ensure the standard lanes exist even when empty.
+  const vol = Volume.fromJSON(json)
+  for (const d of [
+    'afk/todo',
+    'afk/in-progress',
+    'afk/done',
+    'afk/failed',
+    'hitl/todo',
+  ]) {
+    vol.mkdirSync(`${ROOT}/${d}`, { recursive: true })
+  }
+  return vol
+}
+
+describe('queueCount — files in afk/todo (#565)', () => {
+  it('counts .md files in afk/todo', () => {
+    const vol = volWith({ 'afk/todo/001-a.md': 'x', 'afk/todo/002-b.md': 'y' })
+    expect(queueCount(ROOT, { fs: vol })).toBe(2)
+  })
+
+  it('returns 0 when afk/todo is empty', () => {
+    const vol = volWith({})
+    expect(queueCount(ROOT, { fs: vol })).toBe(0)
+  })
+
+  it('returns 0 when the tree does not exist yet', () => {
+    const vol = Volume.fromJSON({})
+    expect(queueCount(ROOT, { fs: vol })).toBe(0)
+  })
+
+  it('ignores non-.md files', () => {
+    const vol = volWith({ 'afk/todo/001-a.md': 'x', 'afk/todo/notes.txt': 'y' })
+    expect(queueCount(ROOT, { fs: vol })).toBe(1)
+  })
+})
+
+describe('queuePick — lowest-numbered task in afk/todo (#565)', () => {
+  it('picks the lowest-numbered task and returns id + path', () => {
+    const vol = volWith({
+      'afk/todo/003-c.md': 'x',
+      'afk/todo/001-a.md': 'y',
+      'afk/todo/002-b.md': 'z',
+    })
+    const pick = queuePick(ROOT, { fs: vol })
+    expect(pick.id).toBe(1)
+    expect(pick.path).toBe(`${ROOT}/afk/todo/001-a.md`)
+    expect(pick.file).toBe('001-a.md')
+  })
+
+  it('returns null when the queue is empty', () => {
+    expect(queuePick(ROOT, { fs: volWith({}) })).toBe(null)
+  })
+
+  it('returns null when the tree does not exist', () => {
+    expect(queuePick(ROOT, { fs: Volume.fromJSON({}) })).toBe(null)
+  })
+})
+
+describe('locateTask — which afk status dir holds a task (#565)', () => {
+  it('finds a task in todo', () => {
+    const vol = volWith({ 'afk/todo/005-e.md': 'x' })
+    expect(locateTask(ROOT, 5, { fs: vol })).toBe('todo')
+  })
+
+  it('finds a task in done', () => {
+    const vol = volWith({ 'afk/done/010-j.md': 'x' })
+    expect(locateTask(ROOT, 10, { fs: vol })).toBe('done')
+  })
+
+  it('returns null for an unknown id', () => {
+    expect(locateTask(ROOT, 99, { fs: volWith({}) })).toBe(null)
+  })
+})
+
+describe('move helpers — start / complete / fail (#565)', () => {
+  it('startTask moves todo → in-progress', () => {
+    const vol = volWith({ 'afk/todo/001-a.md': 'body' })
+    startTask(ROOT, 1, { fs: vol })
+    expect(vol.existsSync(`${ROOT}/afk/todo/001-a.md`)).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/in-progress/001-a.md`)).toBe(true)
+    expect(vol.readFileSync(`${ROOT}/afk/in-progress/001-a.md`, 'utf8')).toBe('body')
+  })
+
+  it('completeTask moves in-progress → done', () => {
+    const vol = volWith({ 'afk/in-progress/002-b.md': 'body' })
+    completeTask(ROOT, 2, { fs: vol })
+    expect(vol.existsSync(`${ROOT}/afk/in-progress/002-b.md`)).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/done/002-b.md`)).toBe(true)
+  })
+
+  it('failTask sweeps a stuck in-progress task → failed', () => {
+    const vol = volWith({ 'afk/in-progress/003-c.md': 'body' })
+    failTask(ROOT, 3, { fs: vol })
+    expect(vol.existsSync(`${ROOT}/afk/in-progress/003-c.md`)).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/failed/003-c.md`)).toBe(true)
+  })
+
+  it('failTask sweeps a never-started todo task → failed (no-op sweep)', () => {
+    const vol = volWith({ 'afk/todo/004-d.md': 'body' })
+    failTask(ROOT, 4, { fs: vol })
+    expect(vol.existsSync(`${ROOT}/afk/todo/004-d.md`)).toBe(false)
+    expect(vol.existsSync(`${ROOT}/afk/failed/004-d.md`)).toBe(true)
+  })
+
+  it('creates a missing destination status dir defensively', () => {
+    // Volume without the standard lanes — startTask must mkdir -p as needed.
+    const vol = Volume.fromJSON({ [`${ROOT}/afk/todo/001-a.md`]: 'body' })
+    startTask(ROOT, 1, { fs: vol })
+    expect(vol.existsSync(`${ROOT}/afk/in-progress/001-a.md`)).toBe(true)
+  })
+
+  it('move helpers return true on success, false when the task is not found', () => {
+    const vol = volWith({ 'afk/todo/001-a.md': 'body' })
+    expect(startTask(ROOT, 1, { fs: vol })).toBe(true)
+    expect(completeTask(ROOT, 999, { fs: vol })).toBe(false)
+  })
+})

--- a/packages/ralph/lib/init.qa.test.js
+++ b/packages/ralph/lib/init.qa.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { Volume } from 'memfs'
+import { initCommand, InitAbort } from './commands/init.js'
+
+// QA augmentation for #565. The dev's init.test.js locks the source-selection
+// happy paths. These attack idempotency (re-running init must not clobber real
+// tasks) and the flag/prompt precedence guards under adversarial input.
+
+const PROJECT = '/project'
+
+function makeStream() {
+  const chunks = []
+  return { write: (s) => (chunks.push(s), true), output: () => chunks.join('') }
+}
+
+function makeExec() {
+  return async (cmd, args) => {
+    const key = `${cmd} ${args.join(' ')}`
+    if (key === 'git rev-parse --show-toplevel') return { exitCode: 0, stdout: PROJECT, stderr: '' }
+    if (key === 'git symbolic-ref refs/remotes/origin/HEAD')
+      return { exitCode: 0, stdout: 'refs/remotes/origin/main', stderr: '' }
+    if (key === 'git branch -a') return { exitCode: 0, stdout: '* main\n', stderr: '' }
+    return { exitCode: 0, stdout: '', stderr: '' }
+  }
+}
+
+function newVol() {
+  const vol = Volume.fromJSON({ [`${PROJECT}/.keep`]: '' }, '/')
+  return vol
+}
+
+function run(vol, opts = {}) {
+  return initCommand({
+    cwd: PROJECT,
+    stdout: makeStream(),
+    stderr: opts.stderr ?? makeStream(),
+    exec: makeExec(),
+    fs: vol,
+    ...opts,
+  })
+}
+
+describe('initCommand — folder scaffold idempotency (#565 QA)', () => {
+  it('running init --source folder twice does not crash and keeps existing tasks', async () => {
+    const vol = newVol()
+    await run(vol, { source: 'folder' })
+    // Simulate a real queued task the author added after the first init.
+    vol.writeFileSync(`${PROJECT}/.ralph/tasks/afk/todo/001-real-task.md`, 'do the thing')
+
+    // Second init must not throw and must not clobber the task file.
+    const result = await run(vol, { source: 'folder' })
+    expect(result.exitCode).toBe(0)
+    expect(vol.existsSync(`${PROJECT}/.ralph/tasks/afk/todo/001-real-task.md`)).toBe(true)
+    expect(vol.readFileSync(`${PROJECT}/.ralph/tasks/afk/todo/001-real-task.md`, 'utf8')).toBe(
+      'do the thing',
+    )
+  })
+
+  it('all five lane dirs exist after scaffold', async () => {
+    const vol = newVol()
+    await run(vol, { source: 'folder' })
+    for (const d of [
+      'afk/todo',
+      'afk/in-progress',
+      'afk/done',
+      'afk/failed',
+      'hitl/todo',
+    ]) {
+      expect(vol.existsSync(`${PROJECT}/.ralph/tasks/${d}`)).toBe(true)
+    }
+  })
+
+  it('a whitespace-only --source is not a typo — falls through to the github default', async () => {
+    const vol = newVol()
+    const result = await run(vol, { source: '   ', isTTY: false })
+    expect(result.source).toBe('github')
+    expect(vol.existsSync(`${PROJECT}/.ralph/tasks`)).toBe(false)
+  })
+
+  it('rejects an invalid --source with a nonzero abort BEFORE any file writes', async () => {
+    const vol = newVol()
+    const stderr = makeStream()
+    let caught
+    try {
+      await run(vol, { source: 'GitLab', stderr })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(InitAbort)
+    expect(caught.exitCode).toBe(1)
+    // Nothing was written — the guard runs before writeConfig.
+    expect(vol.existsSync(`${PROJECT}/ralph.config.sh`)).toBe(false)
+    expect(vol.existsSync(`${PROJECT}/.ralph/tasks`)).toBe(false)
+  })
+
+  it('--source folder beats a would-be interactive prompt (flag wins, prompt not called)', async () => {
+    const vol = newVol()
+    let prompted = false
+    const result = await run(vol, {
+      source: 'folder',
+      isTTY: true,
+      promptAgent: async () => 'claude',
+      promptSource: async () => {
+        prompted = true
+        return 'github'
+      },
+    })
+    expect(prompted).toBe(false)
+    expect(result.source).toBe('folder')
+  })
+})

--- a/packages/ralph/lib/init.test.js
+++ b/packages/ralph/lib/init.test.js
@@ -222,6 +222,7 @@ describe('initCommand — agent selection (#554)', () => {
         asked = true
         return 'codex'
       },
+      promptSource: async () => 'github',
     })
     expect(asked).toBe(false)
     const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
@@ -250,6 +251,7 @@ describe('initCommand — agent selection (#554)', () => {
         askedQuestion = question
         return Promise.resolve(true)
       },
+      promptSource: async () => 'github',
     })
     expect(askedQuestion).toBeTruthy()
     const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
@@ -266,6 +268,7 @@ describe('initCommand — agent selection (#554)', () => {
       fs: vol,
       isTTY: true,
       ask: () => Promise.resolve(false),
+      promptSource: async () => 'github',
     })
     const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
     expect(cfg).toContain('RALPH_AGENT="claude"')
@@ -285,6 +288,7 @@ describe('initCommand — agent selection (#554)', () => {
         asked = true
         return 'codex'
       },
+      promptSource: async () => 'github',
     })
     expect(asked).toBe(true)
     const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
@@ -306,6 +310,7 @@ describe('initCommand — agent selection (#554)', () => {
         asked = true
         return 'claude'
       },
+      promptSource: async () => 'github',
     })
     expect(asked).toBe(false)
     const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
@@ -551,6 +556,7 @@ describe('QA: initCommand — early --agent rejection guard (#560)', () => {
         askedOpts = opts
         return Promise.resolve(true)
       },
+      promptSource: async () => 'github',
     })
     // Lock the phrasing so a rename of the prompt is caught by CI.
     expect(askedQuestion).toBe('Use Codex instead of Claude Code? [y/N]: ')
@@ -892,6 +898,184 @@ describe('initCommand — summary output', () => {
     expect(out).toContain('MAIN_BRANCH:  main')
     expect(out).toContain('DEV_BRANCH:   dev')
     expect(out).toContain('PR_TARGET:    dev')
+  })
+})
+
+describe('initCommand — task source selection (#565)', () => {
+  it('defaults to TASK_SOURCE="github" when no flag and not a TTY', async () => {
+    const { vol, run } = setup()
+    const result = await run()
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('TASK_SOURCE="github"')
+    expect(cfg).not.toContain('{{TASK_SOURCE}}')
+    expect(result.source).toBe('github')
+  })
+
+  it('writes TASK_SOURCE="folder" when --source folder is passed', async () => {
+    const { vol } = setup()
+    const result = await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      source: 'folder',
+    })
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('TASK_SOURCE="folder"')
+    expect(result.source).toBe('folder')
+  })
+
+  it('scaffolds the .ralph/tasks tree (empty dirs) when --source folder', async () => {
+    const { vol } = setup()
+    await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      source: 'folder',
+    })
+    for (const d of [
+      '.ralph/tasks/afk/todo',
+      '.ralph/tasks/afk/in-progress',
+      '.ralph/tasks/afk/done',
+      '.ralph/tasks/afk/failed',
+      '.ralph/tasks/hitl/todo',
+    ]) {
+      expect(vol.existsSync(`${PROJECT}/${d}`)).toBe(true)
+    }
+  })
+
+  it('does NOT scaffold the tasks tree for github mode', async () => {
+    const { vol, run } = setup()
+    await run()
+    expect(vol.existsSync(`${PROJECT}/.ralph/tasks`)).toBe(false)
+  })
+
+  it('rejects an invalid --source flag before any writes (mirrors --agent)', async () => {
+    const { vol } = setup()
+    const stderr = makeStream()
+    let caught
+    try {
+      await initCommand({
+        cwd: PROJECT,
+        stdout: makeStream(),
+        stderr,
+        exec: makeExec(defaultGitHandlers()),
+        fs: vol,
+        source: 'gitlab',
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(InitAbort)
+    expect(caught.exitCode).toBe(1)
+    const err = stderr.output()
+    expect(err).toContain('gitlab')
+    expect(err).toContain('github')
+    expect(err).toContain('folder')
+    expect(vol.existsSync(`${PROJECT}/ralph.config.sh`)).toBe(false)
+  })
+
+  it('normalizes an uppercase --source ("FOLDER") to lowercase folder', async () => {
+    const { vol } = setup()
+    const result = await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      source: 'FOLDER',
+    })
+    expect(result.source).toBe('folder')
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('TASK_SOURCE="folder"')
+  })
+
+  it('prompts for the source when interactive and no flag is given', async () => {
+    const { vol } = setup()
+    let asked = false
+    await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      isTTY: true,
+      promptAgent: async () => 'claude',
+      promptSource: async () => {
+        asked = true
+        return 'folder'
+      },
+    })
+    expect(asked).toBe(true)
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('TASK_SOURCE="folder"')
+  })
+
+  it('does NOT prompt for source when a flag is given even if interactive', async () => {
+    const { vol } = setup()
+    let asked = false
+    await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      isTTY: true,
+      source: 'github',
+      promptAgent: async () => 'claude',
+      promptSource: async () => {
+        asked = true
+        return 'folder'
+      },
+    })
+    expect(asked).toBe(false)
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('TASK_SOURCE="github"')
+  })
+
+  it('non-TTY without a flag defaults to github and does NOT call promptSource', async () => {
+    const { vol } = setup()
+    let asked = false
+    await initCommand({
+      cwd: PROJECT,
+      stdout: makeStream(),
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      isTTY: false,
+      promptSource: async () => {
+        asked = true
+        return 'folder'
+      },
+    })
+    expect(asked).toBe(false)
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg).toContain('TASK_SOURCE="github"')
+  })
+
+  it('the written config carries the TASK_SOURCE explanatory comment', async () => {
+    const { vol, run } = setup()
+    await run()
+    const cfg = vol.readFileSync(`${PROJECT}/ralph.config.sh`, 'utf8')
+    expect(cfg.toLowerCase()).toContain('task source')
+  })
+
+  it('prints the detected source in the summary', async () => {
+    const { vol } = setup()
+    const stdout = makeStream()
+    await initCommand({
+      cwd: PROJECT,
+      stdout,
+      stderr: makeStream(),
+      exec: makeExec(defaultGitHandlers()),
+      fs: vol,
+      source: 'folder',
+    })
+    expect(stdout.output()).toContain('TASK_SOURCE:')
+    expect(stdout.output()).toContain('folder')
   })
 })
 

--- a/packages/ralph/lib/issue-event.js
+++ b/packages/ralph/lib/issue-event.js
@@ -106,9 +106,12 @@ function countErrorSignals(stderrLog) {
   return n
 }
 
-// Verdict precedence: claude-failed label => fail wins (even if CLOSED/OPEN);
+// Verdict precedence: an explicit `override` (folder mode's terminal-directory
+// outcome, #565) wins over everything when it's a non-empty string; else the
+// github precedence applies — claude-failed label => fail (even if CLOSED/OPEN);
 // else CLOSED state OR pending-merge label => pass; else unknown.
-function computeVerdict(labels, state) {
+function computeVerdict(labels, state, override) {
+  if (typeof override === 'string' && override.trim() !== '') return override.trim()
   const ls = Array.isArray(labels) ? labels : []
   if (ls.includes('claude-failed')) return 'fail'
   if (state === 'CLOSED' || ls.includes('pending-merge')) return 'pass'
@@ -136,6 +139,9 @@ export function buildIssueEvent(input) {
     agent = 'claude',
     model: modelOverride = null,
     durationMs = null,
+    // #565: folder-mode verdict from the terminal task directory (done|failed);
+    // when a non-empty string, it overrides the label/state precedence.
+    verdictOverride = null,
   } = input || {}
 
   const parsed = parseAgentStream(rawStreamJson, agent)
@@ -168,7 +174,7 @@ export function buildIssueEvent(input) {
     usage: parsed.usage,
     claude_exit_code: claudeExitCode,
     stderr_error_signals: countErrorSignals(stderrLog),
-    verdict: computeVerdict(labels, state),
+    verdict: computeVerdict(labels, state, verdictOverride),
     // Real PR diff stats (#530), handed in by the entrypoint; default to 0.
     files,
     insertions,

--- a/packages/ralph/lib/issue-event.test.js
+++ b/packages/ralph/lib/issue-event.test.js
@@ -207,6 +207,26 @@ describe('buildIssueEvent — verdict precedence', () => {
     )
     expect(e.verdict).toBe('unknown')
   })
+
+  // #565: folder mode has no issue state/labels to classify by — the terminal
+  // task directory decides the verdict, passed in as verdictOverride. When set
+  // (non-empty), it wins over the label/state precedence above.
+  it('verdictOverride wins over label/state precedence when provided', () => {
+    const e = buildIssueEvent(
+      baseInput({ labels: ['claude-failed'], state: 'CLOSED', verdictOverride: 'pass' }),
+    )
+    expect(e.verdict).toBe('pass')
+  })
+
+  it('verdictOverride "fail" is recorded even for a CLOSED issue', () => {
+    const e = buildIssueEvent(baseInput({ state: 'CLOSED', verdictOverride: 'fail' }))
+    expect(e.verdict).toBe('fail')
+  })
+
+  it('an empty/absent verdictOverride falls back to label/state precedence', () => {
+    const e = buildIssueEvent(baseInput({ state: 'CLOSED', verdictOverride: '' }))
+    expect(e.verdict).toBe('pass')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/ralph/lib/parse-config-var.js
+++ b/packages/ralph/lib/parse-config-var.js
@@ -1,0 +1,40 @@
+// Extract a single `VAR=value` assignment out of ralph.config.sh text WITHOUT
+// sourcing it (#554, #565). The bash loop sources the file, but the JS layer
+// only needs one value at a time (RALPH_AGENT, TASK_SOURCE) to make a decision,
+// so a tiny text parse avoids shelling out. Returns the raw value ('' when
+// absent) — the caller passes it through the relevant registry
+// (resolveAgent/resolveSource) for validation/fallback.
+//
+// Recognizes: `VAR=value`, `VAR="value"`, `VAR='value'`, an optional `export`
+// prefix, and surrounding whitespace. Commented lines (leading `#`) are ignored.
+// The LAST uncommented assignment wins (bash semantics). Never throws.
+
+// Escape a variable name for safe embedding in the assignment regex.
+function escapeName(name) {
+  return String(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function parseConfigVar(text, varName) {
+  if (!text || !varName) return ''
+  const assign = new RegExp(`^\\s*(?:export\\s+)?${escapeName(varName)}\\s*=\\s*(.+?)\\s*$`)
+  let value = ''
+  for (const line of String(text).split('\n')) {
+    if (/^\s*#/.test(line)) continue
+    const m = line.match(assign)
+    if (!m) continue
+    let raw = m[1].trim()
+    // Strip an inline comment on an unquoted value (e.g. `codex # note`).
+    if (raw[0] !== '"' && raw[0] !== "'") {
+      raw = raw.replace(/\s+#.*$/, '').trim()
+    }
+    // Strip matching surrounding quotes.
+    if (
+      (raw.startsWith('"') && raw.endsWith('"')) ||
+      (raw.startsWith("'") && raw.endsWith("'"))
+    ) {
+      raw = raw.slice(1, -1)
+    }
+    value = raw
+  }
+  return value
+}

--- a/packages/ralph/lib/parse-config-var.qa.test.js
+++ b/packages/ralph/lib/parse-config-var.qa.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { parseConfigVar } from './parse-config-var.js'
+
+// QA augmentation for #554/#565. parse-config-var.js has no direct test of its
+// own (it is exercised transitively via read-config-source/read-config-agent).
+// These tests pin the shared assignment grammar's adversarial edges directly, so
+// a future refactor of the regex can't quietly change how ralph.config.sh is
+// read without a red test.
+
+describe('parseConfigVar — bash-assignment grammar edges (#565 QA)', () => {
+  it('returns "" for empty/nullish text or var name', () => {
+    expect(parseConfigVar('', 'TASK_SOURCE')).toBe('')
+    expect(parseConfigVar(null, 'TASK_SOURCE')).toBe('')
+    expect(parseConfigVar('TASK_SOURCE=folder', '')).toBe('')
+    expect(parseConfigVar('TASK_SOURCE=folder', null)).toBe('')
+  })
+
+  it('LAST uncommented assignment wins (bash source semantics)', () => {
+    const text = 'TASK_SOURCE=github\nTASK_SOURCE=folder\n'
+    expect(parseConfigVar(text, 'TASK_SOURCE')).toBe('folder')
+  })
+
+  it('a later COMMENTED reassignment does not override an earlier live one', () => {
+    const text = 'TASK_SOURCE=folder\n# TASK_SOURCE=github\n'
+    expect(parseConfigVar(text, 'TASK_SOURCE')).toBe('folder')
+  })
+
+  it('strips an inline comment on an unquoted value but not inside quotes', () => {
+    expect(parseConfigVar('TASK_SOURCE=folder # local\n', 'TASK_SOURCE')).toBe('folder')
+    // A `#` inside a quoted value is part of the value, not a comment.
+    expect(parseConfigVar('TASK_SOURCE="fol#der"\n', 'TASK_SOURCE')).toBe('fol#der')
+  })
+
+  it('honors the export prefix and surrounding whitespace', () => {
+    expect(parseConfigVar('  export TASK_SOURCE =  folder  \n', 'TASK_SOURCE')).toBe('folder')
+  })
+
+  it('an empty assignment (VAR=) yields ""', () => {
+    expect(parseConfigVar('TASK_SOURCE=\n', 'TASK_SOURCE')).toBe('')
+    expect(parseConfigVar('export TASK_SOURCE=\n', 'TASK_SOURCE')).toBe('')
+  })
+
+  it('does not match a variable whose name merely ENDS with the target', () => {
+    expect(parseConfigVar('MY_TASK_SOURCE=folder\n', 'TASK_SOURCE')).toBe('')
+  })
+
+  it('does not match a variable whose name merely STARTS with the target', () => {
+    expect(parseConfigVar('TASK_SOURCE_X=folder\n', 'TASK_SOURCE')).toBe('')
+  })
+
+  it('a commented line with leading whitespace is ignored', () => {
+    expect(parseConfigVar('   #TASK_SOURCE=folder\n', 'TASK_SOURCE')).toBe('')
+  })
+
+  it('never throws on regex-special characters in the var name', () => {
+    // escapeName must neutralize regex metacharacters.
+    expect(() => parseConfigVar('A.B=1\n', 'A.B')).not.toThrow()
+    expect(parseConfigVar('A.B=1\n', 'A.B')).toBe('1')
+  })
+})

--- a/packages/ralph/lib/read-config-agent.js
+++ b/packages/ralph/lib/read-config-agent.js
@@ -10,31 +10,10 @@
 // semantics). Never throws.
 
 import { existsSync as realExistsSync, readFileSync as realReadFileSync } from 'node:fs'
-
-const ASSIGN = /^\s*(?:export\s+)?RALPH_AGENT\s*=\s*(.+?)\s*$/
+import { parseConfigVar } from './parse-config-var.js'
 
 export function parseConfigAgent(text) {
-  if (!text) return ''
-  let value = ''
-  for (const line of String(text).split('\n')) {
-    if (/^\s*#/.test(line)) continue
-    const m = line.match(ASSIGN)
-    if (!m) continue
-    let raw = m[1].trim()
-    // Strip an inline comment on an unquoted value (e.g. `codex # note`).
-    if (raw[0] !== '"' && raw[0] !== "'") {
-      raw = raw.replace(/\s+#.*$/, '').trim()
-    }
-    // Strip matching surrounding quotes.
-    if (
-      (raw.startsWith('"') && raw.endsWith('"')) ||
-      (raw.startsWith("'") && raw.endsWith("'"))
-    ) {
-      raw = raw.slice(1, -1)
-    }
-    value = raw
-  }
-  return value
+  return parseConfigVar(text, 'RALPH_AGENT')
 }
 
 // Read ralph.config.sh at `path` and return the raw RALPH_AGENT value ('' when

--- a/packages/ralph/lib/read-config-source.js
+++ b/packages/ralph/lib/read-config-source.js
@@ -1,0 +1,25 @@
+// Read the TASK_SOURCE assignment out of ralph.config.sh WITHOUT sourcing it
+// (#565). The cycle preflight needs this one value to decide whether gh auth is
+// required (github) or not (folder), so a tiny text parse avoids shelling out.
+// Returns the raw value ('' when absent) — the caller passes it through
+// resolveSource for validation/fallback. See parse-config-var.js for the shared
+// assignment grammar. Never throws.
+
+import { existsSync as realExistsSync, readFileSync as realReadFileSync } from 'node:fs'
+import { parseConfigVar } from './parse-config-var.js'
+
+export function parseConfigSource(text) {
+  return parseConfigVar(text, 'TASK_SOURCE')
+}
+
+// Read ralph.config.sh at `path` and return the raw TASK_SOURCE value ('' when
+// the file is missing/unreadable or the setting is absent). Injectable fs for
+// tests.
+export function readConfigSource(path, { exists = realExistsSync, readFile = realReadFileSync } = {}) {
+  try {
+    if (!path || !exists(path)) return ''
+    return parseConfigSource(readFile(path, 'utf8'))
+  } catch {
+    return ''
+  }
+}

--- a/packages/ralph/lib/read-config-source.test.js
+++ b/packages/ralph/lib/read-config-source.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { parseConfigSource } from './read-config-source.js'
+
+// #565: mirror parseConfigAgent, but for the TASK_SOURCE setting. The cycle
+// preflight reads this without sourcing ralph.config.sh to decide whether gh
+// auth is required. The raw value is handed to resolveSource for validation.
+describe('parseConfigSource — extract TASK_SOURCE from ralph.config.sh text', () => {
+  it('returns empty string when the setting is absent', () => {
+    expect(parseConfigSource('RALPH_AGENT="claude"\n')).toBe('')
+  })
+
+  it('reads a double-quoted value', () => {
+    expect(parseConfigSource('TASK_SOURCE="folder"\n')).toBe('folder')
+  })
+
+  it('reads a single-quoted value', () => {
+    expect(parseConfigSource("TASK_SOURCE='folder'\n")).toBe('folder')
+  })
+
+  it('reads an unquoted value', () => {
+    expect(parseConfigSource('TASK_SOURCE=folder\n')).toBe('folder')
+  })
+
+  it('ignores commented-out lines', () => {
+    expect(parseConfigSource('# TASK_SOURCE="folder"\n')).toBe('')
+    expect(parseConfigSource('  #TASK_SOURCE=folder\n')).toBe('')
+  })
+
+  it('uses the LAST uncommented assignment', () => {
+    expect(parseConfigSource('TASK_SOURCE=github\nTASK_SOURCE="folder"\n')).toBe('folder')
+  })
+
+  it('tolerates surrounding whitespace and export prefix', () => {
+    expect(parseConfigSource('export TASK_SOURCE="folder"  \n')).toBe('folder')
+    expect(parseConfigSource('   TASK_SOURCE =  folder \n')).toBe('folder')
+  })
+
+  it('strips an inline comment on an unquoted value', () => {
+    expect(parseConfigSource('TASK_SOURCE=folder # local tasks\n')).toBe('folder')
+  })
+
+  it('does not match a DIFFERENT variable that merely ends in TASK_SOURCE', () => {
+    expect(parseConfigSource('MY_TASK_SOURCE=folder\n')).toBe('')
+  })
+
+  it('returns empty string on empty/nullish input', () => {
+    expect(parseConfigSource('')).toBe('')
+    expect(parseConfigSource(null)).toBe('')
+    expect(parseConfigSource(undefined)).toBe('')
+  })
+
+  it('an empty assignment yields empty string (TASK_SOURCE=)', () => {
+    expect(parseConfigSource('TASK_SOURCE=\n')).toBe('')
+  })
+})

--- a/packages/ralph/lib/task-file.js
+++ b/packages/ralph/lib/task-file.js
@@ -1,0 +1,100 @@
+// PURE task-file helpers — NO I/O (#565). A folder-mode task is a numbered `.md`
+// file with optional YAML-ish frontmatter (title + labels) delimited by `---`
+// followed by a markdown body. Identity is the leading integer of the filename
+// (001-fix-login.md → 1), and the next number is max(N)+1 across ALL task
+// directories in BOTH lanes (afk + hitl). Every function is deterministic and
+// takes plain strings/arrays so it is trivially testable and hermetic.
+
+function stripQuotes(value) {
+  const v = value.trim()
+  if (
+    (v.startsWith('"') && v.endsWith('"')) ||
+    (v.startsWith("'") && v.endsWith("'"))
+  ) {
+    return v.slice(1, -1)
+  }
+  return v
+}
+
+// Parse a labels value. Accepts a comma list (`bug, ui`) or a bracketed list
+// (`[bug, ui]`). Empty entries are dropped. Returns a string array.
+function parseLabels(raw) {
+  if (raw == null) return []
+  let s = String(raw).trim()
+  if (s.startsWith('[') && s.endsWith(']')) {
+    s = s.slice(1, -1)
+  }
+  if (s === '') return []
+  return s
+    .split(',')
+    .map((x) => stripQuotes(x).trim())
+    .filter(Boolean)
+}
+
+// Parse a task `.md` file into { title, labels, body }. Frontmatter is the block
+// between the FIRST two `---` fences at the top of the file. A file with no
+// frontmatter yields an empty title/labels and the whole text as the body.
+export function parseTaskFile(text) {
+  const src = text == null ? '' : String(text)
+  const result = { title: '', labels: [], body: src.trim() }
+
+  const lines = src.split(/\r?\n/)
+  if (lines[0]?.trim() !== '---') return result
+
+  // Find the closing fence.
+  let close = -1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      close = i
+      break
+    }
+  }
+  if (close === -1) return result
+
+  for (let i = 1; i < close; i++) {
+    const line = lines[i]
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/)
+    if (!m) continue
+    const key = m[1].toLowerCase()
+    const value = m[2]
+    if (key === 'title') {
+      result.title = stripQuotes(value)
+    } else if (key === 'labels') {
+      result.labels = parseLabels(value)
+    }
+  }
+
+  result.body = lines.slice(close + 1).join('\n').trim()
+  return result
+}
+
+// Leading-integer identity for a task filename. `001-fix-login.md` → 1,
+// `42-x.md` → 42. Returns null when there is no leading integer.
+export function taskIdFromFilename(name) {
+  if (!name) return null
+  const m = String(name).match(/^(\d+)/)
+  if (!m) return null
+  return Number.parseInt(m[1], 10)
+}
+
+// Collect all filenames from a listing that is either a flat array of names or a
+// map of directory → filename array (scanning across every directory / lane).
+function collectNames(listing) {
+  if (Array.isArray(listing)) return listing
+  if (listing && typeof listing === 'object') {
+    return Object.values(listing).flatMap((v) => (Array.isArray(v) ? v : []))
+  }
+  return []
+}
+
+// Next task number: max(leading-integer) + 1 across every filename in the
+// listing (both lanes, all status dirs). An empty/number-less listing yields 1.
+export function nextTaskNumber(listing) {
+  const names = collectNames(listing)
+  let max = 0
+  for (const name of names) {
+    const id = taskIdFromFilename(name)
+    if (id != null && id > max) max = id
+  }
+  return max + 1
+}

--- a/packages/ralph/lib/task-file.qa.test.js
+++ b/packages/ralph/lib/task-file.qa.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import { parseTaskFile, taskIdFromFilename, nextTaskNumber } from './task-file.js'
+
+// QA augmentation for #565. The dev's task-file.test.js locks the happy paths
+// (comma/bracket labels, no-frontmatter, quoted title, next-number max+1). These
+// adversarial cases attack the parser's robustness against real-world task files
+// an author (or an editor on Windows) will actually produce.
+
+describe('parseTaskFile — adversarial frontmatter (#565 QA)', () => {
+  it('BUG: CRLF line endings must not silently drop title/labels', () => {
+    // A `.md` authored on Windows (or via a cross-platform editor) uses \r\n.
+    // src.split('\n') then leaves a trailing \r on every line, so the closing
+    // fence still matches (trim()) BUT the `key: value` regex is anchored with
+    // $ and the trailing \r defeats the `(.*)` capture's tail — title/labels are
+    // silently lost while the body still parses. That is a data-loss defect: the
+    // task's human-readable title vanishes from telemetry.
+    const text = [
+      '---',
+      'title: Fix the login button',
+      'labels: bug, ui',
+      '---',
+      '',
+      'The body survives.',
+    ].join('\r\n')
+    const parsed = parseTaskFile(text)
+    expect(parsed.title).toBe('Fix the login button')
+    expect(parsed.labels).toEqual(['bug', 'ui'])
+  })
+
+  it('does not over-split on a `---` that appears inside the body', () => {
+    const text = ['---', 'title: T', '---', 'intro', '---', 'outro'].join('\n')
+    const parsed = parseTaskFile(text)
+    expect(parsed.title).toBe('T')
+    expect(parsed.body).toBe('intro\n---\noutro')
+  })
+
+  it('frontmatter present but no title → empty title, body preserved', () => {
+    const text = ['---', 'labels: bug', '---', 'the work'].join('\n')
+    const parsed = parseTaskFile(text)
+    expect(parsed.title).toBe('')
+    expect(parsed.labels).toEqual(['bug'])
+    expect(parsed.body).toBe('the work')
+  })
+
+  it('an unterminated frontmatter fence yields no title and the whole text as body', () => {
+    const text = ['---', 'title: never closes', 'still going'].join('\n')
+    const parsed = parseTaskFile(text)
+    expect(parsed.title).toBe('')
+    expect(parsed.body).toBe('---\ntitle: never closes\nstill going')
+  })
+
+  it('an empty file yields empty title/labels/body', () => {
+    const parsed = parseTaskFile('')
+    expect(parsed).toEqual({ title: '', labels: [], body: '' })
+  })
+
+  it('handles a nullish input without throwing', () => {
+    expect(parseTaskFile(null)).toEqual({ title: '', labels: [], body: '' })
+    expect(parseTaskFile(undefined)).toEqual({ title: '', labels: [], body: '' })
+  })
+
+  it('strips quotes from bracketed and quoted label entries', () => {
+    const text = ['---', 'title: T', 'labels: ["bug", \'ui\']', '---', 'b'].join('\n')
+    expect(parseTaskFile(text).labels).toEqual(['bug', 'ui'])
+  })
+
+  it('an empty bracketed labels list [] is an empty array (not [""])', () => {
+    const text = ['---', 'title: T', 'labels: []', '---', 'b'].join('\n')
+    expect(parseTaskFile(text).labels).toEqual([])
+  })
+
+  it('ignores a non-frontmatter line that merely starts with text before ---', () => {
+    // First line is not a fence, so there is no frontmatter at all.
+    const text = ['not a fence', '---', 'title: T', '---'].join('\n')
+    const parsed = parseTaskFile(text)
+    expect(parsed.title).toBe('')
+  })
+})
+
+describe('taskIdFromFilename — adversarial (#565 QA)', () => {
+  it('reads leading zeros as the decimal value (007-x.md → 7, not octal)', () => {
+    expect(taskIdFromFilename('007-x.md')).toBe(7)
+    expect(taskIdFromFilename('012-y.md')).toBe(12)
+  })
+
+  it('pure-number filename resolves to that number', () => {
+    expect(taskIdFromFilename('12.md')).toBe(12)
+    expect(taskIdFromFilename('0.md')).toBe(0)
+  })
+
+  it('returns null for garbage / no leading digit', () => {
+    expect(taskIdFromFilename('v2-thing.md')).toBe(null)
+    expect(taskIdFromFilename('   3-space.md')).toBe(null)
+    expect(taskIdFromFilename(null)).toBe(null)
+    expect(taskIdFromFilename(undefined)).toBe(null)
+  })
+
+  it('reads the leading integer even with no separator/extension', () => {
+    expect(taskIdFromFilename('99')).toBe(99)
+  })
+})
+
+describe('nextTaskNumber — never reuse a number (#565 QA)', () => {
+  it('a gap in numbering yields max+1, not count+1', () => {
+    expect(nextTaskNumber(['001-a.md', '005-e.md'])).toBe(6)
+  })
+
+  it('the highest number in a TERMINAL lane (done/failed) is still counted — never reused', () => {
+    const dirs = {
+      'afk/todo': ['001-a.md'],
+      'afk/done': ['099-z.md'],
+      'afk/failed': ['050-m.md'],
+      'hitl/todo': ['007-g.md'],
+    }
+    expect(nextTaskNumber(dirs)).toBe(100)
+  })
+
+  it('a duplicate number across two lanes does not inflate the next number', () => {
+    expect(nextTaskNumber({ a: ['003-x.md'], b: ['003-y.md'] })).toBe(4)
+  })
+
+  it('zero-padded and unpadded numbers compare by value, not string', () => {
+    // '9-a.md' > '010-b.md' lexically, but 10 > 9 numerically.
+    expect(nextTaskNumber(['9-a.md', '010-b.md'])).toBe(11)
+  })
+
+  it('a listing of only non-numbered files yields 1', () => {
+    expect(nextTaskNumber(['README.md', 'notes.md'])).toBe(1)
+  })
+
+  it('tolerates junk shapes in the map (non-array values are ignored)', () => {
+    expect(nextTaskNumber({ a: ['004-d.md'], b: null, c: 'nope', d: 42 })).toBe(5)
+  })
+
+  it('a null/garbage listing yields 1 without throwing', () => {
+    expect(nextTaskNumber(null)).toBe(1)
+    expect(nextTaskNumber(undefined)).toBe(1)
+    expect(nextTaskNumber('nope')).toBe(1)
+  })
+})

--- a/packages/ralph/lib/task-file.test.js
+++ b/packages/ralph/lib/task-file.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { parseTaskFile, taskIdFromFilename, nextTaskNumber } from './task-file.js'
+
+describe('parseTaskFile — YAML-ish frontmatter + markdown body (#565)', () => {
+  it('extracts title, labels (comma list), and body', () => {
+    const text = [
+      '---',
+      'title: Fix the login button',
+      'labels: bug, ui',
+      '---',
+      '',
+      'The login button does nothing when clicked.',
+      '',
+      'Steps to reproduce: click it.',
+    ].join('\n')
+    const parsed = parseTaskFile(text)
+    expect(parsed.title).toBe('Fix the login button')
+    expect(parsed.labels).toEqual(['bug', 'ui'])
+    expect(parsed.body).toBe(
+      'The login button does nothing when clicked.\n\nSteps to reproduce: click it.',
+    )
+  })
+
+  it('parses labels given as a bracketed list [a, b]', () => {
+    const text = ['---', 'title: T', 'labels: [bug, ui, perf]', '---', 'body'].join('\n')
+    const parsed = parseTaskFile(text)
+    expect(parsed.labels).toEqual(['bug', 'ui', 'perf'])
+  })
+
+  it('treats labels as optional — empty array when absent', () => {
+    const text = ['---', 'title: No labels here', '---', 'the body'].join('\n')
+    const parsed = parseTaskFile(text)
+    expect(parsed.title).toBe('No labels here')
+    expect(parsed.labels).toEqual([])
+    expect(parsed.body).toBe('the body')
+  })
+
+  it('strips surrounding quotes from the title value', () => {
+    const text = ['---', 'title: "Quoted title"', '---', 'b'].join('\n')
+    expect(parseTaskFile(text).title).toBe('Quoted title')
+  })
+
+  it('tolerates a file with no frontmatter — whole text is the body', () => {
+    const text = 'just a plain body with no frontmatter'
+    const parsed = parseTaskFile(text)
+    expect(parsed.title).toBe('')
+    expect(parsed.labels).toEqual([])
+    expect(parsed.body).toBe('just a plain body with no frontmatter')
+  })
+
+  it('drops empty label entries from a trailing comma', () => {
+    const text = ['---', 'title: T', 'labels: bug, , ui,', '---', 'b'].join('\n')
+    expect(parseTaskFile(text).labels).toEqual(['bug', 'ui'])
+  })
+})
+
+describe('taskIdFromFilename — leading integer identity (#565)', () => {
+  it('reads the leading integer from a numbered filename', () => {
+    expect(taskIdFromFilename('001-fix-login.md')).toBe(1)
+    expect(taskIdFromFilename('42-do-thing.md')).toBe(42)
+    expect(taskIdFromFilename('7.md')).toBe(7)
+  })
+
+  it('returns null when the filename has no leading integer', () => {
+    expect(taskIdFromFilename('fix-login.md')).toBe(null)
+    expect(taskIdFromFilename('')).toBe(null)
+    expect(taskIdFromFilename('-3-neg.md')).toBe(null)
+  })
+})
+
+describe('nextTaskNumber — max(N)+1 across all listings (#565)', () => {
+  it('returns 1 for an empty listing', () => {
+    expect(nextTaskNumber([])).toBe(1)
+  })
+
+  it('scans all filenames and takes max+1', () => {
+    const listing = ['001-a.md', '003-c.md', '002-b.md', 'notes.txt']
+    expect(nextTaskNumber(listing)).toBe(4)
+  })
+
+  it('ignores non-numbered files', () => {
+    expect(nextTaskNumber(['readme.md', 'todo.md'])).toBe(1)
+  })
+
+  it('accepts a map of directory → filenames and scans across both lanes', () => {
+    const dirs = {
+      'afk/todo': ['005-e.md'],
+      'afk/done': ['010-j.md'],
+      'hitl/todo': ['007-g.md'],
+    }
+    expect(nextTaskNumber(dirs)).toBe(11)
+  })
+})

--- a/packages/ralph/lib/task-source.js
+++ b/packages/ralph/lib/task-source.js
@@ -1,0 +1,15 @@
+// PURE task-source registry — NO I/O (#565). The single place that normalizes
+// the TASK_SOURCE env var into a resolved source name. Mirrors resolveAgent in
+// agent-registry.js: an unset/empty/whitespace value => github (the default,
+// zero-regression path); a recognized value (case-insensitive, trimmed) => that
+// source; anything else falls back to github so a typo never aborts a run.
+
+export const VALID_SOURCES = ['github', 'folder']
+export const DEFAULT_SOURCE = 'github'
+
+export function resolveSource(env = {}) {
+  const raw = env?.TASK_SOURCE
+  if (raw == null || String(raw).trim() === '') return DEFAULT_SOURCE
+  const normalized = String(raw).trim().toLowerCase()
+  return VALID_SOURCES.includes(normalized) ? normalized : DEFAULT_SOURCE
+}

--- a/packages/ralph/lib/task-source.qa.test.js
+++ b/packages/ralph/lib/task-source.qa.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { resolveSource } from './task-source.js'
+
+// QA augmentation for #565. The dev's task-source.test.js locks the core
+// normalization. These tests attack the "a typo must never abort a run" contract
+// with the adversarial inputs a hand-edited ralph.config.sh / stray env var can
+// actually produce. The invariant: resolveSource ALWAYS returns a member of
+// VALID_SOURCES, defaulting to 'github', and never throws.
+
+describe('resolveSource — adversarial values always resolve safely (#565 QA)', () => {
+  it('mixed-case and padded folder values normalize to folder', () => {
+    expect(resolveSource({ TASK_SOURCE: 'Folder' })).toBe('folder')
+    expect(resolveSource({ TASK_SOURCE: 'FoLdEr' })).toBe('folder')
+    expect(resolveSource({ TASK_SOURCE: '\tfolder\n' })).toBe('folder')
+  })
+
+  it('near-miss / typo values fall back to github (never abort)', () => {
+    for (const v of ['git', 'gitlab', 'folders', 'fold', 'local', 'gh', 'file']) {
+      expect(resolveSource({ TASK_SOURCE: v })).toBe('github')
+    }
+  })
+
+  it('non-string TASK_SOURCE values fall back to github without throwing', () => {
+    expect(resolveSource({ TASK_SOURCE: 123 })).toBe('github')
+    expect(resolveSource({ TASK_SOURCE: true })).toBe('github')
+    expect(resolveSource({ TASK_SOURCE: null })).toBe('github')
+    expect(resolveSource({ TASK_SOURCE: {} })).toBe('github')
+    expect(resolveSource({ TASK_SOURCE: [] })).toBe('github')
+  })
+
+  it('a nullish env object resolves to github', () => {
+    expect(resolveSource(null)).toBe('github')
+    expect(resolveSource(undefined)).toBe('github')
+  })
+
+  it('the result is ALWAYS a valid source for arbitrary garbage', () => {
+    const garbage = ['', '   ', 'GITHUB', 'GitHub', 'x'.repeat(500), '\0', '../folder']
+    for (const g of garbage) {
+      expect(['github', 'folder']).toContain(resolveSource({ TASK_SOURCE: g }))
+    }
+  })
+})

--- a/packages/ralph/lib/task-source.test.js
+++ b/packages/ralph/lib/task-source.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { resolveSource, VALID_SOURCES } from './task-source.js'
+
+describe('resolveSource — TASK_SOURCE normalization (#565)', () => {
+  it('defaults to github when TASK_SOURCE is unset/empty/whitespace', () => {
+    expect(resolveSource({})).toBe('github')
+    expect(resolveSource({ TASK_SOURCE: '' })).toBe('github')
+    expect(resolveSource({ TASK_SOURCE: '   ' })).toBe('github')
+    expect(resolveSource()).toBe('github')
+  })
+
+  it('returns folder for a folder value (case-insensitive, trimmed)', () => {
+    expect(resolveSource({ TASK_SOURCE: 'folder' })).toBe('folder')
+    expect(resolveSource({ TASK_SOURCE: 'FOLDER' })).toBe('folder')
+    expect(resolveSource({ TASK_SOURCE: '  Folder  ' })).toBe('folder')
+  })
+
+  it('returns github explicitly', () => {
+    expect(resolveSource({ TASK_SOURCE: 'github' })).toBe('github')
+  })
+
+  it('falls back to github on an unrecognized value', () => {
+    expect(resolveSource({ TASK_SOURCE: 'gitlab' })).toBe('github')
+    expect(resolveSource({ TASK_SOURCE: 'nonsense' })).toBe('github')
+  })
+
+  it('exposes the valid source list', () => {
+    expect(VALID_SOURCES).toEqual(['github', 'folder'])
+  })
+})

--- a/packages/ralph/templates/prompt-team-folder.md
+++ b/packages/ralph/templates/prompt-team-folder.md
@@ -1,0 +1,323 @@
+# Ralph Loop — Team orchestrator (folder mode)
+
+You are an autonomous agent in a task-resolution loop drawing work from a local
+**folder** queue instead of GitHub. Each invocation processes ONE task
+end-to-end. When done, exit. The outer bash will invoke you again for the next
+task.
+
+You act as the **orchestrator** for a team of specialized agents. Real,
+context-isolated subagents are available via the Task/Agent tool in this
+headless run, and each returns a structured result you pass forward
+explicitly — outputs do not leak between dispatches. Specialist roles are
+composed into this template below as they land; the **dev specialist** (step
+4), the **QA specialist** (step 4b), the **code reviewer specialist** (step
+4c), and the **tech writer specialist** (step 4d) are wired in. You also
+triage each task and scale the team to fit it (step 3b): trivial,
+non-behavioral changes take a light path, while substantive changes run the
+full team. A third **Tier 2 / Heavy** path exists for the largest tasks, but
+it is gated behind the `{{RALPH_HEAVY_TIER}}` flag and is off by default.
+
+Your project root is `{{PROJECT_ROOT}}`. Stay inside it for all
+operations.
+
+Task source: `{{TASK_SOURCE}}`. Tasks live under `.ralph/tasks/` in two lanes:
+`afk/` (autonomous — this loop owns it) with the status directories `todo/`,
+`in-progress/`, `done/`, and `failed/`, and `hitl/` (human-in-the-loop —
+never touched by this loop). Each task is a numbered markdown file
+(`001-short-slug.md`) whose identity is its leading integer. The file has
+YAML-ish frontmatter (`title`, optional `labels`) delimited by `---` followed
+by a markdown body describing the work.
+
+Current effort tier: `{{RALPH_HEAVY_TIER}}` (0 = off). This flag gates the
+Tier 2 / Heavy path in step 3b: when it is `0` the heavy tier is unavailable
+and triage uses only Tier 0 (Light) and Tier 1 (Standard).
+
+## Required sequence
+
+0. **Ensure dependencies**: run `{{INSTALL_CMD}}` (skip if empty).
+
+1. **Select task**: pick the lowest-numbered file in
+   `.ralph/tasks/afk/todo/` (the folder analog of `sort:created-asc`). Read it
+   and parse the frontmatter `title`/`labels` and the body. If the directory is
+   empty, write "RALPH_DONE" and exit. (The bash already checks this before
+   invoking you, so normally there will be one.)
+
+2. **Mark in progress**: move the task file from `.ralph/tasks/afk/todo/` to
+   `.ralph/tasks/afk/in-progress/` with a plain `mv` (keep the same filename) —
+   e.g. `mv .ralph/tasks/afk/todo/<file> .ralph/tasks/afk/in-progress/`. The
+   `.ralph/` tree is gitignored, so this is a filesystem-only move: never
+   `git mv` and never `git add` a task file. This is your happy-path claim on
+   the task; the outer bash sweeps a task left in `todo/` or stuck in
+   `in-progress/` to `failed/` if you do not finish.
+
+3. **Prepare working tree**: `git checkout {{DEV_BRANCH}} && git pull`. Folder
+   mode commits **directly to `{{DEV_BRANCH}}`** — there is NO feature branch,
+   NO pull request, and NO auto-merge. Do all work on `{{DEV_BRANCH}}`.
+
+3b. **Triage and scale the team**: before dispatching, classify the task and
+   scale the team to fit it. Read the task and the files it implies, then pick
+   one of three tiers. Two are always available; the third is gated:
+   - **Tier 0 / Light — trivial / non-behavioral** — the change has no
+     behavioral impact on code: pure docs, plain config, or dependency bumps
+     without logic changes. Skip dev-TDD and QA (steps 4 and 4b) and run only a
+     **light review** plus the writer (steps 4c, 4d). "Light" means the same
+     reviewer (step 4c), just over a docs/config-only diff with no QA
+     augmentation to weigh. Note "TDD skipped (trivial)" in the commit summary.
+   - **Tier 1 / Standard — substantive** — anything that changes behavior:
+     source code, logic, or any change you cannot prove is purely cosmetic. Run
+     the **full team** — dev, QA, review, writer (steps 4 through 4d).
+   - **Tier 2 / Heavy — gated, dark** — the largest tasks: changes whose scope
+     spans many files or modules (multi-file / multi-module scope), broad
+     **audit** work, large **refactor** efforts, schema or data **migration**,
+     or a **multi-hypothesis** investigation where the root cause is unknown and
+     several leads must be explored. Tier 2 is gated behind the
+     `RALPH_HEAVY_TIER` flag (see the effort-tier line above): when the flag is
+     `0` (the default) the heavy tier is **off / unavailable** and you must fall
+     back to Tier 1. When Tier 2 is active and a heavy run **fails to converge**
+     (does not reach green or keeps churning), **degrade to Tier 1** and finish
+     there rather than looping.
+
+   **`ralph-heavy` label override**: if the task carries the `ralph-heavy`
+   label, that **forces Tier 2** (subject to the flag being on). Absent that
+   label, classify by the signals above; when the classifier is **uncertain**,
+   default to **Tier 1** (never Tier 2 on a guess).
+
+   Keep the tier boundaries **conservative**: when in doubt, treat the task as
+   substantive and run the full team (Tier 1). Config that carries logic
+   (build/test wiring, CI behavior, anything the code reads at runtime) is
+   **not** plain config — it is substantive. Only classify as trivial when the
+   change provably cannot alter behavior.
+
+## Tier 2 / Heavy — understand phase (explorer fan-out + inline synthesis)
+
+This phase runs **only on a Tier-2 run** (selected in step 3b, gated behind the
+`{{RALPH_HEAVY_TIER}}` flag). It sits **after** triage (step 3b) and **before**
+the dev dispatch (step 4). On Tier 0 / Tier 1 it is skipped entirely and the dev
+step-4 contract is unchanged.
+
+When Tier 2 is active, **understand before you build**:
+
+1. **Explorer fan-out (read-only)**: dispatch **exactly three** context-isolated
+   subagents in the **explorer** role (see "Explorer specialist" below). The
+   fan-out width is fixed at **3** — not a cost ceiling, but a deliberate choice
+   that avoids unreliable pre-read scope estimation. Hand each explorer a
+   **different, competing hypothesis** about the task's root cause or the right
+   approach, so the three cover **distinct** leads rather than three takes on the
+   same guess. Explorers run strictly **read-only**: they investigate and report,
+   they never write or edit a file during the understand phase. Each returns the
+   structured return defined in its role.
+
+2. **Synthesizer (inline, named seam)**: the orchestrator runs the synthesizer
+   **inline** — it is **not** a separate subagent dispatch, but an explicit,
+   named, reviewable seam in this loop (see "Synthesizer seam" below). It
+   collapses the **three** explorer structured returns into a **single plan**:
+   the confirmed hypothesis (or the best-supported approach), the concrete change
+   it implies, the files in scope, and the risks the explorers surfaced.
+
+3. **Hand off to the dev**: on a Tier-2 run the dev (step 4) receives the
+   synthesized **plan + task** instead of the task alone. The dev's own
+   contract is otherwise unchanged — it still resolves through the strict
+   red → green → refactor loop. On Tier 0 / Tier 1 the dev receives the task
+   title and body exactly as before.
+
+{{ROLE_EXPLORER}}
+
+### Synthesizer seam
+
+The synthesizer is the named, inline step that turns the three explorer returns
+into the one plan handed to the dev. It runs in the orchestrator itself (no
+subagent), reads each explorer's structured return, and:
+
+- **Reconciles verdicts** — prefers a `confirmed` hypothesis backed by concrete
+  evidence; when explorers disagree, it weighs the evidence rather than voting.
+- **Merges evidence** — unions the file paths, call sites, and risks the three
+  explorers surfaced into one scoped picture.
+- **Emits a single plan** — one ordered, actionable plan (approach, files in
+  scope, test strategy, risks) — the artifact handed to the dev as **plan +
+  task** in step 4.
+
+Keeping the synthesizer an explicit, sectioned seam (rather than ad-hoc prose)
+makes the Tier-2 decision reviewable: the plan the dev acts on is traceable back
+to the three competing hypotheses it came from.
+
+4. **Resolve via the dev specialist**: dispatch a context-isolated
+   subagent in the **dev** role (see "Dev specialist" below) with the
+   task title and body. The dev infers its persona from the task and
+   the repo's detected stack and resolves the task through the strict
+   red → green → refactor loop — tests come first, always. Have it
+   return the test file paths it added or modified and the before/after
+   suite results, which you record in the commit summary in step 7. The dev
+   uses Read/Edit/Write as needed and follows the conventions in
+   `CLAUDE.md`.
+
+{{ROLE_DEV}}
+
+4b. **Harden via the QA specialist**: once the dev's suite is green,
+   dispatch a context-isolated subagent in the **QA** role (see "QA
+   specialist" below) with the task, the dev's diff, and the tests the
+   dev added. QA augments the green suite with edge-case and adversarial
+   tests. QA-found bugs **block until green**: hand any failing QA test
+   back to the dev to fix, then return to QA to re-run `{{TEST_CMD}}`,
+   until the dev's tests plus QA's augmentation are all green. The
+   give-up backstop below still bounds this loop. Add QA's new test
+   paths to the commit summary in step 7.
+
+{{ROLE_QA}}
+
+4c. **Review via the code reviewer specialist**: once QA's suite is green but
+   **before** the commit is made, dispatch a context-isolated subagent in the
+   **code reviewer** role (see "Code reviewer specialist" below) with the
+   task, the dev's diff, and the full test set. The reviewer applies the
+   Ralph-authored maintainability standard and gates the change pre-commit.
+   Blocking findings loop **back to the dev** to fix, then return to the reviewer
+   to re-check — bounded to a **maximum of 2 rounds**. If concerns remain
+   unresolved after 2 rounds, do **not** loop further: commit anyway in step 7
+   and record the prominent warning block in the commit summary so a human is
+   pulled in. The give-up backstop below still bounds this loop.
+
+{{ROLE_REVIEW}}
+
+## Tier 2 / Heavy — verify phase (3-reviewer adversarial panel, majority block)
+
+This phase runs **only on a Tier-2 run** (selected in step 3b, gated behind the
+heavy-tier flag `RALPH_HEAVY_TIER`). It is the Tier-2 form of the verify/review
+gate: it sits **after** the single-reviewer step 4c and **before** step 4d and
+the commit step (7), gating the diff **before** the commit lands. On a
+Tier 0 / Tier 1 run it is **skipped entirely** and the single-reviewer step 4c
+above is left unchanged.
+
+When Tier 2 is active, gate the diff with an **adversarial panel of three
+reviewers** instead of a single pass:
+
+1. **Panel of three (reuse the existing reviewer contract)**: dispatch the
+   existing reviewer role (the "Code reviewer specialist" composed above) as
+   **three** context-isolated subagents. The panel does **not** redefine or
+   duplicate the maintainability rules — it **reuses** that one reviewer contract
+   three times, handing each reviewer a **distinct lens**:
+   - **Correctness lens** — does the change do the right thing: logic, edge cases,
+     and behavior against the task and the full test set.
+   - **Security lens** — input handling, injection, secrets, auth, and unsafe
+     operations introduced or exposed by the diff.
+   - **Maintainability lens** — the existing maintainability standard from step
+     4c (oversized-file guard, anti-spaghetti, abstraction quality,
+     prefer-deleting-indirection, do-not-approve-on-behavior-alone), applied
+     as-is. The step-4c maintainability standard simply **becomes the
+     maintainability lens** here; it is not restated.
+
+2. **Majority-of-3 to block (2 of 3)**: the panel blocks the diff only when a
+   **majority — 2 of 3 — of the reviewers** agree it must change.
+   A single reviewer cannot block or trap the loop on its own: one lone objection
+   is recorded but does not gate the commit. When 2 of 3 block, the agreed
+   findings loop back to the dev to fix, then control returns to the panel to
+   re-check the diff and re-run `{{TEST_CMD}}` and `{{LINT_CMD}}`.
+
+3. **Max 2 rounds, then non-convergence commits anyway**: this loop is
+   bounded to a **maximum of 2 rounds** (consistent with the single-reviewer
+   step 4c). If the majority still blocks after 2 rounds, the bots have failed to
+   converge — do **not** loop further. Commit **anyway** in step 7 with the
+   same prominent `[!WARNING]` block step 7 already records, listing the
+   unresolved panel findings so a human is pulled in. On **non-convergence** these
+   semantics are **identical to / consistent with Tier 1**: it is treated as a
+   normal commit-with-warning, so the outer bash success/failure accounting needs
+   **no Tier-2 special case**.
+
+4d. **Document via the tech writer specialist**: once the review gate has
+   passed, dispatch a context-isolated subagent in the **tech writer** role
+   (see "Tech writer specialist" below) with the task and the dev's diff. The
+   writer inspects the diff and **discovers** which documentation the change
+   implies — README, `CLAUDE.md`/`AGENTS.md`, `docs/` files, inline
+   docstrings — updating targets inferred from the diff rather than from
+   configuration, so it works on any repo. It respects the never-touch list:
+   `CLAUDE.md` is editable, but `PROMPT.md`, `ralph.config.sh`, and `.claude/`
+   remain off-limits. Add the doc files it updated to the commit summary in
+   step 7.
+
+{{ROLE_WRITER}}
+
+5. **Validate locally**: run `{{TEST_CMD}}` and `{{LINT_CMD}}` (skip
+   the empty ones). If they fail, fix and re-run. Repeat up to 3 times;
+   if they still fail, go to "Failed".
+
+6. **Mark complete**: move the task file from `.ralph/tasks/afk/in-progress/` to
+   `.ralph/tasks/afk/done/` with a plain `mv` (keep the same filename) — e.g.
+   `mv .ralph/tasks/afk/in-progress/<file> .ralph/tasks/afk/done/`. This is your
+   happy-path completion move. As in step 2, the `.ralph/` tree is gitignored:
+   filesystem-only move, never `git mv`.
+
+7. **Commit to `{{DEV_BRANCH}}`**: `git add <specific files> && git commit -m
+   "fix: <description> (task #N)"`. Stage ONLY code/tests — both the new/updated
+   tests and the implementation in the same commit so the TDD pair is reviewable
+   together. Do NOT stage the task file: the `.ralph/` tree is gitignored and the
+   status move (step 6) is a filesystem-only operation that never enters a
+   commit or diff. The bash pushes `{{DEV_BRANCH}}` for you after this invocation
+   returns. The commit message
+   body must document the TDD process; use this template as the commit summary:
+
+   ```
+   Resolves task #N
+
+   ## Dev/TDD
+   - Tests added/modified: <relative file paths>
+   - Before implementation (red): <failing test names + summary of failure>
+   - After implementation (green): <suite result, e.g. "all 143 tests pass">
+
+   ## QA scenarios added
+   - <edge-case / adversarial scenarios QA added, and the test paths>
+
+   ## Review verdict
+   - <reviewer's verdict and any blocking findings resolved this round>
+
+   ## Docs updated
+   - <documentation files the writer updated, or "none — diff implied no doc change">
+
+   ## Notes
+   <anything else worth flagging for review>
+   ```
+
+   Each section carries one role's output — Dev/TDD from step 4, QA scenarios
+   from step 4b, Review verdict from step 4c, Docs updated from step 4d. Retain
+   a **single per-task log** (`logs/ralph-issue-N.log`) for the whole team run;
+   there are **no per-role logs**.
+
+   If TDD was skipped per the triage in step 3b, replace the Dev/TDD section
+   body with `- Skipped: <reason — must be docs/config/dep-bump only>` and the
+   QA scenarios section with `- Skipped (trivial — light path)`.
+
+   If the code reviewer's concerns were still unresolved after the 2-round
+   limit (step 4c), flag them in the Review verdict section and prepend a
+   prominent warning block to the commit summary so a human is pulled in:
+
+   ```
+   > [!WARNING]
+   > **Unresolved review concerns** — the reviewer and dev did not converge
+   > within the 2-round limit. A human must judge the following before merge:
+   > <list each unresolved blocking finding>
+   ```
+
+## Failed (at any point)
+
+- Leave a short reason in the task body (append a `## Ralph failure` note).
+- The outer bash sweeps the task file to `.ralph/tasks/afk/failed/` when this
+  invocation returns without having moved it to `done/`; you do not need to move
+  it yourself on failure.
+- Exit.
+
+## Absolute restrictions
+
+- NEVER `git push --force` or `git push -f`.
+- NEVER push directly to `{{MAIN_BRANCH}}`. Commit to `{{DEV_BRANCH}}` only; the
+  bash pushes it.
+- NEVER touch: `.env*`, `.git/`, `node_modules/`, `dist/`, `logs/`,
+  `ralph.sh`, `start-ralph.sh`, `PROMPT.md`, `ralph.config.sh`,
+  `.claude/`, and the `.ralph/tasks/hitl/` lane.
+- NEVER `rm -rf` on an absolute path. Use `rm` on a specific file.
+- NEVER merge PRs directly. Folder mode opens no PRs.
+- NEVER close issues manually. Folder mode tracks completion by moving the task
+  file to `done/`, not via issues.
+- NEVER edit, create, or delete files outside `{{PROJECT_ROOT}}`.
+- NEVER run Bash commands that touch files outside `{{PROJECT_ROOT}}`
+  (e.g. `rm`, `mv`, `curl > path`).
+- If `{{TEST_CMD}}` or `{{LINT_CMD}}` breaks 3 times in a row, declare
+  CLAUDE_GIVE_UP and go to "Failed".
+
+{{PROJECT_PROMPT}}

--- a/packages/ralph/templates/ralph.config.sh
+++ b/packages/ralph/templates/ralph.config.sh
@@ -13,6 +13,11 @@ LINT_CMD="{{LINT_CMD}}"
 # else in this file changes between agents.
 RALPH_AGENT="{{RALPH_AGENT}}"
 
+# Task source Ralph pulls work from. "github" (default) resolves open GitHub
+# issues via `gh`; "folder" draws tasks from the local `.ralph/tasks/` tree and
+# commits straight to DEV_BRANCH (no PR/merge). Unset falls back to "github".
+TASK_SOURCE="{{TASK_SOURCE}}"
+
 # Model id for the Codex agent (ignored when RALPH_AGENT=claude). Leave
 # unset/commented to let Codex use its configured default. Example:
 # RALPH_CODEX_MODEL="gpt-5-codex"

--- a/packages/ralph/templates/ralph.sh
+++ b/packages/ralph/templates/ralph.sh
@@ -212,6 +212,30 @@ claude_failed=0
 
 SEARCH_QUERY='state:open -label:claude-working -label:claude-failed -label:do-not-ralph -label:pending-merge'
 
+# --- Task source dispatch (#565) --------------------------------------------
+# Ralph draws work from either GitHub issues (the default, unchanged) or a local
+# `.ralph/tasks/` folder tree (TASK_SOURCE=folder). The source is read from the
+# env sourced from ralph.config.sh. Any value other than an explicit `folder`
+# resolves to github, mirroring lib/task-source.js's resolveSource (an unset /
+# unknown value => github, the zero-regression path). The github branch of every
+# helper below is byte-for-byte the code the loop has always run.
+if [ "${TASK_SOURCE:-github}" = "folder" ]; then
+  TASK_SOURCE="folder"
+else
+  TASK_SOURCE="github"
+fi
+TASKS_ROOT="$PROJECT_ROOT/.ralph/tasks"
+
+# Number of items waiting in the queue.
+queue_count() {
+  if [ "$TASK_SOURCE" = "folder" ]; then
+    node "$RALPH_PKG_DIR/lib/folder-queue.js" count "$TASKS_ROOT" 2>/dev/null || echo 0
+  else
+    gh issue list --search "$SEARCH_QUERY" --limit 100 --json number -q '. | length'
+  fi
+}
+# ---------------------------------------------------------------------------
+
 # Track the previously-selected issue so we can detect a zero-progress spin:
 # if the same issue is re-selected without any exclusion-state changing
 # (claude crashed, no label applied, not closed), the queue can never drain
@@ -219,14 +243,28 @@ SEARCH_QUERY='state:open -label:claude-working -label:claude-failed -label:do-no
 prev_num=""
 
 while :; do
-  count=$(gh issue list --search "$SEARCH_QUERY" --limit 100 --json number -q '. | length')
+  count=$(queue_count)
   if [ "$count" = "0" ]; then
     echo "Fila vazia, encerrando."
     break
   fi
 
-  num=$(gh issue list --search "$SEARCH_QUERY sort:created-asc" --limit 1 --json number -q '.[0].number')
-  echo "==> Iteração para issue #$num ($count restantes) [agent: ${RALPH_RESOLVED_AGENT:-claude}]"
+  if [ "$TASK_SOURCE" = "folder" ]; then
+    # Folder mode: select the lowest-numbered task in afk/todo (id + path). The
+    # AGENT owns the happy-path moves (todo→in-progress→done) and commits
+    # directly to $DEV_BRANCH — no branch, no PR. Bash owns only the failure /
+    # no-op sweep + the zero-progress guard below.
+    pick=$(node "$RALPH_PKG_DIR/lib/folder-queue.js" pick "$TASKS_ROOT" 2>/dev/null)
+    num="${pick%%$'\t'*}"
+    if [ -z "$num" ]; then
+      echo "Fila vazia, encerrando."
+      break
+    fi
+    echo "==> Iteração para task #$num ($count restantes) [agent: ${RALPH_RESOLVED_AGENT:-claude}]"
+  else
+    num=$(gh issue list --search "$SEARCH_QUERY sort:created-asc" --limit 1 --json number -q '.[0].number')
+    echo "==> Iteração para issue #$num ($count restantes) [agent: ${RALPH_RESOLVED_AGENT:-claude}]"
+  fi
 
   # Stream the agent's JSON to jq, but keep stderr OUT of the JSON pipe: any
   # non-JSON line the agent prints to stderr (auth/credit/rate-limit errors,
@@ -237,6 +275,53 @@ while :; do
   run_agent_for_issue "$num"
   issue_end_ms=$(date +%s000)
   issue_dur_ms=$(( issue_end_ms - issue_start_ms ))
+
+  if [ "$TASK_SOURCE" = "folder" ]; then
+    # Terminal directory decides the outcome: the agent moves a completed task
+    # to afk/done. Anything still sitting in afk/todo or afk/in-progress is a
+    # failure/no-op — bash sweeps it to afk/failed so the queue always drains
+    # (this is the folder-mode forward-progress guarantee).
+    outcome=$(node "$RALPH_PKG_DIR/lib/folder-queue.js" locate "$TASKS_ROOT" "$num" 2>/dev/null)
+    if [ "$outcome" != "done" ]; then
+      echo "⚠️  task #$num não foi concluída (dir: ${outcome:-desconhecido}). Movendo para failed." >&2
+      node "$RALPH_PKG_DIR/lib/folder-queue.js" fail "$TASKS_ROOT" "$num" >/dev/null 2>&1 || true
+      outcome="failed"
+    fi
+
+    # Best-effort per-task telemetry: capture one RALPH_ISSUE_EVENT line into
+    # .ralph/metrics/issues.jsonl. TASK_SOURCE=folder makes the sidecar read the
+    # task id (RALPH_TASK_ID) as the event number and the terminal directory
+    # (RALPH_TASK_OUTCOME: done=>pass, failed=>fail) as the verdict, and skip the
+    # gh PR-diff call entirely. Telemetry failure MUST NEVER abort the loop.
+    TASK_SOURCE="folder" \
+      RALPH_TASK_ID="$num" \
+      RALPH_TASK_OUTCOME="$outcome" \
+      RALPH_RUN_ID="$RALPH_RUN_ID" \
+      RALPH_CLAUDE_EXIT="$claude_failed" \
+      RALPH_DEV_BRANCH="${DEV_BRANCH:-}" \
+      RALPH_RAW_JSONL_PATH="logs/ralph-issue-$num.jsonl" \
+      RALPH_STDERR_LOG_PATH="logs/ralph-issue-$num.log" \
+      RALPH_AGENT="${RALPH_RESOLVED_AGENT:-claude}" \
+      RALPH_CODEX_MODEL="${RALPH_CODEX_MODEL:-}" \
+      RALPH_DURATION_MS="$issue_dur_ms" \
+      node "$RALPH_PKG_DIR/lib/capture-issue-event.js" || true
+
+    if [ "$outcome" = "done" ]; then
+      successes+=("$num")
+    else
+      failures+=("$num")
+    fi
+
+    # Zero-progress guard: the sweep above guarantees the task leaves afk/todo,
+    # so the queue must drain. If somehow the SAME task is re-selected (e.g. a
+    # sweep that could not move the file), abort rather than spin forever.
+    if [ "$num" = "$prev_num" ]; then
+      echo "❌ ralph.sh: sem progresso na task #$num (re-selecionada). Abortando o loop." >&2
+      break
+    fi
+    prev_num="$num"
+    continue
+  fi
 
   labels=$(gh issue view "$num" --json labels -q '[.labels[].name] | join(",")')
   state=$(gh issue view "$num" --json state -q '.state')

--- a/packages/ralph/test/loop.test.js
+++ b/packages/ralph/test/loop.test.js
@@ -881,3 +881,123 @@ exit 0
     },
   )
 })
+
+// ---------------------------------------------------------------------------
+// Issue #565 — TASK_SOURCE=folder. The loop draws tasks from a local
+// `.ralph/tasks/afk/todo` tree instead of GitHub, shelling out to
+// lib/folder-queue.js for count/pick/locate/fail. It must NEVER touch gh in
+// folder mode. The happy-path agent moves the task todo→done itself; bash owns
+// the failure/no-op sweep (todo|in-progress → failed) and the zero-progress
+// guard. Telemetry records the task id as issue_number and the terminal
+// directory as the verdict. TASK_SOURCE is supplied via env here (no
+// ralph.config.sh) so the lazy-validation block stays skipped and the test
+// isolates the main loop's source dispatch.
+// ---------------------------------------------------------------------------
+describe('ralph.sh folder task source — issue #565', () => {
+  // node stub: delegate the real JS bridges (folder-queue.js, agent-invocation.js,
+  // capture-issue-event.js) to the real node; everything else echoes a prompt.
+  // jq: minimal no-op streamer. gh: records ANY invocation so the test can prove
+  // folder mode never touches it.
+  function seedFolderStubs() {
+    writeStub(
+      'node',
+      `#!/bin/bash
+case "$*" in
+  *capture-issue-event.js*) exec "${REAL_NODE}" "$@" ;;
+  *agent-invocation.js*) exec "${REAL_NODE}" "$@" ;;
+  *folder-queue.js*) exec "${REAL_NODE}" "$@" ;;
+esac
+echo "PROMPT"
+exit 0
+`,
+    )
+    writeStub('jq', `#!/bin/bash\ncat > /dev/null 2>/dev/null || true\nexit 0\n`)
+    writeStub(
+      'gh',
+      `#!/bin/bash\necho "$*" >> "${join(workdir, 'gh-called.log')}"\nexit 0\n`,
+    )
+  }
+
+  function writeTask(status, file, body = 'do the thing') {
+    const dir = join(workdir, '.ralph', 'tasks', 'afk', status)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, file), body)
+  }
+
+  it('drains the folder queue: completes tasks, records folder telemetry, never touches gh', () => {
+    seedFolderStubs()
+    // Happy-path agent: moves the lowest-numbered todo task to done (mirrors the
+    // git mv the folder orchestrator prompt instructs the real agent to perform).
+    writeStub(
+      'claude',
+      `#!/bin/bash
+cat > /dev/null
+TODO="$PROJECT_ROOT/.ralph/tasks/afk/todo"
+DONE="$PROJECT_ROOT/.ralph/tasks/afk/done"
+mkdir -p "$DONE"
+f=$(ls "$TODO"/*.md 2>/dev/null | sort | head -1)
+[ -n "$f" ] && mv "$f" "$DONE/"
+echo '{"type":"result","subtype":"success"}'
+exit 0
+`,
+    )
+    writeTask('todo', '001-first.md')
+    writeTask('todo', '002-second.md')
+
+    const res = runLoop({ timeout: 20000, extraEnv: { TASK_SOURCE: 'folder' } })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}\nstderr:\n${res.stderr}`).toBeNull()
+    expect(res.status, `stderr:\n${res.stderr}`).toBe(0)
+    expect(res.stdout).toContain('Fila vazia, encerrando.')
+    expect(res.stdout).toMatch(/2 ok, 0 falharam/)
+
+    // Both tasks ended in done.
+    expect(existsSync(join(workdir, '.ralph', 'tasks', 'afk', 'done', '001-first.md'))).toBe(true)
+    expect(existsSync(join(workdir, '.ralph', 'tasks', 'afk', 'done', '002-second.md'))).toBe(true)
+
+    // gh must NEVER be invoked in folder mode (zero-regression the other way:
+    // folder mode is entirely gh-free).
+    expect(
+      existsSync(join(workdir, 'gh-called.log')),
+      `gh was invoked in folder mode:\n${existsSync(join(workdir, 'gh-called.log')) ? readFileSync(join(workdir, 'gh-called.log'), 'utf8') : ''}`,
+    ).toBe(false)
+
+    // Telemetry: one RALPH_ISSUE_EVENT per task; verdict pass; issue_number is
+    // the task id.
+    const metricsFile = join(workdir, '.ralph', 'metrics', 'issues.jsonl')
+    expect(existsSync(metricsFile), `no metrics. stderr:\n${res.stderr}`).toBe(true)
+    const events = readFileSync(metricsFile, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l.slice('RALPH_ISSUE_EVENT '.length)))
+    expect(events.length).toBe(2)
+    for (const ev of events) expect(ev.verdict).toBe('pass')
+    expect(events.map((e) => e.issue_number).sort((a, b) => a - b)).toEqual([1, 2])
+  })
+
+  it('sweeps an uncompleted task to failed and records it as a failure (no infinite spin)', () => {
+    seedFolderStubs()
+    // Agent fails without moving the task; bash must sweep it out of todo.
+    writeStub('claude', `#!/bin/bash\ncat > /dev/null\necho "boom" >&2\nexit 1\n`)
+    writeTask('todo', '007-broken.md')
+
+    const res = runLoop({ timeout: 20000, extraEnv: { TASK_SOURCE: 'folder' } })
+    expect(res.signal, `loop hung. stdout:\n${res.stdout}\nstderr:\n${res.stderr}`).toBeNull()
+    expect(res.status).toBe(0)
+
+    // Swept out of todo into failed so the queue drains (no infinite spin).
+    expect(existsSync(join(workdir, '.ralph', 'tasks', 'afk', 'todo', '007-broken.md'))).toBe(false)
+    expect(existsSync(join(workdir, '.ralph', 'tasks', 'afk', 'failed', '007-broken.md'))).toBe(true)
+    expect(res.stdout).toMatch(/0 ok, 1 falharam/)
+
+    // Folder telemetry: verdict fail; issue_number is the task id.
+    const events = readFileSync(join(workdir, '.ralph', 'metrics', 'issues.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l.slice('RALPH_ISSUE_EVENT '.length)))
+    expect(events.length).toBe(1)
+    expect(events[0].verdict).toBe('fail')
+    expect(events[0].issue_number).toBe(7)
+  })
+})


### PR DESCRIPTION
Closes #565

Adds a configurable **task source** to Ralph: `TASK_SOURCE=github` (default, unchanged) or `folder`, a fully-local backlog under `.ralph/tasks/` that needs no GitHub remote, auth, or `gh`. GitHub mode is preserved byte-for-byte (user story 29). Entirely within the `@lucasfe/ralph` package.

## Dev/TDD
- Tests added/modified:
  - New: `lib/task-source.test.js`, `lib/task-file.test.js`, `lib/folder-queue.test.js`, `lib/read-config-source.test.js`
  - Extended: `lib/init.test.js`, `lib/build-prompt.test.js`, `lib/capture-issue-event.test.js`, `lib/issue-event.test.js`, `lib/deps.test.js`, `lib/doctor.test.js`, `lib/commands/cycle.test.js`, `test/loop.test.js`
- Before implementation (red): folder-source tests failed for the right reason — the loop ran the github path and left `afk/todo` tasks untouched; init wrote no `TASK_SOURCE`; build-prompt selected the github template; folder telemetry recorded nothing.
- After implementation (green): all tests pass.

Implementation spans: `TASK_SOURCE` in the config template; `ralph init --source` flag + interactive prompt + folder scaffold; new pure modules `task-source.js` / `task-file.js` / `folder-queue.js` (library + node CLI) / `parse-config-var.js` / `read-config-source.js`; source-dispatched `queue_count`/pick/outcome in `ralph.sh` (folder commits straight to `DEV_BRANCH`, no PR); folder-mode orchestrator template `prompt-team-folder.md`; telemetry adapted to task id + terminal-dir verdict; `gh` gated on `TASK_SOURCE=github` in deps/doctor/cycle preflight.

## QA scenarios added
QA added 62 adversarial/edge-case tests (`lib/*.qa.test.js`): CRLF/`---`-in-body/unterminated-fence frontmatter parsing; leading-zero & garbage task ids; numbering gaps (`max+1` not count+1) and highest-in-terminal-lane still counted; queue ordering (2 before 10) and hitl never picked; the full move state machine — failure sweep from in-progress and from todo, no-op sweeps, mkdir-p on missing dest; config-var last-assignment-wins & comment handling; folder telemetry never calls `gh`; init scaffold idempotency & invalid `--source` rejection.
- **Bug found & fixed (block-until-green):** `parseTaskFile` split on `\n`, so CRLF task files silently dropped `title`/`labels` (trailing `\r` broke the frontmatter regex). Fixed in `lib/task-file.js` (`split(/\r?\n/)`); the QA test that caught it is retained.

## Review verdict
APPROVE (round 2). Round 1 raised one blocking correctness defect: the folder-mode template told the agent to `git mv`/`git add` task files, but `.ralph/tasks/` is gitignored — `git mv` fails on ignored files and the chained `git add && git commit` would abort, silently failing the happy path (contradicting user story 24). Fixed: template now uses plain `mv` and stages only code/tests. Non-blocking cleanup also applied (init imports `VALID_SOURCES`/`DEFAULT_SOURCE` from the registry; local resolver renamed to avoid shadowing). One pre-existing note deferred: `ralph.sh` end-of-loop cleanup hardcodes `dev` and runs unconditionally — harmless no-op in folder mode, left for a follow-up.

## Docs updated
- `README.md` — new "Choosing the task source" section (layout, task-file format, numbering spec, folder work cycle, `gh`-only-for-github requirement) + `TASK_SOURCE` config row.
- `CONTRIBUTING.md` — documents the third orchestrator template `prompt-team-folder.md` and that it is intentionally outside `template-parity.test.js`, so keep it in sync by hand.

## Notes
- Validation: `packages/ralph` `npm test` → 1232 passed (50 files); repo `npm run lint` → 0 errors (26 pre-existing warnings, all in `src/`, none in changed files).
- Accepted tradeoff (per PRD): folder mode commits straight to the dev branch — no per-task rollback boundary.
