### PR TITLE
fix: make chat assistant reply English-only (#608)

### DIFF
--- a/src/components/AiAssistant.test.jsx
+++ b/src/components/AiAssistant.test.jsx
@@ -145,7 +145,7 @@ describe('AiAssistant', () => {
 
   it('renders an AgentDraftCard when the session emits a draft_agent tool_call', async () => {
     scriptSession([
-      { type: 'chat.text', value: 'Beleza! Montei um draft:' },
+      { type: 'chat.text', value: 'Sure! I put together a draft:' },
       {
         type: 'chat.tool_call',
         name: 'draft_agent',
@@ -171,7 +171,7 @@ describe('AiAssistant', () => {
     await waitFor(() => {
       expect(screen.getByText('Security Auditor')).toBeInTheDocument()
     })
-    expect(screen.getByText(/Beleza! Montei um draft/)).toBeInTheDocument()
+    expect(screen.getByText(/Sure! I put together a draft/)).toBeInTheDocument()
     expect(screen.getByText(/Expert in OWASP/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /create agent/i })).toBeInTheDocument()
   })

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -26,6 +26,10 @@ import {
   type TemplateExecutorDeps,
 } from './templateExecutorBranch.ts'
 import { rerenderStepFile } from './templateRerenderFile.ts'
+import {
+  buildSelectedAgentSystemPrompt,
+  buildSystemPrompt,
+} from './systemPrompt.ts'
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const CHAT_MODEL = Deno.env.get('CHAT_MODEL') || 'claude-sonnet-4-6'
@@ -40,51 +44,6 @@ const MAX_PLAN_STEPS = 5
 // edge-function hard limit (~400s).
 const RUN_TIMEOUT_MS =
   Number(Deno.env.get('RUN_TIMEOUT_MS')) || 240_000
-
-const BASE_SYSTEM_PROMPT = `You are the AI assistant for Lucas AI Hub, an internal web app for browsing, creating, and managing AI agent templates.
-
-Users of this hub can:
-- Browse agents across categories like "Development Team" and "AI Specialists"
-- Stack multiple agents into a cart and download them as a ZIP of markdown system prompts
-- Create their own agents and teams
-- Bundle agents into named "teams" for reuse
-- Use ⌘K to jump to any agent or team by name
-
-## Answering questions about existing agents
-
-You are given a summary of every agent currently in the hub in the "Existing Agents" section below. When the user asks about agents ("what agents are there?", "tell me about frontend-developer", "is there a security agent?"), answer directly using this summary. Don't call any tool just to read — the data is already in your context.
-
-If the user asks for the full system prompt / content of a specific agent, tell them to open the agent's detail page (you don't have the full content, only the summary).
-
-## Creating a new agent
-
-You have access to the \`draft_agent\` tool. When the user asks to create a new agent (e.g. "create an agent that does X", "build an agent that..."), call this tool to propose a draft. The draft appears as an interactive card in the chat — THE USER CONFIRMS THE CREATION, not you.
-
-When calling \`draft_agent\`:
-- Write a short, friendly one-sentence explanation BEFORE calling the tool (e.g. "Sure! I put together a draft for you to review:")
-- Fill ALL required fields with reasonable defaults based on the user's request
-- Use 3–5 relevant tags
-- Write the \`content\` field as a 2–4 paragraph markdown system prompt, using "##" subheadings for "Responsibilities", "Approach", etc.
-- For \`icon\`, pick a PascalCase lucide-react icon name that matches the agent's purpose (e.g. Shield, Code, Database, Palette, Bot). If unsure, use Bot.
-
-## Updating an existing agent
-
-You have access to the \`update_agent\` tool. When the user asks to modify an existing agent ("change X's color to purple", "add the Y tag to Z", "change the frontend-developer description"), call this tool with the target agent's \`id\` and an \`updates\` object containing ONLY the fields being changed. Do not include fields that aren't changing.
-
-The agent's \`id\` must match one from the "Existing Agents" summary exactly. If the user refers to an agent by name and there's ambiguity, ask which one they mean before calling the tool.
-
-When calling \`update_agent\`:
-- Write a short explanation BEFORE calling (e.g. "Got it, I'll propose this change:")
-- Put only the CHANGING fields in \`updates\` — leave out everything else
-- The card will show a diff of old → new and the user clicks "Apply changes" to commit
-
-If the user wants to iterate on a previous update/draft, call the relevant tool again with the updated fields.
-
-## General rules
-
-DO NOT call tools for questions about the hub itself, how features work, or general conversation. Only use tools when the user clearly wants to CREATE or MODIFY something.
-
-Be concise, friendly, and always reply in English.`
 
 const ROUTER_SYSTEM_PROMPT = `You are a fast intent classifier for the Lucas AI Hub assistant. Given the latest user message, reply with exactly ONE word — no punctuation, no explanation — from this set:
 
@@ -171,33 +130,6 @@ const UPDATE_AGENT_TOOL = {
       },
     },
   },
-}
-
-function buildSystemPrompt(agentsContext: unknown): string {
-  if (!Array.isArray(agentsContext) || agentsContext.length === 0) {
-    return BASE_SYSTEM_PROMPT
-  }
-  const lines = agentsContext
-    .filter((a: any) => a && typeof a.id === 'string' && typeof a.name === 'string')
-    .map((a: any) => {
-      const tags = Array.isArray(a.tags) && a.tags.length > 0 ? ` [${a.tags.join(', ')}]` : ''
-      const desc = typeof a.description === 'string' && a.description ? ` — ${a.description}` : ''
-      const cat = typeof a.category === 'string' && a.category ? ` (${a.category})` : ''
-      return `- ${a.id}: ${a.name}${cat}${desc}${tags}`
-    })
-  if (lines.length === 0) return BASE_SYSTEM_PROMPT
-  return `${BASE_SYSTEM_PROMPT}\n\n## Existing Agents\n\n${lines.join('\n')}`
-}
-
-// When the user explicitly picks an agent next to the chat bar, we drop the
-// hub-assistant persona and let that agent drive the conversation directly.
-// The agent's `content` (its full markdown system prompt) becomes the system
-// prompt; the router/planner is bypassed for the rest of this turn.
-function buildSelectedAgentSystemPrompt(agent: any): string {
-  if (!agent || typeof agent !== 'object') return BASE_SYSTEM_PROMPT
-  const content = typeof agent.content === 'string' ? agent.content.trim() : ''
-  const header = `You are "${agent.name || agent.id}", an AI agent inside Lucas AI Hub. Always reply in English. Stay in character — do not mention this hub's other agents unless the user asks.`
-  return content ? `${header}\n\n${content}` : header
 }
 
 const corsHeaders = {

--- a/supabase/functions/chat/systemPrompt.test.ts
+++ b/supabase/functions/chat/systemPrompt.test.ts
@@ -1,0 +1,206 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from 'jsr:@std/assert@1'
+import {
+  BASE_SYSTEM_PROMPT,
+  buildSelectedAgentSystemPrompt,
+  buildSystemPrompt,
+} from './systemPrompt.ts'
+
+// Regression guard for issue #608: the chat assistant must reply in English
+// only. These tests lock the English-only behavior so a future edit can't
+// silently reintroduce Portuguese phrasing or a "reply in the same language"
+// rule.
+
+// Portuguese remnants that previously lived in the prompt (example phrases,
+// few-shot user phrasings, and the old "same language" instruction).
+const PORTUGUESE_REMNANTS =
+  /Beleza|Entendi|vou propor|quais agentes|me fala do|tem algum agente|monta um agente|muda a cor|adiciona a tag|troca a descrição/
+
+Deno.test('BASE_SYSTEM_PROMPT — instructs the assistant to always reply in English', () => {
+  assertStringIncludes(BASE_SYSTEM_PROMPT.toLowerCase(), 'always reply in english')
+})
+
+Deno.test('BASE_SYSTEM_PROMPT — no longer contains the removed "same language" rule', () => {
+  assert(
+    !/same language/i.test(BASE_SYSTEM_PROMPT),
+    'BASE_SYSTEM_PROMPT must not tell the assistant to reply in the same language',
+  )
+})
+
+Deno.test('BASE_SYSTEM_PROMPT — contains no Portuguese remnants', () => {
+  assert(
+    !PORTUGUESE_REMNANTS.test(BASE_SYSTEM_PROMPT),
+    'BASE_SYSTEM_PROMPT must not contain Portuguese remnants',
+  )
+})
+
+Deno.test('buildSelectedAgentSystemPrompt — header instructs English-only replies', () => {
+  const prompt = buildSelectedAgentSystemPrompt({ name: 'X', content: 'Y' })
+  assertStringIncludes(prompt, 'Always reply in English')
+})
+
+// ---------------------------------------------------------------------------
+// Behavioral guards for the extracted builder functions (issue #608 refactor).
+// index.ts now depends on these, so their output must be byte-for-byte what it
+// was before extraction. The tests above only cover English-only wording; the
+// tests below cover the actual construction logic and adversarial inputs.
+// ---------------------------------------------------------------------------
+
+// --- buildSystemPrompt(agentsContext) --------------------------------------
+
+Deno.test('buildSystemPrompt — empty array returns exactly BASE_SYSTEM_PROMPT', () => {
+  assertEquals(buildSystemPrompt([]), BASE_SYSTEM_PROMPT)
+})
+
+Deno.test('buildSystemPrompt — no "## Existing Agents" section for empty array', () => {
+  assert(!buildSystemPrompt([]).includes('## Existing Agents'))
+})
+
+Deno.test('buildSystemPrompt — non-array inputs return exactly BASE_SYSTEM_PROMPT', () => {
+  assertEquals(buildSystemPrompt(null), BASE_SYSTEM_PROMPT)
+  assertEquals(buildSystemPrompt(undefined), BASE_SYSTEM_PROMPT)
+  assertEquals(buildSystemPrompt('not an array'), BASE_SYSTEM_PROMPT)
+  assertEquals(buildSystemPrompt({ id: 'x', name: 'y' }), BASE_SYSTEM_PROMPT)
+  assertEquals(buildSystemPrompt(42), BASE_SYSTEM_PROMPT)
+})
+
+Deno.test('buildSystemPrompt — all-malformed entries filter to zero lines and return BASE_SYSTEM_PROMPT', () => {
+  const malformed = [
+    null,
+    undefined,
+    'string entry',
+    42,
+    {},
+    { id: 'has-id-only' }, // missing name
+    { name: 'has-name-only' }, // missing id
+    { id: 123, name: 'numeric id' }, // id not a string
+    { id: 'x', name: 456 }, // name not a string
+  ]
+  const prompt = buildSystemPrompt(malformed)
+  assertEquals(prompt, BASE_SYSTEM_PROMPT)
+  // No dangling header left over from the filtered-empty case.
+  assert(!prompt.includes('## Existing Agents'))
+})
+
+Deno.test('buildSystemPrompt — valid agent appends the Existing Agents section with id and name', () => {
+  const prompt = buildSystemPrompt([{ id: 'frontend-dev', name: 'Frontend Developer' }])
+  assertStringIncludes(prompt, '## Existing Agents')
+  assertStringIncludes(prompt, '- frontend-dev: Frontend Developer')
+  // The base prompt is preserved verbatim as the prefix.
+  assert(prompt.startsWith(BASE_SYSTEM_PROMPT))
+  assertStringIncludes(prompt, `${BASE_SYSTEM_PROMPT}\n\n## Existing Agents\n\n`)
+})
+
+Deno.test('buildSystemPrompt — renders category, description, and tags when present', () => {
+  const prompt = buildSystemPrompt([
+    {
+      id: 'sec',
+      name: 'Security Auditor',
+      category: 'AI Specialists',
+      description: 'Finds vulnerabilities',
+      tags: ['security', 'audit'],
+    },
+  ])
+  assertStringIncludes(
+    prompt,
+    '- sec: Security Auditor (AI Specialists) — Finds vulnerabilities [security, audit]',
+  )
+})
+
+Deno.test('buildSystemPrompt — omits category, description, and tags when absent', () => {
+  const prompt = buildSystemPrompt([{ id: 'bare', name: 'Bare Agent' }])
+  // Exactly the id/name line with no extra decorations.
+  assertStringIncludes(prompt, '\n- bare: Bare Agent')
+  assert(!prompt.includes('- bare: Bare Agent ('))
+  assert(!prompt.includes('- bare: Bare Agent —'))
+  assert(!prompt.includes('- bare: Bare Agent ['))
+})
+
+Deno.test('buildSystemPrompt — empty tags array and empty strings are omitted', () => {
+  const prompt = buildSystemPrompt([
+    { id: 'e', name: 'Empties', category: '', description: '', tags: [] },
+  ])
+  assertStringIncludes(prompt, '\n- e: Empties')
+  assert(!prompt.includes('- e: Empties ('))
+  assert(!prompt.includes('- e: Empties —'))
+  assert(!prompt.includes('- e: Empties ['))
+})
+
+Deno.test('buildSystemPrompt — mixed valid/malformed keeps only valid lines', () => {
+  const prompt = buildSystemPrompt([
+    { id: 'ok1', name: 'Agent One' },
+    null,
+    { id: 'no-name' },
+    { id: 'ok2', name: 'Agent Two' },
+    'garbage',
+  ])
+  assertStringIncludes(prompt, '- ok1: Agent One')
+  assertStringIncludes(prompt, '- ok2: Agent Two')
+  assert(!prompt.includes('no-name'))
+  // Section built from exactly the two valid lines joined by a newline.
+  assertStringIncludes(prompt, '## Existing Agents\n\n- ok1: Agent One\n- ok2: Agent Two')
+})
+
+// --- buildSelectedAgentSystemPrompt(agent) ---------------------------------
+
+Deno.test('buildSelectedAgentSystemPrompt — null / non-object returns BASE_SYSTEM_PROMPT', () => {
+  assertEquals(buildSelectedAgentSystemPrompt(null), BASE_SYSTEM_PROMPT)
+  assertEquals(buildSelectedAgentSystemPrompt(undefined), BASE_SYSTEM_PROMPT)
+  assertEquals(buildSelectedAgentSystemPrompt('a string'), BASE_SYSTEM_PROMPT)
+  assertEquals(buildSelectedAgentSystemPrompt(7), BASE_SYSTEM_PROMPT)
+})
+
+Deno.test('buildSelectedAgentSystemPrompt — missing content returns just the header (no trailing block)', () => {
+  const prompt = buildSelectedAgentSystemPrompt({ name: 'Helper' })
+  assertStringIncludes(prompt, 'Always reply in English')
+  assertStringIncludes(prompt, 'You are "Helper"')
+  assert(!prompt.includes('\n\n'), 'header-only output must not contain a content block separator')
+})
+
+Deno.test('buildSelectedAgentSystemPrompt — empty and whitespace content collapse to header-only', () => {
+  const empty = buildSelectedAgentSystemPrompt({ name: 'Helper', content: '' })
+  const spaces = buildSelectedAgentSystemPrompt({ name: 'Helper', content: '   \n\t  ' })
+  const headerOnly = buildSelectedAgentSystemPrompt({ name: 'Helper' })
+  assertEquals(empty, headerOnly)
+  assertEquals(spaces, headerOnly)
+  assertStringIncludes(empty, 'Always reply in English')
+})
+
+Deno.test('buildSelectedAgentSystemPrompt — non-string content is ignored (header-only)', () => {
+  const prompt = buildSelectedAgentSystemPrompt({ name: 'Helper', content: { foo: 'bar' } })
+  const headerOnly = buildSelectedAgentSystemPrompt({ name: 'Helper' })
+  assertEquals(prompt, headerOnly)
+})
+
+Deno.test('buildSelectedAgentSystemPrompt — content is appended as header + "\\n\\n" + trimmed content', () => {
+  const agent = { name: 'Helper', content: '  Do the thing.  ' }
+  const prompt = buildSelectedAgentSystemPrompt(agent)
+  const header =
+    'You are "Helper", an AI agent inside Lucas AI Hub. Always reply in English. Stay in character — do not mention this hub\'s other agents unless the user asks.'
+  assertEquals(prompt, `${header}\n\nDo the thing.`)
+})
+
+Deno.test('buildSelectedAgentSystemPrompt — falls back to id when name is missing', () => {
+  const prompt = buildSelectedAgentSystemPrompt({ id: 'agent-42', content: 'Hi' })
+  assertStringIncludes(prompt, 'You are "agent-42"')
+})
+
+Deno.test('buildSelectedAgentSystemPrompt — English-only header is injected even when content is in another language', () => {
+  // Adversarial: an agent whose own system prompt is written in Portuguese.
+  // The English-only guarantee comes from the injected HEADER, which must be
+  // present regardless of the content's language.
+  const agent = {
+    name: 'Assistente',
+    content: 'Você é um assistente. Responda sempre em português e seja educado.',
+  }
+  const prompt = buildSelectedAgentSystemPrompt(agent)
+  assertStringIncludes(prompt, 'Always reply in English')
+  // The header precedes the foreign-language content.
+  assert(
+    prompt.indexOf('Always reply in English') < prompt.indexOf('português'),
+    'English-only instruction must appear before the agent content',
+  )
+})

--- a/supabase/functions/chat/systemPrompt.ts
+++ b/supabase/functions/chat/systemPrompt.ts
@@ -1,0 +1,77 @@
+// System-prompt constants and pure prompt-builder functions for the chat
+// Edge Function. Extracted from index.ts so they can be unit-tested without
+// pulling in the top-level `Deno.serve` call (issue #608).
+
+// deno-lint-ignore-file no-explicit-any
+
+export const BASE_SYSTEM_PROMPT = `You are the AI assistant for Lucas AI Hub, an internal web app for browsing, creating, and managing AI agent templates.
+
+Users of this hub can:
+- Browse agents across categories like "Development Team" and "AI Specialists"
+- Stack multiple agents into a cart and download them as a ZIP of markdown system prompts
+- Create their own agents and teams
+- Bundle agents into named "teams" for reuse
+- Use ⌘K to jump to any agent or team by name
+
+## Answering questions about existing agents
+
+You are given a summary of every agent currently in the hub in the "Existing Agents" section below. When the user asks about agents ("what agents are there?", "tell me about frontend-developer", "is there a security agent?"), answer directly using this summary. Don't call any tool just to read — the data is already in your context.
+
+If the user asks for the full system prompt / content of a specific agent, tell them to open the agent's detail page (you don't have the full content, only the summary).
+
+## Creating a new agent
+
+You have access to the \`draft_agent\` tool. When the user asks to create a new agent (e.g. "create an agent that does X", "build an agent that..."), call this tool to propose a draft. The draft appears as an interactive card in the chat — THE USER CONFIRMS THE CREATION, not you.
+
+When calling \`draft_agent\`:
+- Write a short, friendly one-sentence explanation BEFORE calling the tool (e.g. "Sure! I put together a draft for you to review:")
+- Fill ALL required fields with reasonable defaults based on the user's request
+- Use 3–5 relevant tags
+- Write the \`content\` field as a 2–4 paragraph markdown system prompt, using "##" subheadings for "Responsibilities", "Approach", etc.
+- For \`icon\`, pick a PascalCase lucide-react icon name that matches the agent's purpose (e.g. Shield, Code, Database, Palette, Bot). If unsure, use Bot.
+
+## Updating an existing agent
+
+You have access to the \`update_agent\` tool. When the user asks to modify an existing agent ("change X's color to purple", "add the Y tag to Z", "change the frontend-developer description"), call this tool with the target agent's \`id\` and an \`updates\` object containing ONLY the fields being changed. Do not include fields that aren't changing.
+
+The agent's \`id\` must match one from the "Existing Agents" summary exactly. If the user refers to an agent by name and there's ambiguity, ask which one they mean before calling the tool.
+
+When calling \`update_agent\`:
+- Write a short explanation BEFORE calling (e.g. "Got it, I'll propose this change:")
+- Put only the CHANGING fields in \`updates\` — leave out everything else
+- The card will show a diff of old → new and the user clicks "Apply changes" to commit
+
+If the user wants to iterate on a previous update/draft, call the relevant tool again with the updated fields.
+
+## General rules
+
+DO NOT call tools for questions about the hub itself, how features work, or general conversation. Only use tools when the user clearly wants to CREATE or MODIFY something.
+
+Be concise, friendly, and always reply in English.`
+
+export function buildSystemPrompt(agentsContext: unknown): string {
+  if (!Array.isArray(agentsContext) || agentsContext.length === 0) {
+    return BASE_SYSTEM_PROMPT
+  }
+  const lines = agentsContext
+    .filter((a: any) => a && typeof a.id === 'string' && typeof a.name === 'string')
+    .map((a: any) => {
+      const tags = Array.isArray(a.tags) && a.tags.length > 0 ? ` [${a.tags.join(', ')}]` : ''
+      const desc = typeof a.description === 'string' && a.description ? ` — ${a.description}` : ''
+      const cat = typeof a.category === 'string' && a.category ? ` (${a.category})` : ''
+      return `- ${a.id}: ${a.name}${cat}${desc}${tags}`
+    })
+  if (lines.length === 0) return BASE_SYSTEM_PROMPT
+  return `${BASE_SYSTEM_PROMPT}\n\n## Existing Agents\n\n${lines.join('\n')}`
+}
+
+// When the user explicitly picks an agent next to the chat bar, we drop the
+// hub-assistant persona and let that agent drive the conversation directly.
+// The agent's `content` (its full markdown system prompt) becomes the system
+// prompt; the router/planner is bypassed for the rest of this turn.
+export function buildSelectedAgentSystemPrompt(agent: any): string {
+  if (!agent || typeof agent !== 'object') return BASE_SYSTEM_PROMPT
+  const content = typeof agent.content === 'string' ? agent.content.trim() : ''
+  const header = `You are "${agent.name || agent.id}", an AI agent inside Lucas AI Hub. Always reply in English. Stay in character — do not mention this hub's other agents unless the user asks.`
+  return content ? `${header}\n\n${content}` : header
+}


### PR DESCRIPTION
Closes #608

## Dev/TDD
- Tests added/modified: `supabase/functions/chat/systemPrompt.test.ts` (new), `src/components/AiAssistant.test.jsx` (fixtures)
- Note: the issue body was stale — the production system prompt in `supabase/functions/chat/index.ts` (assistant-output example phrases, few-shot user-phrasing examples, and the trailing "reply in the same language" → "always reply in English" rule) and the line-181 `AiAssistant.test.jsx` reply assertion were **already translated by #610**. Those 3 acceptance criteria were already satisfied on `dev`.
- What this PR adds: a **regression guard** locking the English-only behavior so a future edit can't silently reintroduce Portuguese or a "reply in the same language" rule, plus cleanup of leftover Portuguese test fixtures.
- Before implementation (red): the 4 new tests in `systemPrompt.test.ts` failed with `TS2307 Cannot find module './systemPrompt.ts'` — the module/exports didn't exist yet (correct red).
- After implementation (green): extracted `BASE_SYSTEM_PROMPT`, `buildSystemPrompt`, `buildSelectedAgentSystemPrompt` **verbatim** from `index.ts` into a new `systemPrompt.ts` module (so they're testable without triggering top-level `Deno.serve`); `index.ts` now imports them. Functions suite **234 passed / 0 failed**; frontend **558 passed / 0 failed**.

## QA scenarios added
- 16 adversarial/edge-case tests appended to `supabase/functions/chat/systemPrompt.test.ts`:
  - `buildSystemPrompt`: empty array, non-array inputs (null/undefined/string/object/number), all-malformed entries (no dangling "## Existing Agents" header), valid agent rendering, category/description/tags present vs. absent, mixed valid/malformed.
  - `buildSelectedAgentSystemPrompt`: null/non-object, empty/whitespace/missing content → header-only, string content → `header + "\n\n" + content`, missing-name-uses-id, and the CRITICAL adversarial case — a selected agent whose own `content` is in another language still gets an English-only header ("Always reply in English").
- All pass; no behavioral defect exposed by the extraction.

## Review verdict
- **APPROVE**. The reviewer byte-diffed the extracted constants/functions against `HEAD` and confirmed the extraction is verbatim — no prompt wording drift, so model behavior is unchanged. The new module has a clear single responsibility, improves `index.ts` cohesion (~68 fewer lines), and the indirection is justified (enables unit-testing without `Deno.serve`). Naming/placement/comments match sibling modules. No blocking findings.

## Docs updated
- none — diff implied no doc change. The refactor is internal and no `docs/` file enumerates the chat system-prompt modules or the language behavior.

## Notes
- Pre-existing unrelated: the frontend suite reports "1 error" (an unhandled promise rejection in a component) that is present on clean `dev` with or without this change; out of scope for #608.
- `npm run lint` (0 errors, 26 pre-existing warnings) and `npm run build` both pass.
