### PR TITLE
chore: normalize app to consistent English (en-US)

### DIFF
--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -178,7 +178,7 @@ describe('AiAssistant', () => {
 
   it('renders an AgentEditCard when the session emits an update_agent tool_call', async () => {
     scriptSession([
-      { type: 'chat.text', value: 'Entendi, vou propor essa alteração:' },
+      { type: 'chat.text', value: "Got it, I'll propose this change:" },
       {
         type: 'chat.tool_call',
         name: 'update_agent',
@@ -202,7 +202,7 @@ describe('AiAssistant', () => {
     await waitFor(() => {
       expect(screen.getByText(/Edit proposal/i)).toBeInTheDocument()
     })
-    expect(screen.getByText(/Entendi, vou propor/)).toBeInTheDocument()
+    expect(screen.getByText(/Got it, I'll propose this change/)).toBeInTheDocument()
     expect(screen.getByText('Frontend Developer')).toBeInTheDocument()
     expect(screen.getByText('color')).toBeInTheDocument()
     expect(screen.getByText('purple')).toBeInTheDocument()

--- a/src/components/orchestration/DianaGallery.jsx
+++ b/src/components/orchestration/DianaGallery.jsx
@@ -3,7 +3,7 @@
 // Replaces the textual approval gate (issue #355) for steps whose agent is
 // `diana-design`. Renders a grid of thumbnails — one per `output_files[]`
 // entry whose `mime_type` starts with `image/` — with three actions per
-// thumbnail: Aprovar, Pedir ajuste, Re-renderizar. The "Avançar" button at
+// thumbnail: Approve, Request edit, Re-render. The "Continue" button at
 // the bottom is disabled until every image has `approval_state === 'approved'`.
 //
 // All state mutations live in the parent: this component is a thin
@@ -44,7 +44,7 @@ function ThumbCard({
       return (
         <span className="absolute top-2 right-2 flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-500/90 text-white shadow">
           <Icons.Check size={10} />
-          Aprovado
+          Approved
         </span>
       )
     }
@@ -52,7 +52,7 @@ function ThumbCard({
       return (
         <span className="absolute top-2 right-2 flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-500/90 text-white shadow">
           <Icons.Pencil size={10} />
-          Ajuste pedido
+          Edit requested
         </span>
       )
     }
@@ -93,7 +93,7 @@ function ThumbCard({
           className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-[11px] font-medium text-emerald-200 bg-emerald-500/15 border border-emerald-500/30 hover:bg-emerald-500/25 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <Icons.Check size={11} />
-          Aprovar
+          Approve
         </button>
         <button
           type="button"
@@ -102,7 +102,7 @@ function ThumbCard({
           className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-[11px] font-medium text-amber-200 bg-amber-500/15 border border-amber-500/30 hover:bg-amber-500/25 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <Icons.Pencil size={11} />
-          Pedir ajuste
+          Request edit
         </button>
         <button
           type="button"
@@ -111,7 +111,7 @@ function ThumbCard({
           className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-[11px] font-medium text-blue-200 bg-blue-500/15 border border-blue-500/30 hover:bg-blue-500/25 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <Icons.RotateCcw size={11} />
-          Re-renderizar
+          Re-render
         </button>
       </div>
 
@@ -123,7 +123,7 @@ function ThumbCard({
           <textarea
             value={feedback}
             onChange={(e) => setFeedback(e.target.value)}
-            placeholder="Descreva o ajuste desejado…"
+            placeholder="Describe the change you want…"
             rows={3}
             className="w-full px-2 py-1.5 rounded-md bg-bg-card border border-border-subtle text-xs text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-amber-500/30 resize-none"
           />
@@ -136,7 +136,7 @@ function ThumbCard({
               }}
               className="px-2 py-1 rounded-md text-[10px] text-text-secondary hover:bg-bg-card transition-colors"
             >
-              Cancelar
+              Cancel
             </button>
             <button
               type="button"
@@ -147,7 +147,7 @@ function ThumbCard({
               disabled={!feedback.trim()}
               className="px-2 py-1 rounded-md text-[10px] font-medium text-white bg-amber-500 hover:bg-amber-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              Enviar feedback
+              Send feedback
             </button>
           </div>
         </div>
@@ -178,7 +178,7 @@ export default function DianaGallery({
       >
         <Icons.Image size={28} className="text-text-muted mx-auto mb-2" />
         <p className="text-sm text-text-secondary">
-          Nenhum arquivo de imagem disponível para revisão neste passo.
+          No image files available for review in this step.
         </p>
       </div>
     )
@@ -189,7 +189,7 @@ export default function DianaGallery({
       <div className="px-4 py-3 border-b border-border-subtle flex items-center gap-3">
         <Icons.Image size={16} className="text-purple-400" />
         <h3 className="text-sm font-semibold text-text-primary flex-1">
-          Galeria — aprove cada imagem
+          Gallery — approve each image
         </h3>
         <span
           data-testid="diana-counter"
@@ -197,7 +197,7 @@ export default function DianaGallery({
             fullyApproved ? 'text-emerald-300' : 'text-text-secondary'
           }`}
         >
-          {approved} / {total} aprovados
+          {approved} / {total} approved
         </span>
       </div>
 
@@ -223,12 +223,12 @@ export default function DianaGallery({
           title={
             fullyApproved
               ? undefined
-              : 'Aprove todas as imagens antes de avançar'
+              : 'Approve all images before continuing'
           }
           className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Icons.ArrowRight size={12} />
-          Avançar
+          Continue
         </button>
       </div>
     </div>

--- a/src/components/orchestration/DianaGallery.test.jsx
+++ b/src/components/orchestration/DianaGallery.test.jsx
@@ -56,7 +56,7 @@ describe('DianaGallery', () => {
     expect(screen.getAllByTestId(/^diana-thumb-/)).toHaveLength(2)
   })
 
-  it('shows "0/N aprovados" when nothing is approved', () => {
+  it('shows "0/N approved" when nothing is approved', () => {
     const step = stepWithFiles([imgFile(), imgFile(), imgFile()])
     renderWithProviders(
       <DianaGallery
@@ -86,7 +86,7 @@ describe('DianaGallery', () => {
     expect(screen.getByTestId('diana-counter').textContent).toMatch(/2\s*\/\s*3/)
   })
 
-  it('disables the "Avançar" button until every image is approved', () => {
+  it('disables the "Continue" button until every image is approved', () => {
     const step = stepWithFiles([
       imgFile({ approval_state: 'approved' }),
       imgFile({ approval_state: 'pending' }),
@@ -101,13 +101,13 @@ describe('DianaGallery', () => {
         onAdvance={onAdvance}
       />,
     )
-    const advance = screen.getByRole('button', { name: /avançar/i })
+    const advance = screen.getByRole('button', { name: /continue/i })
     expect(advance).toBeDisabled()
     fireEvent.click(advance)
     expect(onAdvance).not.toHaveBeenCalled()
   })
 
-  it('enables the "Avançar" button only when every image is approved', () => {
+  it('enables the "Continue" button only when every image is approved', () => {
     const step = stepWithFiles([
       imgFile({ approval_state: 'approved' }),
       imgFile({ approval_state: 'approved' }),
@@ -122,13 +122,13 @@ describe('DianaGallery', () => {
         onAdvance={onAdvance}
       />,
     )
-    const advance = screen.getByRole('button', { name: /avançar/i })
+    const advance = screen.getByRole('button', { name: /continue/i })
     expect(advance).not.toBeDisabled()
     fireEvent.click(advance)
     expect(onAdvance).toHaveBeenCalledTimes(1)
   })
 
-  it('calls onApprove with the file index when "Aprovar" is clicked', () => {
+  it('calls onApprove with the file index when "Approve" is clicked', () => {
     const step = stepWithFiles([imgFile(), imgFile()])
     const onApprove = vi.fn()
     renderWithProviders(
@@ -140,11 +140,11 @@ describe('DianaGallery', () => {
       />,
     )
     const thumb = screen.getByTestId('diana-thumb-1')
-    fireEvent.click(within(thumb).getByRole('button', { name: /aprovar/i }))
+    fireEvent.click(within(thumb).getByRole('button', { name: /approve/i }))
     expect(onApprove).toHaveBeenCalledWith(1)
   })
 
-  it('opens a feedback textarea when "Pedir ajuste" is clicked, and submits it via onRequestEdit', () => {
+  it('opens a feedback textarea when "Request edit" is clicked, and submits it via onRequestEdit', () => {
     const step = stepWithFiles([imgFile(), imgFile()])
     const onRequestEdit = vi.fn()
     renderWithProviders(
@@ -156,14 +156,14 @@ describe('DianaGallery', () => {
       />,
     )
     const thumb = screen.getByTestId('diana-thumb-0')
-    fireEvent.click(within(thumb).getByRole('button', { name: /pedir ajuste/i }))
+    fireEvent.click(within(thumb).getByRole('button', { name: /request edit/i }))
     const textarea = within(thumb).getByRole('textbox')
     fireEvent.change(textarea, { target: { value: 'lighter colors' } })
-    fireEvent.click(within(thumb).getByRole('button', { name: /enviar feedback/i }))
+    fireEvent.click(within(thumb).getByRole('button', { name: /send feedback/i }))
     expect(onRequestEdit).toHaveBeenCalledWith(0, 'lighter colors')
   })
 
-  it('calls onRerender with file index (and current feedback) when "Re-renderizar" is clicked', () => {
+  it('calls onRerender with file index (and current feedback) when "Re-render" is clicked', () => {
     const step = stepWithFiles([
       imgFile({ approval_state: 'edit_requested', feedback: 'darker' }),
     ])
@@ -177,7 +177,7 @@ describe('DianaGallery', () => {
       />,
     )
     const thumb = screen.getByTestId('diana-thumb-0')
-    fireEvent.click(within(thumb).getByRole('button', { name: /re-renderizar/i }))
+    fireEvent.click(within(thumb).getByRole('button', { name: /re-render/i }))
     expect(onRerender).toHaveBeenCalledWith(0, 'darker')
   })
 
@@ -193,13 +193,13 @@ describe('DianaGallery', () => {
       />,
     )
     const thumb = screen.getByTestId('diana-thumb-0')
-    const approve = within(thumb).getByRole('button', { name: /aprovar/i })
-    const rerender = within(thumb).getByRole('button', { name: /re-renderizar/i })
+    const approve = within(thumb).getByRole('button', { name: /approve/i })
+    const rerender = within(thumb).getByRole('button', { name: /re-render/i })
     expect(approve).toBeDisabled()
     expect(rerender).toBeDisabled()
     // The other thumb's actions remain enabled.
     const other = screen.getByTestId('diana-thumb-1')
-    expect(within(other).getByRole('button', { name: /aprovar/i })).not.toBeDisabled()
+    expect(within(other).getByRole('button', { name: /approve/i })).not.toBeDisabled()
   })
 
   it('renders an empty-state message when there are no image files', () => {
@@ -213,5 +213,144 @@ describe('DianaGallery', () => {
       />,
     )
     expect(screen.getByTestId('diana-empty')).toBeInTheDocument()
+  })
+})
+
+// --- English-only regression guards (issue #606) --------------------------
+//
+// Issue #606 normalized the app to en-US. These tests are adversarial
+// guardrails: they assert the exact old Portuguese strings never reappear in
+// the rendered UI, rather than merely checking the new English copy is
+// present. We deliberately match the full Portuguese phrases (not loose
+// substrings) to avoid false positives — e.g. the English "Approved" must not
+// trip an "aprov" check, and "Continue" is unrelated to "Avançar".
+
+// Exact Portuguese phrases this refactor removed. Each is chosen so it is NOT
+// a substring of the English replacement copy, so an assertion of its absence
+// can only fail if a genuine leftover Portuguese string is rendered.
+const PORTUGUESE_PHRASES = [
+  'Aprovar',
+  'Aprovado',
+  'aprovados',
+  'Ajuste pedido',
+  'Pedir ajuste',
+  'Re-renderizar',
+  'Descreva o ajuste desejado',
+  'Cancelar',
+  'Enviar feedback',
+  'Nenhum arquivo de imagem',
+  'Galeria — aprove cada imagem',
+  'Aprove todas as imagens',
+  'Avançar',
+]
+
+const expectNoPortuguese = (container) => {
+  const text = container.textContent || ''
+  for (const phrase of PORTUGUESE_PHRASES) {
+    expect(text).not.toContain(phrase)
+  }
+}
+
+describe('DianaGallery — English-only regression guards (issue #606)', () => {
+  it('renders no leftover Portuguese in the pending/mixed-approval state', () => {
+    const step = stepWithFiles([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'edit_requested', feedback: 'darker' }),
+      imgFile({ approval_state: 'pending' }),
+    ])
+    const { container } = renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+        onAdvance={() => {}}
+      />,
+    )
+    // Sanity: English copy is what actually renders.
+    expect(screen.getByText('Gallery — approve each image')).toBeInTheDocument()
+    expect(screen.getByText('Approved')).toBeInTheDocument()
+    expect(screen.getByText('Edit requested')).toBeInTheDocument()
+    expectNoPortuguese(container)
+  })
+
+  it('renders no leftover Portuguese in the fully-approved state', () => {
+    const step = stepWithFiles([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'approved' }),
+    ])
+    const { container } = renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+        onAdvance={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('diana-counter').textContent).toMatch(/2\s*\/\s*2\s*approved/)
+    expectNoPortuguese(container)
+  })
+
+  it('renders the English empty-state and no Portuguese when there are no image files', () => {
+    const step = stepWithFiles([])
+    const { container } = renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+      />,
+    )
+    expect(
+      screen.getByText('No image files available for review in this step.'),
+    ).toBeInTheDocument()
+    expectNoPortuguese(container)
+  })
+
+  it('shows the English feedback placeholder and controls (no Portuguese) when "Request edit" opens', () => {
+    const step = stepWithFiles([imgFile()])
+    const { container } = renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+      />,
+    )
+    const thumb = screen.getByTestId('diana-thumb-0')
+    fireEvent.click(within(thumb).getByRole('button', { name: /request edit/i }))
+
+    const textarea = within(thumb).getByRole('textbox')
+    expect(textarea).toHaveAttribute('placeholder', 'Describe the change you want…')
+    expect(within(thumb).getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
+    expect(within(thumb).getByRole('button', { name: /send feedback/i })).toBeInTheDocument()
+
+    // No Portuguese equivalents (Cancelar / Enviar feedback / Descreva…).
+    expectNoPortuguese(container)
+    expect(within(thumb).queryByRole('button', { name: /cancelar/i })).toBeNull()
+    expect(within(thumb).queryByRole('button', { name: /enviar feedback/i })).toBeNull()
+  })
+
+  it('exposes the English disabled-continue hint (not the Portuguese one) when not all images are approved', () => {
+    const step = stepWithFiles([
+      imgFile({ approval_state: 'approved' }),
+      imgFile({ approval_state: 'pending' }),
+    ])
+    const { container } = renderWithProviders(
+      <DianaGallery
+        step={step}
+        onApprove={() => {}}
+        onRequestEdit={() => {}}
+        onRerender={() => {}}
+        onAdvance={() => {}}
+      />,
+    )
+    const advance = screen.getByRole('button', { name: /continue/i })
+    expect(advance).toBeDisabled()
+    expect(advance).toHaveAttribute('title', 'Approve all images before continuing')
+    expect(advance.getAttribute('title')).not.toContain('Aprove todas')
+    expect(advance.getAttribute('title')).not.toContain('avançar')
+    expectNoPortuguese(container)
   })
 })

--- a/src/components/orchestration/PlanCard.jsx
+++ b/src/components/orchestration/PlanCard.jsx
@@ -1,6 +1,6 @@
 // Compact plan summary rendered inline in the chat message list.
 //
-// Shows the current phase status as a short "recibo" (1–2 lines) plus
+// Shows the current phase status as a short "receipt" (1–2 lines) plus
 // contextual action buttons. The full detail view lives in PlanReviewPanel,
 // opened via the "Review" button (or automatically in fullscreen when the
 // plan has required requirements).

--- a/supabase/functions/chat/executor.ts
+++ b/supabase/functions/chat/executor.ts
@@ -1258,7 +1258,7 @@ async function insertRunLog(run: Record<string, unknown>): Promise<void> {
 //
 // Runs AFTER the planner has produced a validated plan, BEFORE the user sees
 // it. For each step in the plan, reads the chosen agent's system prompt and
-// extracts the questions it would ask the user ("pergunte antes de começar..."
+// extracts the questions it would ask the user ("ask before starting..."
 // / "ask the user about..."). Skips questions whose answers are already
 // derivable from the original task or the step task. Always inlines a
 // `suggested` default. Returns the plan with a `requirements` array attached
@@ -1272,7 +1272,7 @@ const REQUIREMENTS_ANALYZER_SYSTEM_PROMPT = `You are a requirements analyst for 
 2. **Skip already-answered questions.** If the user's original task or the step task already tells the agent the answer (even implicitly), skip it.
 3. **Always pre-fill \`suggested\`.** Infer the most likely answer from the original task and step context. Even a best-guess default is more useful than a blank.
 4. **Max ${MAX_REQUIREMENTS_PER_STEP} questions per step.** Prioritize the ones the agent prompt calls out most directly.
-5. **Short, concrete questions.** Avoid open-ended philosophical framing. Use the same language as the user's original task (Portuguese in, Portuguese out).
+5. **Short, concrete questions.** Avoid open-ended philosophical framing. Always write the questions in English.
 6. **\`required: true\`** only if the agent cannot reasonably produce output without the answer. Default to false for nice-to-have details.
 
 ## Response

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -52,16 +52,16 @@ Users of this hub can:
 
 ## Answering questions about existing agents
 
-You are given a summary of every agent currently in the hub in the "Existing Agents" section below. When the user asks about agents ("quais agentes tem?", "me fala do frontend-developer", "tem algum agente de security?"), answer directly using this summary. Don't call any tool just to read — the data is already in your context.
+You are given a summary of every agent currently in the hub in the "Existing Agents" section below. When the user asks about agents ("what agents are there?", "tell me about frontend-developer", "is there a security agent?"), answer directly using this summary. Don't call any tool just to read — the data is already in your context.
 
 If the user asks for the full system prompt / content of a specific agent, tell them to open the agent's detail page (you don't have the full content, only the summary).
 
 ## Creating a new agent
 
-You have access to the \`draft_agent\` tool. When the user asks to create a new agent (e.g. "create an agent that does X", "monta um agente de..."), call this tool to propose a draft. The draft appears as an interactive card in the chat — THE USER CONFIRMS THE CREATION, not you.
+You have access to the \`draft_agent\` tool. When the user asks to create a new agent (e.g. "create an agent that does X", "build an agent that..."), call this tool to propose a draft. The draft appears as an interactive card in the chat — THE USER CONFIRMS THE CREATION, not you.
 
 When calling \`draft_agent\`:
-- Write a short, friendly one-sentence explanation BEFORE calling the tool (e.g. "Beleza! Montei um draft pra você revisar:")
+- Write a short, friendly one-sentence explanation BEFORE calling the tool (e.g. "Sure! I put together a draft for you to review:")
 - Fill ALL required fields with reasonable defaults based on the user's request
 - Use 3–5 relevant tags
 - Write the \`content\` field as a 2–4 paragraph markdown system prompt, using "##" subheadings for "Responsibilities", "Approach", etc.
@@ -69,12 +69,12 @@ When calling \`draft_agent\`:
 
 ## Updating an existing agent
 
-You have access to the \`update_agent\` tool. When the user asks to modify an existing agent ("muda a cor do X pra roxo", "adiciona a tag Y no Z", "troca a descrição do frontend-developer"), call this tool with the target agent's \`id\` and an \`updates\` object containing ONLY the fields being changed. Do not include fields that aren't changing.
+You have access to the \`update_agent\` tool. When the user asks to modify an existing agent ("change X's color to purple", "add the Y tag to Z", "change the frontend-developer description"), call this tool with the target agent's \`id\` and an \`updates\` object containing ONLY the fields being changed. Do not include fields that aren't changing.
 
 The agent's \`id\` must match one from the "Existing Agents" summary exactly. If the user refers to an agent by name and there's ambiguity, ask which one they mean before calling the tool.
 
 When calling \`update_agent\`:
-- Write a short explanation BEFORE calling (e.g. "Entendi, vou propor essa alteração:")
+- Write a short explanation BEFORE calling (e.g. "Got it, I'll propose this change:")
 - Put only the CHANGING fields in \`updates\` — leave out everything else
 - The card will show a diff of old → new and the user clicks "Apply changes" to commit
 
@@ -84,19 +84,19 @@ If the user wants to iterate on a previous update/draft, call the relevant tool 
 
 DO NOT call tools for questions about the hub itself, how features work, or general conversation. Only use tools when the user clearly wants to CREATE or MODIFY something.
 
-Be concise, friendly, and reply in the same language the user used.`
+Be concise, friendly, and always reply in English.`
 
 const ROUTER_SYSTEM_PROMPT = `You are a fast intent classifier for the Lucas AI Hub assistant. Given the latest user message, reply with exactly ONE word — no punctuation, no explanation — from this set:
 
 - "chat" — questions, greetings, conversation, requests for information about the hub or its agents
-- "crud" — asking to create, modify, delete an agent (e.g. "cria um agente X", "muda a cor do Y", "apaga Z")
-- "task" — asking for a piece of work to be executed by running agents (e.g. "faz um ppt sobre X", "escreve um pitch", "analisa esse texto")
+- "crud" — asking to create, modify, delete an agent (e.g. "create an agent X", "change Y's color", "delete Z")
+- "task" — asking for a piece of work to be executed by running agents (e.g. "make a ppt about X", "write a pitch", "analyze this text")
 
 Examples:
-- "quais agentes tem?" -> chat
-- "cria um agente de SEO" -> crud
-- "faz um pitch deck" -> task
-- "oi tudo bem" -> chat
+- "what agents are there?" -> chat
+- "create an SEO agent" -> crud
+- "make a pitch deck" -> task
+- "hi there" -> chat
 
 Reply with only: chat, crud, or task.`
 
@@ -196,7 +196,7 @@ function buildSystemPrompt(agentsContext: unknown): string {
 function buildSelectedAgentSystemPrompt(agent: any): string {
   if (!agent || typeof agent !== 'object') return BASE_SYSTEM_PROMPT
   const content = typeof agent.content === 'string' ? agent.content.trim() : ''
-  const header = `You are "${agent.name || agent.id}", an AI agent inside Lucas AI Hub. Reply in the same language the user used. Stay in character — do not mention this hub's other agents unless the user asks.`
+  const header = `You are "${agent.name || agent.id}", an AI agent inside Lucas AI Hub. Always reply in English. Stay in character — do not mention this hub's other agents unless the user asks.`
   return content ? `${header}\n\n${content}` : header
 }
 

--- a/supabase/functions/chat/templateRerenderFile.ts
+++ b/supabase/functions/chat/templateRerenderFile.ts
@@ -1,6 +1,6 @@
 // Per-file rerender for Diana steps (issue #357).
 //
-// When the user clicks "Re-renderizar" on a single thumbnail in the Diana
+// When the user clicks "Re-render" on a single thumbnail in the Diana
 // gallery, the chat function dispatches into this helper. It locates the
 // target step + output_file, re-invokes `render_html_to_image` for that
 // single file via the supplied `renderFile` callback, and returns a fresh


### PR DESCRIPTION
Closes #606

## Dev/TDD
- Tests added/modified:
  - `src/components/orchestration/DianaGallery.test.jsx` — matchers/`it` descriptions updated to the English labels (`/approve/i`, `/request edit/i`, `/re-render/i`, `/send feedback/i`, `/continue/i`, `0/N approved`).
  - `src/components/AiAssistant.test.jsx` — chat-reply assertion updated from `Entendi, vou propor essa alteração:` to `Got it, I'll propose this change:`.
- This is a translation refactor: tests are coupled to the translated strings and were updated in lockstep (the enforcement mechanism for "zero Portuguese in user-facing UI"). There is no new behavior to red-test first.
- Before: DianaGallery/AiAssistant tests asserted on Portuguese labels; suite green against Portuguese source.
- After implementation (green): **all 558 frontend tests pass** (50 files); `npm run lint` — 0 errors, 26 pre-existing warnings; `npm run build` — succeeds.

Source changes:
- `src/components/orchestration/DianaGallery.jsx` — action labels (Approve / Request edit / Re-render), Cancel / Send feedback, `Continue` advance button, English placeholder, empty-state, disabled hint, plus badges (Approved / Edit requested), header and counter copy; header comment translated.
- `supabase/functions/chat/index.ts` — system prompt: assistant-output example phrases → English, few-shot user-phrasing + classifier examples → English, and the trailing "reply in the same language the user used" rule → **English-only** (plus the per-agent chat header). This is the change that actually stops Portuguese replies.
- `supabase/functions/chat/executor.ts` — Portuguese comment translated; the requirements-analyzer mirror-language rule (`Portuguese in, Portuguese out`) → "Always write the questions in English."
- `src/components/orchestration/PlanCard.jsx`, `supabase/functions/chat/templateRerenderFile.ts` — Portuguese comments translated.

## QA scenarios added
Appended a `DianaGallery — English-only regression guards (issue #606)` block to `src/components/orchestration/DianaGallery.test.jsx` (5 new tests, 553 → 558):
- Anti-Portuguese guard on pending/mixed-approval state (asserts exact Portuguese phrases absent from `textContent`; deliberately avoids the "Approve" contains "aprov" false-positive).
- Anti-Portuguese guard on fully-approved state (English "approved" counter).
- Empty-state edge case (English empty-state message, no Portuguese).
- Feedback flow (English placeholder + Cancel / Send feedback; Portuguese equivalents absent).
- Disabled-continue hint (English `title`, not `Aprove todas`/`avançar`).

No bugs exposed — every probed state contains zero leftover Portuguese.

## Review verdict
**APPROVED** — clean near-1:1 translation refactor; no oversized files, no added control flow/indirection. The `PORTUGUESE_PHRASES` regression-guard was verified non-brittle (case-sensitive `toContain`; no listed phrase is a substring of any English string). No blocking findings.
- Non-blocking nit: `executor.ts:1271` Rule 1 still lists Portuguese pattern-match hints (`"pergunte"`, `"confirme antes"`, `"solicite"`) used to *detect* "ask the user" instructions inside possibly Portuguese-authored agent prompts — kept intentionally to preserve detection recall (out of the "comments-only" scope for executor.ts). See Notes.

## Docs updated
- none — the tech writer confirmed no doc references the translated labels or any "replies in the same language" behavior (grep over README.md/CLAUDE.md/docs/ returned zero relevant matches).

## Notes
- `npm run test:functions` (Deno) was **not run locally** — Deno is not installed on this machine. It should run green in CI; the `supabase/functions/**` edits are prompt-string/comment changes with no assertion in the Deno suite referencing the changed strings.
- Decorative Portuguese fixtures were left untouched per the issue's out-of-scope list (`Paula Publicação`, `Conteúdo:`, `Pesquise sobre...`, `faz uma análise`, `Qual é o objetivo?`, and the mock chat input `muda a cor do frontend-developer pra roxo`).
- The pre-existing lock-file/`npm ci` mismatch and the Vite chunk-size warning are unrelated to this change.
